### PR TITLE
feat(prover): add recursive fibonacci test

### DIFF
--- a/crates/prover/tests/prover.rs
+++ b/crates/prover/tests/prover.rs
@@ -92,3 +92,32 @@ fn test_prove_and_verify_fibonacci_program() {
 
     verify_cairo_m::<Blake2sMerkleChannel>(proof).unwrap();
 }
+
+#[test]
+#[should_panic(expected = "called `Result::unwrap()` on an `Err` value: InvalidLogupSum")]
+fn test_prove_and_verify_recursive_fibonacci_program() {
+    let source_path = format!(
+        "{}/tests/test_data/{}",
+        env!("CARGO_MANIFEST_DIR"),
+        "recursive_fibonacci.cm"
+    );
+    let compiled_fib = compile_cairo(
+        fs::read_to_string(&source_path).unwrap(),
+        source_path,
+        CompilerOptions::default(),
+    )
+    .unwrap();
+
+    let runner_output = run_cairo_program(
+        &compiled_fib.program,
+        "fib",
+        &[M31::from(5)],
+        Default::default(),
+    )
+    .unwrap();
+
+    let mut prover_input = import_from_runner_output(&runner_output).unwrap();
+    let proof = prove_cairo_m::<Blake2sMerkleChannel>(&mut prover_input).unwrap();
+
+    verify_cairo_m::<Blake2sMerkleChannel>(proof).unwrap();
+}

--- a/crates/prover/tests/test_data/recursive_fibonacci.cm
+++ b/crates/prover/tests/test_data/recursive_fibonacci.cm
@@ -1,0 +1,9 @@
+func fib(n: felt) -> felt {
+    if (n == 0) {
+        return 0;
+    }
+    if (n == 1) {
+        return 1;
+    }
+    return fib(n - 1) + fib(n - 2);
+}


### PR DESCRIPTION
Prover team is having troubles with instruction like "b = b + temp" or "i = i + 1" as they access twice a same memory cell in one cycle. So the first read to the previous _b_ or _i_ sets `prev_clock` to the current clock. During the second memory access (the write in this case), the clock hasn't changed and the `prev_clock` of the memory cell is the current clock as well.
There is no such problem in the recursive fibonacci (we will split our efforts on fixing the previously mentioned bug encountered on iterative fibonacci and fixing the invalid logup sum of the recursive fibonacci).