### PR TITLE
fix(compiler): binary equality codegen

### DIFF
--- a/crates/compiler/codegen/tests/codegen_tests.rs
+++ b/crates/compiler/codegen/tests/codegen_tests.rs
@@ -130,6 +130,7 @@ codegen_test!(function_with_return, "simple");
 // --- Arithmetic ---
 codegen_test!(add_two_numbers, "arithmetic");
 codegen_test!(subtract_numbers, "arithmetic");
+codegen_test!(equality, "arithmetic");
 
 // --- Control Flow ---
 codegen_test!(simple_if, "control_flow");

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_equality.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_equality.snap
@@ -1,0 +1,42 @@
+---
+source: crates/compiler/codegen/tests/codegen_tests.rs
+expression: snapshot_content
+---
+---
+source: crates/compiler/codegen/tests/codegen_tests.rs
+expression: codegen_output
+---
+Fixture: equality.cm
+============================================================
+Source code:
+func main() -> felt {
+    let a = 1;
+    let b = 0;
+    let c = a == b;
+    let d = a == 0;
+    return c + d;
+}
+
+============================================================
+Generated CASM:
+main:
+   0: 6 1 _ 0              // Store immediate: [fp + 0] = 1
+   1: 6 0 _ 1              // Store immediate: [fp + 1] = 0
+   2: 2 0 1 2              // Equality check: [fp + 2] = [fp + 0] - [fp + 1]
+   3: 31 2 3 _             // if [fp + 2] != 0 jmp rel eq_false_2
+   4: 6 1 _ 2              // [fp + 2] = 1
+   5: 20 7 _ _             // jump abs eq_end_2
+eq_false_2:
+   6: 6 0 _ 2              // [fp + 2] = 0
+eq_end_2:
+   7: 4 2 _ 3              // Store: [fp + 3] = [fp + 2]
+   8: 3 0 0 4              // Equality check: [fp + 4] = [fp + 0] - 0
+   9: 31 4 3 _             // if [fp + 4] != 0 jmp rel eq_false_4
+  10: 6 1 _ 4              // [fp + 4] = 1
+  11: 20 13 _ _            // jump abs eq_end_4
+eq_false_4:
+  12: 6 0 _ 4              // [fp + 4] = 0
+eq_end_4:
+  13: 4 4 _ 5              // Store: [fp + 5] = [fp + 4]
+  14: 0 3 5 -3             // [fp + -3] = [fp + 3] op [fp + 5]
+  15: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else.snap
@@ -22,10 +22,16 @@ test_if_else:
 test_if_else:
 test_if_else_0:
    0: 3 -4 0 0             // Equality check: [fp + 0] = [fp + -4] - 0
-   1: 31 0 3 _             // if [fp + 0] != 0 jmp rel test_if_else_2
+   1: 31 0 3 _             // if [fp + 0] != 0 jmp rel eq_false_1
+   2: 6 1 _ 0              // [fp + 0] = 1
+   3: 20 5 _ _             // jump abs eq_end_1
+eq_false_1:
+   4: 6 0 _ 0              // [fp + 0] = 0
+eq_end_1:
+   5: 31 0 3 _             // if [fp + 0] != 0 jmp rel test_if_else_2
 test_if_else_1:
-   2: 6 1 _ -3             // Return value: [fp - 3] = 1
-   3: 15 _ _ _             // return
+   6: 6 1 _ -3             // Return value: [fp - 3] = 1
+   7: 15 _ _ _             // return
 test_if_else_2:
-   4: 6 2 _ -3             // Return value: [fp - 3] = 2
-   5: 15 _ _ _             // return
+   8: 6 2 _ -3             // Return value: [fp - 3] = 2
+   9: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else_with_merge.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else_with_merge.snap
@@ -25,12 +25,18 @@ test_if_else:
 test_if_else_0:
    0: 6 0 _ 0              // Store immediate: [fp + 0] = 0
    1: 3 -4 0 1             // Equality check: [fp + 1] = [fp + -4] - 0
-   2: 31 1 3 _             // if [fp + 1] != 0 jmp rel test_if_else_2
+   2: 31 1 3 _             // if [fp + 1] != 0 jmp rel eq_false_2
+   3: 6 1 _ 1              // [fp + 1] = 1
+   4: 20 6 _ _             // jump abs eq_end_2
+eq_false_2:
+   5: 6 0 _ 1              // [fp + 1] = 0
+eq_end_2:
+   6: 31 1 3 _             // if [fp + 1] != 0 jmp rel test_if_else_2
 test_if_else_1:
-   3: 6 1 _ 0              // Store immediate: [fp + 0] = 1
-   4: 20 6 _ _             // jump abs test_if_else_3
+   7: 6 1 _ 0              // Store immediate: [fp + 0] = 1
+   8: 20 10 _ _            // jump abs test_if_else_3
 test_if_else_2:
-   5: 6 2 _ 0              // Store immediate: [fp + 0] = 2
+   9: 6 2 _ 0              // Store immediate: [fp + 0] = 2
 test_if_else_3:
