### PR TITLE
feat(vm): support calling entrypoints with args

### DIFF
--- a/crates/common/src/program.rs
+++ b/crates/common/src/program.rs
@@ -4,6 +4,17 @@ use serde::{Deserialize, Serialize};
 
 use crate::Instruction;
 
+/// Information about a function entrypoint
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EntrypointInfo {
+    /// The program counter (instruction index) where the function starts
+    pub pc: usize,
+    /// Names of the function arguments
+    pub args: Vec<String>,
+    /// Number of return values
+    pub num_return_values: usize,
+}
+
 /// Metadata about the compiled program
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProgramMetadata {
@@ -26,8 +37,8 @@ pub struct ProgramMetadata {
 pub struct Program {
     /// The program instructions
     pub instructions: Vec<Instruction>,
-    /// Entrypoint names mapped to instruction indices
-    pub entrypoints: HashMap<String, usize>,
+    /// Entrypoint names mapped to their information
+    pub entrypoints: HashMap<String, EntrypointInfo>,
     /// Program metadata
     pub metadata: ProgramMetadata,
 }
@@ -46,7 +57,7 @@ impl Program {
     /// Create a new program
     pub const fn new(
         instructions: Vec<Instruction>,
-        entrypoints: HashMap<String, usize>,
+        entrypoints: HashMap<String, EntrypointInfo>,
         metadata: ProgramMetadata,
     ) -> Self {
         Self {
@@ -56,9 +67,9 @@ impl Program {
         }
     }
 
-    /// Get the entry point address for a given function name
-    pub fn get_entrypoint(&self, name: &str) -> Option<usize> {
-        self.entrypoints.get(name).copied()
+    /// Get the full entrypoint information for a given function name
+    pub fn get_entrypoint(&self, name: &str) -> Option<&EntrypointInfo> {
+        self.entrypoints.get(name)
     }
 
     /// Get the total number of instructions

--- a/crates/compiler/codegen/src/generator.rs
+++ b/crates/compiler/codegen/src/generator.rs
@@ -543,11 +543,6 @@ impl CodeGenerator {
     pub fn instructions(&self) -> &[InstructionBuilder] {
         &self.instructions
     }
-
-    /// Get function entrypoints (for testing)
-    pub const fn function_entrypoints(&self) -> &HashMap<String, EntrypointInfo> {
-        &self.function_entrypoints
-    }
 }
 
 impl Default for CodeGenerator {

--- a/crates/prover/tests/fibonacci_trace_test.rs
+++ b/crates/prover/tests/fibonacci_trace_test.rs
@@ -30,6 +30,7 @@ pub mod fibonacci {
 
         use cairo_m_prover::adapter::{import_from_runner_artifacts, import_from_runner_output};
         use cairo_m_runner::run_cairo_program;
+        use stwo_prover::core::fields::m31::M31;
         use tempfile::TempDir;
 
         #[test]
@@ -43,8 +44,9 @@ pub mod fibonacci {
                 .expect("Failed to compile Cairo-M program");
 
             // Run the program to generate trace and memory data
-            let cairo_result = run_cairo_program(&compiled, "main", Default::default())
-                .expect("Failed to run Cairo-M program");
+            let cairo_result =
+                run_cairo_program(&compiled, "fib", &[M31::from(10)], Default::default())
+                    .expect("Failed to run Cairo-M program");
 
             // Create paths for temporary trace and memory files
             let trace_path = temp_dir.path().join("trace.bin");

--- a/crates/runner/benches/fibonacci_loop.cm
+++ b/crates/runner/benches/fibonacci_loop.cm
@@ -10,9 +10,3 @@ func fibonacci_loop(n: felt) -> felt {
     }
     return a;
 }
-
-func main() -> felt {
-    let n = 1000000;
-    let result = fibonacci_loop(n);
-    return result;
-}

--- a/crates/runner/benches/vm_benchmark.rs
+++ b/crates/runner/benches/vm_benchmark.rs
@@ -2,14 +2,12 @@ use std::fs;
 use std::time::Duration;
 
 use cairo_m_compiler::{compile_cairo, CompilerOptions};
-use cairo_m_runner::vm::VM;
+use cairo_m_runner::run_cairo_program;
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use stwo_prover::core::fields::m31::M31;
 use tempfile::NamedTempFile;
 
 const BENCHMARK_DURATION_SECS: u64 = 30;
-// FP offset to account for the calling convention of the executed main function.
-// For this function, there are 0 args and only 1 return value.
-const FP_OFFSET: u32 = 3;
 
 fn fibonacci_1m_benchmark(c: &mut Criterion) {
     let source_path = format!(
@@ -23,12 +21,16 @@ fn fibonacci_1m_benchmark(c: &mut Criterion) {
     let program = (*output.program).clone();
 
     // Run once to get metrics for throughput calculation and reuse for serialization benchmarks
-    let mut vm = VM::try_from(&program).unwrap();
-    let entrypoint = program.get_entrypoint("main").unwrap();
-    vm.run_from_entrypoint(entrypoint as u32, 3).unwrap();
+    let output = run_cairo_program(
+        &program,
+        "fibonacci_loop",
+        &[M31::from(1_000_000)],
+        Default::default(),
+    )
+    .expect("Execution failed");
 
     let mut group = c.benchmark_group("fibonacci_1m");
-    group.throughput(Throughput::Elements(vm.trace.len() as u64));
+    group.throughput(Throughput::Elements(output.vm.trace.len() as u64));
     group.measurement_time(Duration::from_secs(BENCHMARK_DURATION_SECS));
 
     group.bench_function("e2e", |b| {
@@ -36,39 +38,55 @@ fn fibonacci_1m_benchmark(c: &mut Criterion) {
             let trace_file = NamedTempFile::new().expect("Failed to create trace temp file");
             let memory_trace_file =
                 NamedTempFile::new().expect("Failed to create memory trace temp file");
-            let mut vm = VM::try_from(&program).unwrap();
-            vm.run_from_entrypoint(entrypoint as u32, FP_OFFSET)
-                .unwrap();
-            vm.write_binary_trace(trace_file.path()).unwrap();
-            vm.write_binary_memory_trace(memory_trace_file.path())
+            let output = run_cairo_program(
+                &program,
+                "fibonacci_loop",
+                &[M31::from(1_000_000)],
+                Default::default(),
+            )
+            .expect("Execution failed");
+            output.vm.write_binary_trace(trace_file.path()).unwrap();
+            output
+                .vm
+                .write_binary_memory_trace(memory_trace_file.path())
                 .unwrap();
 
-            black_box(vm)
+            black_box(output.vm)
         })
     });
 
     group.bench_function("execution_only", |b| {
         b.iter(|| {
-            let mut vm = VM::try_from(&program).unwrap();
-            vm.run_from_entrypoint(entrypoint as u32, FP_OFFSET)
-                .unwrap();
-            black_box(vm)
+            let output = run_cairo_program(
+                &program,
+                "fibonacci_loop",
+                &[M31::from(1_000_000)],
+                Default::default(),
+            )
+            .expect("Execution failed");
+            black_box(output.vm)
         })
     });
 
     group.bench_function("io_only", |b| {
         // Pre-execute the VM for I/O testing
-        let mut vm = VM::try_from(&program).unwrap();
-        vm.run_from_entrypoint(entrypoint as u32, FP_OFFSET)
-            .unwrap();
+        let output = run_cairo_program(
+            &program,
+            "fibonacci_loop",
+            &[M31::from(1_000_000)],
+            Default::default(),
+        )
+        .expect("Execution failed");
 
         let trace_file = NamedTempFile::new().expect("Failed to create trace temp file");
         let memory_trace_file =
             NamedTempFile::new().expect("Failed to create memory trace temp file");
 
         b.iter(|| {
-            vm.write_binary_trace(trace_file.path()).unwrap();
-            vm.write_binary_memory_trace(memory_trace_file.path())
+            output.vm.write_binary_trace(trace_file.path()).unwrap();
+            output
+                .vm
+                .write_binary_memory_trace(memory_trace_file.path())
                 .unwrap();
             black_box(())
         })
@@ -76,14 +94,14 @@ fn fibonacci_1m_benchmark(c: &mut Criterion) {
 
     group.bench_function("serialize_vm_trace", |b| {
         b.iter(|| {
-            let serialized = vm.serialize_trace();
+            let serialized = output.vm.serialize_trace();
             black_box(serialized)
         })
     });
 
     group.bench_function("serialize_memory_trace", |b| {
         b.iter(|| {
-            let serialized = vm.memory.serialize_trace();
+            let serialized = output.vm.memory.serialize_trace();
             black_box(serialized)
         })
     });

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -20,6 +20,9 @@ pub enum RunnerError {
 
     #[error("Failed to read return value: {0}")]
     ReturnValueError(#[from] MemoryError),
+
+    #[error("Argument count mismatch: expected {expected}, provided {provided}")]
+    ArgumentCountMismatch { expected: usize, provided: usize },
 }
 
 /// Options for running a Cairo program
@@ -31,8 +34,8 @@ pub struct RunnerOptions {
 /// Result of running a Cairo program
 #[derive(Debug)]
 pub struct RunnerOutput {
-    /// The return value of the program
-    pub return_value: u32,
+    /// The return values of the program
+    pub return_values: Vec<M31>,
     /// The final VM
     pub vm: VM,
 }
@@ -42,35 +45,65 @@ pub struct RunnerOutput {
 /// ## Arguments
 /// * `program` - The compiled program to run
 /// * `entrypoint` - Name of the entry point function to execute
+/// * `args` - Arguments to pass to the entrypoint function
 /// * `options` - Runner options
 ///
 /// ## Returns
-/// * `Ok(RunnerOutput)` - Program executed successfully with return value
+/// * `Ok(RunnerOutput)` - Program executed successfully with return values
 /// * `Err(RunnerError)` - Execution failed
 pub fn run_cairo_program(
     program: &Program,
     entrypoint: &str,
+    args: &[M31],
     _options: RunnerOptions,
 ) -> Result<RunnerOutput> {
-    let entrypoint_pc = program.get_entrypoint(entrypoint).ok_or_else(|| {
+    let entrypoint_info = program.get_entrypoint(entrypoint).ok_or_else(|| {
         RunnerError::EntryPointNotFound(
             entrypoint.to_string(),
             program.entrypoints.keys().cloned().collect(),
         )
     })?;
 
+    // Use provided num_return_values or get from entrypoint info
+    let num_return_values = entrypoint_info.num_return_values;
+
+    // Validate argument count matches expected
+    if args.len() != entrypoint_info.args.len() {
+        return Err(RunnerError::ArgumentCountMismatch {
+            expected: entrypoint_info.args.len(),
+            provided: args.len(),
+        });
+    }
+
     let mut vm = VM::try_from(program)?;
 
-    // TODO: Get entrypoint information from the compiled program to know how many args / return data to allocate
-    const FP_OFFSET: u32 = 3;
-    vm.run_from_entrypoint(entrypoint_pc as u32, FP_OFFSET)?;
+    // Calculate FP offset based on Cairo-M calling convention:
+    // Frame layout: [args, return_values, old_fp, return_pc]
+    // FP points to the first address after the frame
+    let fp_offset = args.len() + num_return_values + 2;
 
-    // Get the return value from [fp - 3]
-    let return_address = vm.state.fp - M31::from(FP_OFFSET);
-    let return_value = vm.memory.get_data(return_address)?;
+    // Write arguments to memory before the frame pointer
+    // The new FP will be at initial_fp + fp_offset
+    // Arguments should be at [new_fp - M - K - 2 + i] for arg i
+    let initial_fp = vm.state.fp;
+    let new_fp = initial_fp + M31::from(fp_offset as u32);
+    for (i, arg) in args.iter().enumerate() {
+        // For M args and K returns: arg_i is at [fp - M - K - 2 + i]
+        let offset = args.len() + num_return_values + 2 - i;
+        let arg_address = new_fp - M31::from(offset as u32);
+        vm.memory.insert(arg_address, (*arg).into())?;
+    }
 
-    Ok(RunnerOutput {
-        return_value: return_value.0,
-        vm,
-    })
+    vm.run_from_entrypoint(entrypoint_info.pc as u32, fp_offset as u32)?;
+
+    // Retrieve return values from memory
+    // Return values are stored at [fp - num_return_values - 2] to [fp - 3]
+    let mut return_values = Vec::with_capacity(num_return_values);
+    for i in 0..num_return_values {
+        let return_address = vm.state.fp - M31::from((num_return_values + 2 - i) as u32);
+        let value = vm.memory.get_data(return_address)?;
+        return_values.push(M31::from(value.0));
+    }
+
+    Ok(RunnerOutput { return_values, vm })
 }

--- a/crates/runner/tests/test_data/fibonacci.cm
+++ b/crates/runner/tests/test_data/fibonacci.cm
@@ -1,9 +1,3 @@
-func main() -> felt {
-    let n = 10;
-    let result = fib(n);
-    return result;
-}
-
 func fib(n: felt) -> felt {
     if (n == 0) {
         return 0;

--- a/crates/runner/tests/test_data/fibonacci_loop.cm
+++ b/crates/runner/tests/test_data/fibonacci_loop.cm
@@ -10,9 +10,3 @@ func fibonacci_loop(n: felt) -> felt {
     }
     return a;
 }
-
-func main() -> felt {
-    let n = 10;
-    let result = fibonacci_loop(n);
-    return result;
-}

--- a/crates/runner/tests/test_data/power.cm
+++ b/crates/runner/tests/test_data/power.cm
@@ -1,10 +1,3 @@
-func main() -> felt {
-    let base = 3;
-    let exp = 10;
-    let result = power(base, exp);
-    return result;
-}
-
 func power(base: felt, exp: felt) -> felt {
     if (exp == 0) {
         return 1;


### PR DESCRIPTION
Adds support for running a program from an entrypoint and passing args. Modified the compiled artifacts to add a list of named args. the names for now are only placeholders.