### PR TITLE
fix(compiler): compiled imm location

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -22,7 +22,7 @@ lint:
         - run:
             cargo clippy --message-format json --locked --workspace
             --all-targets -- -W clippy::all -W clippy::nursery --cap-lints=warn
-            --no-deps -D warnings
+            --no-deps -D warnings -D unused_imports
       run_timeout: 20m
   enabled:
     - cspell@8.19.4

--- a/crates/compiler/codegen/src/compiled_program.rs
+++ b/crates/compiler/codegen/src/compiled_program.rs
@@ -26,7 +26,7 @@ pub struct CompiledInstruction {
     pub opcode: u32,
 
     /// The operands for this instruction (offsets and immediate)
-    /// Format: [off0, off1_or_imm, off2] where the second operand can be an immediate value or an offset
+    /// Format: [off0, off1, off2] where the second operand can be an immediate value or an offset
     pub operands: Vec<M31>,
 }
 
@@ -82,18 +82,18 @@ impl CompiledInstruction {
         Self { opcode, operands }
     }
 
-    /// Get offset 0 (fp-relative source 1)
-    pub fn off0(&self) -> Option<M31> {
+    /// Get operand 0 (fp-relative source 1)
+    pub fn op0(&self) -> Option<M31> {
         self.operands.first().copied()
     }
 
-    /// Get offset 1 (fp-relative source 2)
-    pub fn off1_or_imm(&self) -> Option<M31> {
+    /// Get operand 1 (fp-relative source 2)
+    pub fn op1(&self) -> Option<M31> {
         self.operands.get(1).copied()
     }
 
-    /// Get offset 2 (fp-relative destination)
-    pub fn off2(&self) -> Option<M31> {
+    /// Get operand 2 (fp-relative destination)
+    pub fn op2(&self) -> Option<M31> {
         self.operands.get(2).copied()
     }
 }
@@ -107,9 +107,9 @@ impl Serialize for CompiledInstruction {
         let mut values = vec![M31::from(self.opcode)];
 
         // Add the three offsets
-        values.push(self.off0().unwrap_or_else(Zero::zero));
-        values.push(self.off1_or_imm().unwrap_or_else(Zero::zero));
-        values.push(self.off2().unwrap_or_else(Zero::zero));
+        values.push(self.op0().unwrap_or_else(Zero::zero));
+        values.push(self.op1().unwrap_or_else(Zero::zero));
+        values.push(self.op2().unwrap_or_else(Zero::zero));
 
         let hex_values: Vec<String> = values
             .iter()
@@ -138,14 +138,14 @@ impl<'de> Deserialize<'de> for CompiledInstruction {
             .map_err(serde::de::Error::custom)?;
 
         // Parse offsets from hex
-        let off0 = parse_hex_offset(&hex_vec[1])
+        let op0 = parse_hex_offset(&hex_vec[1])
             .ok_or_else(|| serde::de::Error::custom("Failed to parse off0"))?;
-        let off1_or_imm = parse_hex_offset(&hex_vec[2])
+        let op1 = parse_hex_offset(&hex_vec[2])
             .ok_or_else(|| serde::de::Error::custom("Failed to parse off1"))?;
-        let off2 = parse_hex_offset(&hex_vec[3])
+        let op2 = parse_hex_offset(&hex_vec[3])
             .ok_or_else(|| serde::de::Error::custom("Failed to parse off2"))?;
 
-        let operands = vec![off0, off1_or_imm, off2];
+        let operands = vec![op0, op1, op2];
 
         Ok(Self::new(opcode, operands))
     }

--- a/crates/compiler/codegen/src/generator.rs
+++ b/crates/compiler/codegen/src/generator.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use cairo_m_compiler_mir::{
     BasicBlockId, Instruction, InstructionKind, MirFunction, MirModule, Terminator,
 };
-use num_traits::Zero;
 use stwo_prover::core::fields::m31::M31;
 
 use crate::compiled_program::{CompiledInstruction, CompiledProgram, ProgramMetadata};

--- a/crates/compiler/codegen/src/lib.rs
+++ b/crates/compiler/codegen/src/lib.rs
@@ -16,7 +16,6 @@
 #![allow(clippy::option_if_let_else)]
 
 use cairo_m_compiler_mir::{BasicBlockId, MirModule};
-use stwo_prover::core::fields::m31::M31;
 
 pub mod builder;
 pub mod compiled_program;
@@ -53,7 +52,7 @@ pub enum Operand {
 
 impl Operand {
     /// Create a literal operand from an integer
-    pub fn literal(value: i32) -> Self {
+    pub const fn literal(value: i32) -> Self {
         Self::Literal(value)
     }
 

--- a/crates/compiler/codegen/tests/label_resolution_tests.rs
+++ b/crates/compiler/codegen/tests/label_resolution_tests.rs
@@ -75,7 +75,7 @@ fn test_operand_creation() {
 
     let literal_op = Operand::literal(42);
     match literal_op {
-        Operand::Literal(val) => assert_eq!(val.0, 42),
+        Operand::Literal(val) => assert_eq!(val, 42),
         _ => panic!("Expected literal operand"),
     }
 
@@ -89,7 +89,6 @@ fn test_operand_creation() {
 #[test]
 fn test_instruction_operand_methods() {
     use cairo_m_compiler_codegen::{opcodes, CasmInstruction};
-    use stwo_prover::core::fields::m31::M31;
 
     // Test with_operand method
     let instr1 = CasmInstruction::new(opcodes::JMP_ABS_IMM)
@@ -112,11 +111,11 @@ fn test_instruction_operand_methods() {
     let instr3 = CasmInstruction::new(opcodes::JMP_ABS_IMM).with_imm(100);
 
     match &instr3.operand {
-        Some(Operand::Literal(val)) => assert_eq!(val.0, 100),
+        Some(Operand::Literal(val)) => assert_eq!(*val, 100),
         _ => panic!("Expected literal operand"),
     }
 
     // Test imm() getter method
-    assert_eq!(instr3.imm(), Some(M31::from(100)));
+    assert_eq!(instr3.imm(), Some(100));
     assert_eq!(instr1.imm(), None); // Label operand should return None for imm()
 }

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_add_two_numbers.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_add_two_numbers.snap
@@ -19,8 +19,8 @@ Generated CASM:
 add_two_numbers:
 add_two_numbers:
 add_two_numbers_0:
-   0: 6 _ 10 0             // Store immediate: [fp+0] = 10
-   1: 6 _ 32 1             // Store immediate: [fp+1] = 32
+   0: 6 10 _ 0             // Store immediate: [fp+0] = 10
+   1: 6 32 _ 1             // Store immediate: [fp+1] = 32
    2: 0 0 1 2              // [fp + 2] = [fp + 0] op [fp + 1]
    3: 4 2 _ -3             // Return value: [fp-3] = [fp+2]
    4: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_subtract_numbers.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_subtract_numbers.snap
@@ -19,8 +19,8 @@ Generated CASM:
 subtract_numbers:
 subtract_numbers:
 subtract_numbers_0:
-   0: 6 _ 100 0            // Store immediate: [fp+0] = 100
-   1: 6 _ 25 1             // Store immediate: [fp+1] = 25
+   0: 6 100 _ 0            // Store immediate: [fp+0] = 100
+   1: 6 25 _ 1             // Store immediate: [fp+1] = 25
    2: 2 0 1 2              // [fp + 2] = [fp + 0] op [fp + 1]
    3: 4 2 _ -3             // Return value: [fp-3] = [fp+2]
    4: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else.snap
@@ -24,8 +24,8 @@ test_if_else_0:
    0: 3 -4 0 0             // Equality check: [fp+0] = [fp+-4] - 0
    1: 31 0 3 _             // if [fp+0] != 0 jmp rel test_if_else_2
 test_if_else_1:
-   2: 6 _ 1 -3             // Return value: [fp-3] = 1
+   2: 6 1 _ -3             // Return value: [fp-3] = 1
    3: 15 _ _ _             // return
 test_if_else_2:
-   4: 6 _ 2 -3             // Return value: [fp-3] = 2
+   4: 6 2 _ -3             // Return value: [fp-3] = 2
    5: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else_with_merge.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else_with_merge.snap
@@ -23,14 +23,14 @@ Generated CASM:
 test_if_else:
 test_if_else:
 test_if_else_0:
-   0: 6 _ 0 0              // Store immediate: [fp+0] = 0
+   0: 6 0 _ 0              // Store immediate: [fp+0] = 0
    1: 3 -4 0 1             // Equality check: [fp+1] = [fp+-4] - 0
    2: 31 1 3 _             // if [fp+1] != 0 jmp rel test_if_else_2
 test_if_else_1:
-   3: 6 _ 1 0              // Store immediate: [fp+0] = 1
-   4: 20 _ 6 _             // jump abs test_if_else_3
+   3: 6 1 _ 0              // Store immediate: [fp+0] = 1
+   4: 20 6 _ _             // jump abs test_if_else_3
 test_if_else_2:
-   5: 6 _ 2 0              // Store immediate: [fp+0] = 2
+   5: 6 2 _ 0              // Store immediate: [fp+0] = 2
 test_if_else_3:
    6: 4 0 _ -3             // Return value: [fp-3] = [fp+0]
    7: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_simple_if.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_simple_if.snap
@@ -23,8 +23,8 @@ test_if_0:
    0: 3 -4 0 0             // Equality check: [fp+0] = [fp+-4] - 0
    1: 31 0 3 _             // if [fp+0] != 0 jmp rel test_if_2
 test_if_1:
-   2: 6 _ 1 -3             // Return value: [fp-3] = 1
+   2: 6 1 _ -3             // Return value: [fp-3] = 1
    3: 15 _ _ _             // return
 test_if_2:
-   4: 6 _ 2 -3             // Return value: [fp-3] = 2
+   4: 6 2 _ -3             // Return value: [fp-3] = 2
    5: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_fib.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_fib.snap
@@ -28,7 +28,7 @@ func fib(n: felt) -> felt {
 ============================================================
 Generated CASM:
 main:
-   0: 6 _ 10 0             // Store immediate: [fp+0] = 10
+   0: 6 10 _ 0             // Store immediate: [fp+0] = 10
    1: 4 0 _ 1              // Arg 0: [fp + 1] = [fp + 0]
    2: 12 3 6 _             // call fib
    3: 4 2 _ 2              // Store: [fp+2] = [fp+2]
@@ -38,13 +38,13 @@ fib:
    6: 3 -4 0 0             // Equality check: [fp+0] = [fp+-4] - 0
    7: 31 0 3 _             // if [fp+0] != 0 jmp rel fib_2
 fib_1:
-   8: 6 _ 0 -3             // Return value: [fp-3] = 0
+   8: 6 0 _ -3             // Return value: [fp-3] = 0
    9: 15 _ _ _             // return
 fib_2:
   10: 3 -4 1 1             // Equality check: [fp+1] = [fp+-4] - 1
   11: 31 1 3 _             // if [fp+1] != 0 jmp rel fib_4
 fib_3:
-  12: 6 _ 1 -3             // Return value: [fp-3] = 1
+  12: 6 1 _ -3             // Return value: [fp-3] = 1
   13: 15 _ _ _             // return
 fib_4:
   14: 3 -4 1 2             // [fp + 2] = [fp + -4] op 1

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_simple_call.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_simple_call.snap
@@ -19,7 +19,7 @@ func main() -> felt {
 ============================================================
 Generated CASM:
 helper:
-   0: 6 _ 42 -3            // Return value: [fp-3] = 42
+   0: 6 42 _ -3            // Return value: [fp-3] = 42
    1: 15 _ _ _             // return
 main:
    2: 12 1 0 _             // call helper

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__simple_function_simple.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__simple_function_simple.snap
@@ -15,5 +15,5 @@ func test() -> felt {
 ============================================================
 Generated CASM:
 test:
-   0: 6 _ 42 -3            // Return value: [fp-3] = 42
+   0: 6 42 _ -3            // Return value: [fp-3] = 42
    1: 15 _ _ _             // return


### PR DESCRIPTION
the `imm` is always encoded as the first non-offset instruction argument.