### PR TITLE
fix(compiler): optimize comparisons with 0

### DIFF
--- a/crates/compiler/codegen/src/generator.rs
+++ b/crates/compiler/codegen/src/generator.rs
@@ -386,20 +386,21 @@ impl CodeGenerator {
                 let then_label = format!("{function_name}_{then_target:?}");
                 let else_label = format!("{function_name}_{else_target:?}");
 
+                // For comparison, we compute `a - b`. The result is non-zero if they are not equal.
+                builder.generate_arithmetic_op(BinaryOp::Sub, temp_slot_offset, *left, *right)?;
+
                 match op {
                     BinaryOp::Eq => {
-                        // For `a == b`, we compute `a - b`. The result is zero if they are equal.
-                        builder.generate_arithmetic_op(
-                            BinaryOp::Sub,
-                            temp_slot_offset,
-                            *left,
-                            *right,
-                        )?;
-
                         // `jnz` jumps if the result is non-zero.
                         // A non-zero result means `a != b`, so we should jump to the `else` block.
                         // Otherwise we can simply fallthrough.
                         builder.jnz_offset(temp_slot_offset, &else_label)?;
+                    }
+                    BinaryOp::Neq => {
+                        // `jnz` jumps if the result is non-zero.
+                        // A non-zero result means `a != b`, so we should jump to the `then` block.
+                        // Otherwise we can simply fallthrough.
+                        builder.jnz_offset(temp_slot_offset, &then_label)?;
                     }
                     _ => {
                         return Err(CodegenError::UnsupportedInstruction(format!(

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else.snap
@@ -21,8 +21,8 @@ Generated CASM:
 test_if_else:
 test_if_else:
 test_if_else_0:
-   0: 3 -4 0 0             // [fp + 0] = [fp + -4] op 0
-   1: 31 0 3 _             // if [fp + 0] != 0 jmp rel test_if_else_2
+   0: 31 -4 4 _            // if [fp + -4] != 0 jmp rel test_if_else_2
+   1: 20 2 _ _             // jump abs test_if_else_1
 test_if_else_1:
    2: 6 1 _ -3             // Return value 0: [fp -3] = 1
    3: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else_with_merge.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else_with_merge.snap
@@ -24,8 +24,8 @@ test_if_else:
 test_if_else:
 test_if_else_0:
    0: 6 0 _ 0              // Store immediate: [fp + 0] = 0
-   1: 3 -4 0 1             // [fp + 1] = [fp + -4] op 0
-   2: 31 1 3 _             // if [fp + 1] != 0 jmp rel test_if_else_2
+   1: 31 -4 4 _            // if [fp + -4] != 0 jmp rel test_if_else_2
+   2: 20 3 _ _             // jump abs test_if_else_1
 test_if_else_1:
    3: 6 1 _ 0              // Store immediate: [fp + 0] = 1
    4: 20 6 _ _             // jump abs test_if_else_3

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_simple_if.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_simple_if.snap
@@ -20,8 +20,8 @@ Generated CASM:
 test_if:
 test_if:
 test_if_0:
-   0: 3 -4 0 0             // [fp + 0] = [fp + -4] op 0
-   1: 31 0 3 _             // if [fp + 0] != 0 jmp rel test_if_2
+   0: 31 -4 4 _            // if [fp + -4] != 0 jmp rel test_if_2
+   1: 20 2 _ _             // jump abs test_if_1
 test_if_1:
    2: 6 1 _ -3             // Return value 0: [fp -3] = 1
    3: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_fib.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_fib.snap
@@ -34,21 +34,21 @@ main:
    3: 4 3 _ -3             // Return value 0: [fp -3] = [fp + 3]
    4: 15 _ _ _             // return
 fib:
-   5: 3 -4 0 0             // [fp + 0] = [fp + -4] op 0
-   6: 31 0 3 _             // if [fp + 0] != 0 jmp rel fib_2
+   5: 31 -4 4 _            // if [fp + -4] != 0 jmp rel fib_2
+   6: 20 7 _ _             // jump abs fib_1
 fib_1:
    7: 6 0 _ -3             // Return value 0: [fp -3] = 0
    8: 15 _ _ _             // return
 fib_2:
-   9: 3 -4 1 1             // [fp + 1] = [fp + -4] op 1
-  10: 31 1 3 _             // if [fp + 1] != 0 jmp rel fib_4
+   9: 3 -4 1 0             // [fp + 0] = [fp + -4] op 1
+  10: 31 0 3 _             // if [fp + 0] != 0 jmp rel fib_4
 fib_3:
   11: 6 1 _ -3             // Return value 0: [fp -3] = 1
   12: 15 _ _ _             // return
 fib_4:
-  13: 3 -4 1 2             // [fp + 2] = [fp + -4] op 1
-  14: 12 4 5 _             // call fib
-  15: 3 -4 2 5             // [fp + 5] = [fp + -4] op 2
-  16: 12 7 5 _             // call fib
-  17: 0 3 6 -3             // [fp + -3] = [fp + 3] op [fp + 6]
+  13: 3 -4 1 1             // [fp + 1] = [fp + -4] op 1
+  14: 12 3 5 _             // call fib
+  15: 3 -4 2 4             // [fp + 4] = [fp + -4] op 2
+  16: 12 6 5 _             // call fib
+  17: 0 2 5 -3             // [fp + -3] = [fp + 2] op [fp + 5]
   18: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_fib_loop.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_fib_loop.snap
@@ -38,26 +38,19 @@ fibonacci_loop_0:
    2: 6 0 _ 2              // Store immediate: [fp + 2] = 0
 fibonacci_loop_1:
    3: 2 2 -4 3             // [fp + 3] = [fp + 2] op [fp + -4]
-   4: 31 3 3 _             // if [fp + 3] != 0, jump to neq_non_zero_0
-   5: 6 0 _ 3              // [fp + 3] = 0
-   6: 20 8 _ _             // jump to neq_end_1
-neq_non_zero_0:
-   7: 6 1 _ 3              // [fp + 3] = 1
-neq_end_1:
-   8: 31 3 2 _             // if [fp + 3] != 0 jmp rel fibonacci_loop_2
-   9: 20 15 _ _            // jump abs fibonacci_loop_3
+   4: 31 3 1 _             // if [fp + 3] != 0 jmp rel fibonacci_loop_2
 fibonacci_loop_2:
-  10: 4 0 _ 4              // Store: [fp + 4] = [fp + 0]
-  11: 4 1 _ 0              // Store: [fp + 0] = [fp + 1]
-  12: 0 1 4 1              // [fp + 1] = [fp + 1] op [fp + 4]
-  13: 1 2 1 2              // [fp + 2] = [fp + 2] op 1
-  14: 20 3 _ _             // jump abs fibonacci_loop_1
+   5: 4 0 _ 4              // Store: [fp + 4] = [fp + 0]
+   6: 4 1 _ 0              // Store: [fp + 0] = [fp + 1]
+   7: 0 1 4 1              // [fp + 1] = [fp + 1] op [fp + 4]
+   8: 1 2 1 2              // [fp + 2] = [fp + 2] op 1
+   9: 20 3 _ _             // jump abs fibonacci_loop_1
 fibonacci_loop_3:
-  15: 4 0 _ -3             // Return value 0: [fp -3] = [fp + 0]
-  16: 15 _ _ _             // return
+  10: 4 0 _ -3             // Return value 0: [fp -3] = [fp + 0]
+  11: 15 _ _ _             // return
 main:
-  17: 6 10 _ 0             // Store immediate: [fp + 0] = 10
-  18: 12 2 0 _             // call fibonacci_loop
-  19: 4 1 _ 3              // Store: [fp + 3] = [fp + 1]
-  20: 4 3 _ -3             // Return value 0: [fp -3] = [fp + 3]
-  21: 15 _ _ _             // return
+  12: 6 10 _ 0             // Store immediate: [fp + 0] = 10
+  13: 12 2 0 _             // call fibonacci_loop
+  14: 4 1 _ 3              // Store: [fp + 3] = [fp + 1]
+  15: 4 3 _ -3             // Return value 0: [fp -3] = [fp + 3]
+  16: 15 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__optimization_in_place_update.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__optimization_in_place_update.snap
@@ -50,25 +50,18 @@ test_loop_optimization_0:
    7: 6 0 _ 1              // Store immediate: [fp + 1] = 0
 test_loop_optimization_1:
    8: 3 0 5 2              // [fp + 2] = [fp + 0] op 5
-   9: 31 2 3 _             // if [fp + 2] != 0, jump to neq_non_zero_0
-  10: 6 0 _ 2              // [fp + 2] = 0
-  11: 20 13 _ _            // jump to neq_end_1
-neq_non_zero_0:
-  12: 6 1 _ 2              // [fp + 2] = 1
-neq_end_1:
-  13: 31 2 2 _             // if [fp + 2] != 0 jmp rel test_loop_optimization_2
-  14: 20 18 _ _            // jump abs test_loop_optimization_3
+   9: 31 2 1 _             // if [fp + 2] != 0 jmp rel test_loop_optimization_2
 test_loop_optimization_2:
-  15: 0 1 0 1              // [fp + 1] = [fp + 1] op [fp + 0]
-  16: 1 0 1 0              // [fp + 0] = [fp + 0] op 1
-  17: 20 8 _ _             // jump abs test_loop_optimization_1
+  10: 0 1 0 1              // [fp + 1] = [fp + 1] op [fp + 0]
+  11: 1 0 1 0              // [fp + 0] = [fp + 0] op 1
+  12: 20 8 _ _             // jump abs test_loop_optimization_1
 test_loop_optimization_3:
-  18: 4 1 _ -3             // Return value 0: [fp -3] = [fp + 1]
-  19: 15 _ _ _             // return
+  13: 4 1 _ -3             // Return value 0: [fp -3] = [fp + 1]
+  14: 15 _ _ _             // return
 main:
-  20: 12 1 0 _             // call test_in_place_update
-  21: 4 0 _ 2              // Store: [fp + 2] = [fp + 0]
-  22: 12 4 6 _             // call test_loop_optimization
-  23: 4 3 _ 5              // Store: [fp + 5] = [fp + 3]
-  24: 0 2 5 -3             // [fp + -3] = [fp + 2] op [fp + 5]
-  25: 15 _ _ _             // return
+  15: 12 1 0 _             // call test_in_place_update
+  16: 4 0 _ 2              // Store: [fp + 2] = [fp + 0]
+  17: 12 4 6 _             // call test_loop_optimization
+  18: 4 3 _ 5              // Store: [fp + 5] = [fp + 3]
+  19: 0 2 5 -3             // [fp + -3] = [fp + 2] op [fp + 5]
+  20: 15 _ _ _             // return

--- a/crates/compiler/mir/src/ir_generation/tests/mir_generation_tests.rs
+++ b/crates/compiler/mir/src/ir_generation/tests/mir_generation_tests.rs
@@ -76,6 +76,7 @@ mir_test!(reassignment_from_var, "variables");
 
 // --- Optimizations ---
 mir_test!(unused_variable_elimination, "optimizations");
+mir_test!(zero_conditions, "optimizations");
 
 // --- Aggregates (Structs/Tuples) ---
 mir_test!(struct_literal, "aggregates");

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_nested_loops.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_nested_loops.snap
@@ -40,8 +40,7 @@ module {
       jump 1
 
     1:
-      %2 = %1 Neq 3
-      if %2 then jump 2 else jump 3
+      if %1 Neq 3 then jump 2 else jump 3
 
     2:
       %3 = stackalloc 1
@@ -52,8 +51,7 @@ module {
       return %0
 
     4:
-      %4 = %3 Neq 4
-      if %4 then jump 5 else jump 6
+      if %3 Neq 4 then jump 5 else jump 6
 
     5:
       %0 = %0 Add 1

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_simple_while.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_simple_while.snap
@@ -36,8 +36,7 @@ module {
       jump 1
 
     1:
-      %2 = %0 Neq 10
-      if %2 then jump 2 else jump 3
+      if %0 Neq 10 then jump 2 else jump 3
 
     2:
       %1 = %1 Add %0

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_fib.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_fib.snap
@@ -50,7 +50,7 @@ module {
     entry: 0
 
     0:
-      if %0 Eq 0 then jump 1 else jump 2
+      if %0 then jump 2 else jump 1
 
     1:
       return 0

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_fib_loop.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_fib_loop.snap
@@ -46,8 +46,7 @@ module {
       jump 1
 
     1:
-      %4 = %3 Neq %0
-      if %4 then jump 2 else jump 3
+      if %3 Neq %0 then jump 2 else jump 3
 
     2:
       %5 = stackalloc 1

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__optimizations_zero_conditions.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__optimizations_zero_conditions.snap
@@ -6,19 +6,17 @@ expression: snapshot_content
 source: crates/compiler/mir/src/ir_generation/tests/mir_generation_tests.rs
 expression: mir_output
 ---
-Fixture: if_both_return.cm
+Fixture: zero_conditions.cm
 ============================================================
 Source code:
-//!ASSERT BLOCK_COUNT(test): 3 // entry, then, else. NO merge block.
-//!ASSERT NOT_CONTAINS: jump 3 // Should not jump to a merge block.
-
-// Tests an `if-else` where both branches terminate with a `return`.
-// No merge block should be generated.
-func test(x: felt) -> felt {
-    if (x == 0) {
+func zero_conditions(x: felt) -> felt {
+    if (0 == x){
         return 1;
-    } else {
+    }
+    if (x != 0){
         return 2;
+    } else {
+        return 3;
     }
 }
 
@@ -26,7 +24,7 @@ func test(x: felt) -> felt {
 Generated MIR:
 module {
   // Function 0
-  fn test {
+  fn zero_conditions {
     parameters: [0]
     entry: 0
 
@@ -37,7 +35,13 @@ module {
       return 1
 
     2:
+      if %0 then jump 3 else jump 4
+
+    3:
       return 2
+
+    4:
+      return 3
 
   }
 

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/optimizations/zero_conditions.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/optimizations/zero_conditions.cm
@@ -1,0 +1,10 @@
+func zero_conditions(x: felt) -> felt {
+    if (0 == x){
+        return 1;
+    }
+    if (x != 0){
+        return 2;
+    } else {
+        return 3;
+    }
+}


### PR DESCRIPTION
Closes CORE-855
- `mir/passes.rs` : updated the `FuseCmpBranch` MIR pass to produce simple If statements when lef tor right member is litteral 0
- `codegen/generator.rs` : added support for `Neq` in `BranchCmp` terminator
TODO : add the case for `UnaryOp::Not` in the `FuseCmpBranch` pass once #135 is merged.