-   6: 4 0 _ -3             // Return value: [fp - 3] = [fp + 0]
-   7: 15 _ _ _             // return
+  10: 4 0 _ -3             // Return value: [fp - 3] = [fp + 0]
+  11: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_simple_if.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_simple_if.snap
@@ -21,10 +21,16 @@ test_if:
 test_if:
 test_if_0:
    0: 3 -4 0 0             // Equality check: [fp + 0] = [fp + -4] - 0
-   1: 31 0 3 _             // if [fp + 0] != 0 jmp rel test_if_2
+   1: 31 0 3 _             // if [fp + 0] != 0 jmp rel eq_false_1
+   2: 6 1 _ 0              // [fp + 0] = 1
+   3: 20 5 _ _             // jump abs eq_end_1
+eq_false_1:
+   4: 6 0 _ 0              // [fp + 0] = 0
+eq_end_1:
+   5: 31 0 3 _             // if [fp + 0] != 0 jmp rel test_if_2
 test_if_1:
-   2: 6 1 _ -3             // Return value: [fp - 3] = 1
-   3: 15 _ _ _             // return
+   6: 6 1 _ -3             // Return value: [fp - 3] = 1
+   7: 15 _ _ _             // return
 test_if_2:
-   4: 6 2 _ -3             // Return value: [fp - 3] = 2
-   5: 15 _ _ _             // return
+   8: 6 2 _ -3             // Return value: [fp - 3] = 2
+   9: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_fib.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_fib.snap
@@ -36,22 +36,34 @@ main:
    5: 15 _ _ _             // return
 fib:
    6: 3 -4 0 0             // Equality check: [fp + 0] = [fp + -4] - 0
-   7: 31 0 3 _             // if [fp + 0] != 0 jmp rel fib_2
+   7: 31 0 3 _             // if [fp + 0] != 0 jmp rel eq_false_1
+   8: 6 1 _ 0              // [fp + 0] = 1
+   9: 20 11 _ _            // jump abs eq_end_1
+eq_false_1:
+  10: 6 0 _ 0              // [fp + 0] = 0
+eq_end_1:
+  11: 31 0 3 _             // if [fp + 0] != 0 jmp rel fib_2
 fib_1:
-   8: 6 0 _ -3             // Return value: [fp - 3] = 0
-   9: 15 _ _ _             // return
-fib_2:
-  10: 3 -4 1 1             // Equality check: [fp + 1] = [fp + -4] - 1
-  11: 31 1 3 _             // if [fp + 1] != 0 jmp rel fib_4
-fib_3:
-  12: 6 1 _ -3             // Return value: [fp - 3] = 1
+  12: 6 0 _ -3             // Return value: [fp - 3] = 0
   13: 15 _ _ _             // return
-fib_4:
-  14: 3 -4 1 2             // [fp + 2] = [fp + -4] op 1
-  15: 4 2 _ 3              // Arg 0: [fp + 3] = [fp + 2]
-  16: 12 5 6 _             // call fib
-  17: 3 -4 2 6             // [fp + 6] = [fp + -4] op 2
-  18: 4 6 _ 7              // Arg 0: [fp + 7] = [fp + 6]
-  19: 12 9 6 _             // call fib
-  20: 0 4 8 -3             // [fp + -3] = [fp + 4] op [fp + 8]
+fib_2:
+  14: 3 -4 1 1             // Equality check: [fp + 1] = [fp + -4] - 1
+  15: 31 1 3 _             // if [fp + 1] != 0 jmp rel eq_false_3
+  16: 6 1 _ 1              // [fp + 1] = 1
+  17: 20 19 _ _            // jump abs eq_end_3
+eq_false_3:
+  18: 6 0 _ 1              // [fp + 1] = 0
+eq_end_3:
+  19: 31 1 3 _             // if [fp + 1] != 0 jmp rel fib_4
+fib_3:
+  20: 6 1 _ -3             // Return value: [fp - 3] = 1
   21: 15 _ _ _             // return
+fib_4:
+  22: 3 -4 1 2             // [fp + 2] = [fp + -4] op 1
+  23: 4 2 _ 3              // Arg 0: [fp + 3] = [fp + 2]
+  24: 12 5 6 _             // call fib
+  25: 3 -4 2 6             // [fp + 6] = [fp + -4] op 2
+  26: 4 6 _ 7              // Arg 0: [fp + 7] = [fp + 6]
+  27: 12 9 6 _             // call fib
+  28: 0 4 8 -3             // [fp + -3] = [fp + 4] op [fp + 8]
+  29: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/test_cases/arithmetic/equality.cm
+++ b/crates/compiler/codegen/tests/test_cases/arithmetic/equality.cm
@@ -1,0 +1,7 @@
+func main() -> felt {
+    let a = 1;
+    let b = 0;
+    let c = a == b;
+    let d = a == 0;
+    return c + d;
+}


### PR DESCRIPTION
fixes an issue where `let x = a == b;` would not be lowered properly, as we'd not branch to a place where we'd assign a 1 / 0 properly.

This introduces some extra overhead for `if (a == b)` cases that will need to be eliminated with optimization passes