### PR TITLE
refactor(compiler): func -> fn

### DIFF
--- a/cairo-m-project/src/library/utils.cm
+++ b/cairo-m-project/src/library/utils.cm
@@ -1,3 +1,3 @@
-func foo(){
+fn foo(){
     return();
 }

--- a/cairo-m-project/src/main.cm
+++ b/cairo-m-project/src/main.cm
@@ -1,7 +1,7 @@
 use math::helper_func;
 use library::utils::foo;
 
-func main() {
+fn main() {
     let x = 3;
     helper_func();
     foo();

--- a/cairo-m-project/src/math.cm
+++ b/cairo-m-project/src/math.cm
@@ -1,4 +1,4 @@
-func helper_func() -> (){
+fn helper_func() -> (){
     let x =2;
     return();
 }

--- a/crates/cairo-m-ls/docs/test_design.md
+++ b/crates/cairo-m-ls/docs/test_design.md
@@ -156,7 +156,7 @@ async fn test_variable_type_hover() {
     test_transform!(
         HoverTransformer,
         r#"
-func main() {
+fn main() {
     let x: felt = 42;
     let y = x<caret>;
     return y;
@@ -181,13 +181,13 @@ name = "test_project"
             "main.cm" => r#"
 use math::add;
 
-func main() {
+fn main() {
     let result = <caret>add(3, 4);
     return result;
 }
 "#,
             "math.cm" => r#"
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 "#
@@ -234,7 +234,7 @@ async fn test_basic_diagnostics() {
     test_transform!(
         DiagnosticsTransformer,
         r#"
-func main() {
+fn main() {
     let _x = undefined_var; // This should produce an error
 }
 "#
@@ -259,8 +259,8 @@ func main() {
 let mut ls = sandbox! {
     files {
         "cairom.toml" => r#"[project]\nname = "test""#,
-        "main.cm" => "use lib::func;",
-        "lib.cm" => "fn func() {}"
+        "main.cm" => "use lib::fn;",
+        "lib.cm" => "fn fn() {}"
     }
 };
 ```
@@ -275,7 +275,7 @@ fixture.add_file(
     r#"
 use utils::helper_foo;
 
-func main() {
+fn main() {
     let result = helper_foo(42);
 }
 "#,
@@ -283,7 +283,7 @@ func main() {
 fixture.add_file(
     "utils.cm",
     r#"
-func helper_foo(x: felt) -> felt {
+fn helper_foo(x: felt) -> felt {
     return x * 2;
 }
 "#,
@@ -430,7 +430,7 @@ async fn goto_variable_definition() {
     test_transform!(
         GotoDefinition,
         r#"
-func main() {
+fn main() {
     let x = 42;
     let y = <caret>x + 1;
     return y;
@@ -480,7 +480,7 @@ async fn test_basic_diagnostics() {
     test_transform!(
         DiagnosticsTransformer,
         r#"
-func main() {
+fn main() {
     let _x = undefined_var; // This should produce an error
 }
 "#

--- a/crates/cairo-m-ls/src/backend.rs
+++ b/crates/cairo-m-ls/src/backend.rs
@@ -1072,7 +1072,7 @@ impl LanguageServer for Backend {
                 ("let", CompletionItemKind::KEYWORD),
                 ("local", CompletionItemKind::KEYWORD),
                 ("const", CompletionItemKind::KEYWORD),
-                ("func", CompletionItemKind::KEYWORD),
+                ("fn", CompletionItemKind::KEYWORD),
                 ("struct", CompletionItemKind::KEYWORD),
                 ("true", CompletionItemKind::KEYWORD),
                 ("false", CompletionItemKind::KEYWORD),

--- a/crates/cairo-m-ls/tests/e2e/diagnostics_test.rs
+++ b/crates/cairo-m-ls/tests/e2e/diagnostics_test.rs
@@ -54,7 +54,7 @@ async fn test_basic_diagnostics() {
     test_transform!(
         DiagnosticsTransformer,
         r#"
-func main() {
+fn main() {
     let _x = undefined_var; // This should produce an error
 }
 "#
@@ -66,7 +66,7 @@ async fn test_no_errors() {
     test_transform!(
         DiagnosticsTransformer,
         r#"
-func main() {
+fn main() {
     let x = 42;
     let _y = x + 1;
 }

--- a/crates/cairo-m-ls/tests/e2e/goto_definition/cross_file_definitions.rs
+++ b/crates/cairo-m-ls/tests/e2e/goto_definition/cross_file_definitions.rs
@@ -12,13 +12,13 @@ version = "0.1.0"
             "src/main.cm" => r#"
 use math::add;
 
-func main() {
+fn main() {
     let result = <caret>add(3, 4);
     return result;
 }
 "#,
             "src/math.cm" => r#"
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 "#
@@ -30,7 +30,7 @@ func add(a: felt, b: felt) -> felt {
         r#"
 use math::add;
 
-func main() {
+fn main() {
     let result = <caret>add(3, 4);
     return result;
 }
@@ -55,12 +55,12 @@ version = "0.1.0"
             "src/main.cm" => r#"
 use <caret>utils::helper;
 
-func main() {
+fn main() {
     helper();
 }
 "#,
             "src/utils.cm" => r#"
-func helper() -> felt {
+fn helper() -> felt {
     42
 }
 "#
@@ -72,7 +72,7 @@ func helper() -> felt {
         r#"
 use <caret>utils;
 
-func main() {
+fn main() {
     helper();
 }
 "#,
@@ -98,7 +98,7 @@ version = "0.1.0"
             "src/main.cm" => r#"
 use types::Point;
 
-func main() {
+fn main() {
     let p: <caret>Point = Point { x: 1, y: 2 };
 }
 "#,
@@ -116,7 +116,7 @@ struct Point {
         r#"
 use types::Point;
 
-func main() {
+fn main() {
     let p: <caret>Point = Point { x: 1, y: 2 };
 }
 "#,
@@ -142,12 +142,12 @@ version = "0.1.0"
             "src/main.cm" => r#"
 use math::ops::add;
 
-func main() {
+fn main() {
     let result = <caret>add(1, 2);
 }
 "#,
     "math/ops.cm" => r#"
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     a + b
 }
 "#
@@ -159,7 +159,7 @@ func add(a: felt, b: felt) -> felt {
         r#"
 use math::ops::add;
 
-func main() {
+fn main() {
     let result = <caret>add(1, 2);
 }
 "#,
@@ -183,7 +183,7 @@ version = "0.1.0"
             "src/main.cm" => r#"
 use nonexistent::function;
 
-func main() {
+fn main() {
     <caret>function();
 }
 "#
@@ -195,7 +195,7 @@ func main() {
         r#"
 use nonexistent::function;
 
-func main() {
+fn main() {
     <caret>function();
 }
 "#,

--- a/crates/cairo-m-ls/tests/e2e/goto_definition/local_definitions.rs
+++ b/crates/cairo-m-ls/tests/e2e/goto_definition/local_definitions.rs
@@ -6,7 +6,7 @@ async fn goto_variable_definition() {
     test_transform!(
         GotoDefinition,
         r#"
-func main() {
+fn main() {
     let x = 42;
     let y = <caret>x + 1;
     return y;
@@ -20,11 +20,11 @@ async fn goto_function_definition() {
     test_transform!(
         GotoDefinition,
         r#"
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 
-func main() {
+fn main() {
     let result = <caret>add(3, 4);
     return result;
 }
@@ -37,7 +37,7 @@ async fn goto_parameter_definition() {
     test_transform!(
         GotoDefinition,
         r#"
-func calculate(value: felt) -> felt {
+fn calculate(value: felt) -> felt {
     return <caret>value * 2;
 }
 "#
@@ -54,7 +54,7 @@ struct Point {
     y: felt,
 }
 
-func main() {
+fn main() {
     let p: <caret>Point = Point { x: 1, y: 2 };
     return p;
 }
@@ -72,7 +72,7 @@ struct Rectangle {
     height: felt,
 }
 
-func main() {
+fn main() {
     let rect = Rectangle { width: 10, height: 20 };
     let w = rect.<caret>width;
     return w;
@@ -86,7 +86,7 @@ async fn goto_local_in_block() {
     test_transform!(
         GotoDefinition,
         r#"
-func main() {
+fn main() {
     let outer = 1;
     {
         let inner = 2;
@@ -103,7 +103,7 @@ async fn goto_loop_variable() {
     test_transform!(
         GotoDefinition,
         r#"
-func main() {
+fn main() {
     for i in 0..10 {
         let doubled = <caret>i * 2;
     }
@@ -117,7 +117,7 @@ async fn goto_shadowed_variable() {
     test_transform!(
         GotoDefinition,
         r#"
-func main() {
+fn main() {
     let x = 1;
     let x = 2;
     let y = <caret>x + 1;  // Should go to the second definition
@@ -132,7 +132,7 @@ async fn no_definition_for_keyword() {
     test_transform!(
         GotoDefinition,
         r#"
-func main() {
+fn main() {
     <caret>let x = 42;
     return x;
 }
@@ -145,7 +145,7 @@ async fn no_definition_for_literal() {
     test_transform!(
         GotoDefinition,
         r#"
-func main() {
+fn main() {
     let x = <caret>42;
 }
 "#
@@ -157,15 +157,15 @@ async fn goto_function_in_call_chain() {
     test_transform!(
         GotoDefinition,
         r#"
-func first() -> felt {
+fn first() -> felt {
     1
 }
 
-func second() -> felt {
+fn second() -> felt {
     2
 }
 
-func main() {
+fn main() {
     let x = <caret>first() + second();
 }
 "#
@@ -177,8 +177,8 @@ async fn goto_nested_function_definition() {
     test_transform!(
         GotoDefinition,
         r#"
-func outer() {
-    func inner() -> felt {
+fn outer() {
+    fn inner() -> felt {
         42
     }
 

--- a/crates/cairo-m-ls/tests/e2e/goto_definition/snapshots/e2e__goto_definition__local_definitions__goto_function_definition.snap
+++ b/crates/cairo-m-ls/tests/e2e/goto_definition/snapshots/e2e__goto_definition__local_definitions__goto_function_definition.snap
@@ -2,4 +2,4 @@
 source: crates/cairo-m-ls/tests/e2e/goto_definition/local_definitions.rs
 expression: result
 ---
-Definition at <TEMP_DIR>/main.cm:2:6
+Definition at <TEMP_DIR>/main.cm:2:4

--- a/crates/cairo-m-ls/tests/e2e/goto_definition/snapshots/e2e__goto_definition__local_definitions__goto_parameter_definition.snap
+++ b/crates/cairo-m-ls/tests/e2e/goto_definition/snapshots/e2e__goto_definition__local_definitions__goto_parameter_definition.snap
@@ -2,4 +2,4 @@
 source: crates/cairo-m-ls/tests/e2e/goto_definition/local_definitions.rs
 expression: result
 ---
-Definition at <TEMP_DIR>/main.cm:2:16
+Definition at <TEMP_DIR>/main.cm:2:14

--- a/crates/cairo-m-ls/tests/e2e/hover/cross_file_hover.rs
+++ b/crates/cairo-m-ls/tests/e2e/hover/cross_file_hover.rs
@@ -13,7 +13,7 @@ async fn test_hover_on_imported_function() {
         r#"
 use utils::helper_foo;
 
-func main() {
+fn main() {
     let result = helper_foo(42);
 }
 "#,
@@ -21,7 +21,7 @@ func main() {
     fixture.add_file(
         "src/utils.cm",
         r#"
-func helper_foo(x: felt) -> felt {
+fn helper_foo(x: felt) -> felt {
     return x * 2;
 }
 "#,
@@ -31,7 +31,7 @@ func helper_foo(x: felt) -> felt {
         r#"
 use utils::helper_foo;
 
-func main() {
+fn main() {
     let result = helper_<caret>foo(42);
 }
 "#,
@@ -52,7 +52,7 @@ async fn test_hover_on_imported_type() {
         r#"
 use types::CustomType;
 
-func main() {
+fn main() {
     let value: CustomType = CustomType { value: 42 };
 }
 "#,
@@ -70,7 +70,7 @@ struct CustomType {
         r#"
 use types::CustomType;
 
-func main() {
+fn main() {
     let value: Custom<caret>Type = CustomType { value: 42 };
 }
 "#,
@@ -90,7 +90,7 @@ async fn test_hover_on_module_name() {
         r#"
 use utils::calculate;
 
-func main() {
+fn main() {
     let result = calculate(10, 20);
 }
 "#,
@@ -98,11 +98,11 @@ func main() {
     fixture.add_file(
         "src/utils.cm",
         r#"
-func calculate(a: felt, b: felt) -> felt {
+fn calculate(a: felt, b: felt) -> felt {
     a + b
 }
 
-func multiply(a: felt, b: felt) -> felt {
+fn multiply(a: felt, b: felt) -> felt {
     a * b
 }
 "#,
@@ -112,7 +112,7 @@ func multiply(a: felt, b: felt) -> felt {
         r#"
 use util<caret>s::calculate;
 
-func main() {
+fn main() {
     let result = calculate(10, 20);
 }
 "#,
@@ -132,7 +132,7 @@ async fn test_hover_on_imported_constant() {
         r#"
 use constants::MAX_VALUE;
 
-func main() {
+fn main() {
     let limit = MAX_VALUE;
     return();
 }
@@ -149,7 +149,7 @@ const MAX_VALUE = 1000;
         r#"
 use constants::MAX_VALUE;
 
-func main() {
+fn main() {
     let limit = MAX_<caret>VALUE;
     return();
 }

--- a/crates/cairo-m-ls/tests/e2e/hover/type_hover.rs
+++ b/crates/cairo-m-ls/tests/e2e/hover/type_hover.rs
@@ -6,7 +6,7 @@ async fn test_variable_type_hover() {
     test_transform!(
         HoverTransformer,
         r#"
-func main() {
+fn main() {
     let x: felt = 42;
     let y = x<caret>;
     return y;
@@ -20,11 +20,11 @@ async fn test_function_signature_hover() {
     test_transform!(
         HoverTransformer,
         r#"
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 
-func main() {
+fn main() {
     let sum = ad<caret>d(1, 2);
     return sum;
 }
@@ -37,7 +37,7 @@ async fn test_parameter_type_hover() {
     test_transform!(
         HoverTransformer,
         r#"
-func process(value<caret>: felt) -> felt {
+fn process(value<caret>: felt) -> felt {
     return value * 2;
 }
 "#
@@ -49,7 +49,7 @@ async fn test_return_type_hover() {
     test_transform!(
         HoverTransformer,
         r#"
-func calculate() -> fe<caret>lt {
+fn calculate() -> fe<caret>lt {
     return 42;
 }
 "#
@@ -61,7 +61,7 @@ async fn test_hover_on_type_annotation() {
     test_transform!(
         HoverTransformer,
         r#"
-func main() {
+fn main() {
     let x: fe<caret>lt = 100;
     return x;
 }
@@ -74,11 +74,11 @@ async fn test_hover_on_function_call_result() {
     test_transform!(
         HoverTransformer,
         r#"
-func get_value() -> felt {
+fn get_value() -> felt {
     42
 }
 
-func main() {
+fn main() {
     let result = get_va<caret>lue();
 }
 "#
@@ -90,7 +90,7 @@ async fn test_hover_no_info() {
     test_transform!(
         HoverTransformer,
         r#"
-func main() {
+fn main() {
     // Hovering on whitespace should return no info
     let x = 42;   <caret>
 }
@@ -103,7 +103,7 @@ async fn test_hover_on_binary_expression() {
     test_transform!(
         HoverTransformer,
         r#"
-func main() {
+fn main() {
     let a: felt = 10;
     let b: felt = 20;
     let sum = a + <caret>b;
@@ -122,7 +122,7 @@ struct Point {
     y: felt,
 }
 
-func main() {
+fn main() {
     let p = Point { x: 10, y: 20 };
     let x_val = p.x<caret>;
 }

--- a/crates/cairo-m-ls/tests/e2e/simple_test.rs
+++ b/crates/cairo-m-ls/tests/e2e/simple_test.rs
@@ -8,7 +8,7 @@ async fn test_simple_diagnostics() {
     fixture.add_file(
         "src/main.cm",
         r#"
-func main() {
+fn main() {
     let _x = undefined_var; // This should produce an error
 }
 "#,

--- a/crates/cairo-m-ls/tests/e2e/snapshots/e2e__diagnostics_test__basic_diagnostics.snap
+++ b/crates/cairo-m-ls/tests/e2e/snapshots/e2e__diagnostics_test__basic_diagnostics.snap
@@ -4,4 +4,4 @@ expression: result
 ---
 2:13-26: Error: Undeclared variable 'undefined_var'
 2:8-10: Warning: Unused variable '_x'
-1:5-9: Error: Function 'main' doesn't return on all paths
+1:3-7: Error: Function 'main' doesn't return on all paths

--- a/crates/cairo-m-ls/tests/e2e/snapshots/e2e__diagnostics_test__no_errors.snap
+++ b/crates/cairo-m-ls/tests/e2e/snapshots/e2e__diagnostics_test__no_errors.snap
@@ -3,4 +3,4 @@ source: crates/cairo-m-ls/tests/e2e/diagnostics_test.rs
 expression: result
 ---
 3:8-10: Warning: Unused variable '_y'
-1:5-9: Error: Function 'main' doesn't return on all paths
+1:3-7: Error: Function 'main' doesn't return on all paths

--- a/crates/cairo-m-ls/tests/e2e/support/fixture.rs
+++ b/crates/cairo-m-ls/tests/e2e/support/fixture.rs
@@ -144,14 +144,14 @@ mod tests {
         let fixture = Fixture::new();
 
         // Test adding a file with explicit extension
-        fixture.add_file("test.cm", "func main() {}");
+        fixture.add_file("test.cm", "fn main() {}");
         assert!(fixture.file_exists("test.cm"));
-        assert_eq!(fixture.read_file("test.cm"), "func main() {}");
+        assert_eq!(fixture.read_file("test.cm"), "fn main() {}");
 
         // Test adding a file without extension (should default to .cm)
-        fixture.add_file("test2", "func test() {}");
+        fixture.add_file("test2", "fn test() {}");
         assert!(fixture.file_exists("test2.cm"));
-        assert_eq!(fixture.read_file("test2.cm"), "func test() {}");
+        assert_eq!(fixture.read_file("test2.cm"), "fn test() {}");
 
         // Test adding a cairom.toml file
         fixture.add_cairom_toml("test_project");
@@ -159,7 +159,7 @@ mod tests {
         assert!(fixture.read_file("cairom.toml").contains("test_project"));
 
         // Test adding a file in a subdirectory
-        fixture.add_file("src/lib.cm", "func lib_func() {}");
+        fixture.add_file("src/lib.cm", "fn lib_func() {}");
         assert!(fixture.file_exists("src/lib.cm"));
 
         // Test root path and URLs

--- a/crates/compiler/codegen/tests/multi_file_integration.rs
+++ b/crates/compiler/codegen/tests/multi_file_integration.rs
@@ -70,18 +70,18 @@ fn test_cross_module_codegen() {
     let main_source = r#"
 use math::add;
 
-func main() -> felt {
+fn main() -> felt {
     let result = add(10, 20);
     return result;
 }
 "#;
 
     let math_source = r#"
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 
-func multiply(a: felt, b: felt) -> felt {
+fn multiply(a: felt, b: felt) -> felt {
     return a * b;
 }
 "#;
@@ -142,11 +142,11 @@ fn test_multi_module_functions_codegen() {
     let db = TestDatabase::default();
 
     let utilities_source = r#"
-func square(x: felt) -> felt {
+fn square(x: felt) -> felt {
     return x * x;
 }
 
-func double(x: felt) -> felt {
+fn double(x: felt) -> felt {
     return x + x;
 }
 "#;
@@ -155,7 +155,7 @@ func double(x: felt) -> felt {
 use utilities::square;
 use utilities::double;
 
-func compute(x: felt) -> felt {
+fn compute(x: felt) -> felt {
     let a = square(x);
     let b = double(x);
     return a + b;
@@ -165,7 +165,7 @@ func compute(x: felt) -> felt {
     let main_source = r#"
 use calculator::compute;
 
-func main() -> felt {
+fn main() -> felt {
     return compute(5);
 }
 "#;
@@ -229,21 +229,21 @@ fn test_unused_function_compilation() {
     let main_source = r#"
 use library::used_function;
 
-func main() -> felt {
+fn main() -> felt {
     return used_function();
 }
 "#;
 
     let library_source = r#"
-func used_function() -> felt {
+fn used_function() -> felt {
     return 42;
 }
 
-func unused_function() -> felt {
+fn unused_function() -> felt {
     return 99;
 }
 
-func another_unused() -> felt {
+fn another_unused() -> felt {
     return 123;
 }
 "#;
@@ -296,7 +296,7 @@ fn test_compilation_with_missing_imports() {
     let main_source = r#"
 use missing_module::missing_function;
 
-func main() -> felt {
+fn main() -> felt {
     return missing_function(42);
 }
 "#;
@@ -338,13 +338,13 @@ fn test_deterministic_compilation() {
     let db = TestDatabase::default();
 
     let module_a_source = r#"
-func func_a() -> felt {
+fn func_a() -> felt {
     return 1;
 }
 "#;
 
     let module_b_source = r#"
-func func_b() -> felt {
+fn func_b() -> felt {
     return 2;
 }
 "#;
@@ -353,7 +353,7 @@ func func_b() -> felt {
 use module_a::func_a;
 use module_b::func_b;
 
-func main() -> felt {
+fn main() -> felt {
     return func_a() + func_b();
 }
 "#;

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_add_two_numbers.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_add_two_numbers.snap
@@ -9,11 +9,12 @@ expression: codegen_output
 Fixture: add_two_numbers.cm
 ============================================================
 Source code:
-func add_two_numbers() -> felt {
+fn add_two_numbers() -> felt {
     let a = 10;
     let b = 32;
     return a + b;
 }
+
 ============================================================
 Generated CASM:
 add_two_numbers:

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_and.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_and.snap
@@ -9,7 +9,7 @@ expression: codegen_output
 Fixture: and.cm
 ============================================================
 Source code:
-func simple_and() -> felt {
+fn simple_and() -> felt {
     let x = 10;
     let y = 20;
     let z = x && y;

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_equality.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_equality.snap
@@ -9,7 +9,7 @@ expression: codegen_output
 Fixture: equality.cm
 ============================================================
 Source code:
-func main() -> felt {
+fn main() -> felt {
     let a = 1;
     let b = 0;
     let c = a == b;

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_left_imm.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_left_imm.snap
@@ -9,7 +9,7 @@ expression: codegen_output
 Fixture: left_imm.cm
 ============================================================
 Source code:
-func with_left_imm() -> felt {
+fn with_left_imm() -> felt {
     let x = 1+1;
     let y = 2*x;
     let z = 20/x;

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_not_equals.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_not_equals.snap
@@ -9,7 +9,7 @@ expression: codegen_output
 Fixture: not_equals.cm
 ============================================================
 Source code:
-func simple_neq() -> felt {
+fn simple_neq() -> felt {
     let x = 10;
     let y = 20;
     let z = x != y;

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_or.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_or.snap
@@ -9,7 +9,7 @@ expression: codegen_output
 Fixture: or.cm
 ============================================================
 Source code:
-func simple_or() -> felt {
+fn simple_or() -> felt {
     let x = 10;
     let y = 20;
     let z = x || y;

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_subtract_numbers.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_subtract_numbers.snap
@@ -9,11 +9,12 @@ expression: codegen_output
 Fixture: subtract_numbers.cm
 ============================================================
 Source code:
-func subtract_numbers() -> felt {
+fn subtract_numbers() -> felt {
     let a = 100;
     let b = 25;
     return a - b;
 }
+
 ============================================================
 Generated CASM:
 subtract_numbers:

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_unary.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__arithmetic_unary.snap
@@ -10,32 +10,32 @@ Fixture: unary.cm
 ============================================================
 Source code:
 // Tests various unary operations.
-func test_neg(a: felt) -> felt {
+fn test_neg(a: felt) -> felt {
     let c = -a;
     return c;
 }
 
-func test_not(a: felt) -> felt {
+fn test_not(a: felt) -> felt {
     let c = !a;
     return c;
 }
 
-func test_neg_literal() -> felt {
+fn test_neg_literal() -> felt {
     let c = -42;
     return c;
 }
 
-func test_not_literal_nonzero() -> felt {
+fn test_not_literal_nonzero() -> felt {
     let c = !5;
     return c;
 }
 
-func test_double_neg(a: felt) -> felt {
+fn test_double_neg(a: felt) -> felt {
     let c = --a;
     return c;
 }
 
-func test_not_not(a: felt) -> felt {
+fn test_not_not(a: felt) -> felt {
     let c = !!a;
     return c;
 }

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_complex_condition.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_complex_condition.snap
@@ -9,7 +9,7 @@ expression: codegen_output
 Fixture: complex_condition.cm
 ============================================================
 Source code:
-func complex_condition() -> felt {
+fn complex_condition() -> felt {
     let x = 10;
     let y = 5;
     let cond = x == 2 && y != 3;

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else.snap
@@ -9,13 +9,14 @@ expression: codegen_output
 Fixture: if_else.cm
 ============================================================
 Source code:
-func test_if_else(x: felt) -> felt {
+fn test_if_else(x: felt) -> felt {
     if (x == 0) {
         return 1;
     } else {
         return 2;
     }
 }
+
 ============================================================
 Generated CASM:
 test_if_else:

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else_with_merge.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_if_else_with_merge.snap
@@ -9,7 +9,7 @@ expression: codegen_output
 Fixture: if_else_with_merge.cm
 ============================================================
 Source code:
-func test_if_else(x: felt) -> felt {
+fn test_if_else(x: felt) -> felt {
     let y = 0;
     if (x == 0) {
         y = 1;
@@ -18,6 +18,7 @@ func test_if_else(x: felt) -> felt {
     }
     return y;
 }
+
 ============================================================
 Generated CASM:
 test_if_else:

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_simple_if.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__control_flow_simple_if.snap
@@ -9,12 +9,13 @@ expression: codegen_output
 Fixture: simple_if.cm
 ============================================================
 Source code:
-func test_if(x: felt) -> felt {
+fn test_if(x: felt) -> felt {
     if (x == 0) {
         return 1;
     }
     return 2;
 }
+
 ============================================================
 Generated CASM:
 test_if:

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__expressions_tuple_destructuring.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__expressions_tuple_destructuring.snap
@@ -11,16 +11,16 @@ Fixture: tuple_destructuring.cm
 Source code:
 // Test tuple destructuring in MIR generation
 
-func test_basic_tuple_destructuring() -> felt {
+fn test_basic_tuple_destructuring() -> felt {
     let (x, y) = (10, 20);
     return x + y;
 }
 
-func get_pair() -> (felt, felt) {
+fn get_pair() -> (felt, felt) {
     return (100, 200);
 }
 
-func test_tuple_destructuring_from_function() -> felt {
+fn test_tuple_destructuring_from_function() -> felt {
     let (a, b) = get_pair();
     return a + b;
 }

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_fib.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_fib.snap
@@ -9,13 +9,13 @@ expression: codegen_output
 Fixture: fib.cm
 ============================================================
 Source code:
-func main() -> felt {
+fn main() -> felt {
     let n = 10;
     let result = fib(n);
     return result;
 }
 
-func fib(n: felt) -> felt {
+fn fib(n: felt) -> felt {
     if (n == 0) {
         return 0;
     }

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_fib_loop.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_fib_loop.snap
@@ -9,7 +9,7 @@ expression: codegen_output
 Fixture: fib_loop.cm
 ============================================================
 Source code:
-func fibonacci_loop(n: felt) -> felt {
+fn fibonacci_loop(n: felt) -> felt {
     let a = 0;
     let b = 1;
     let i = 0;
@@ -22,7 +22,7 @@ func fibonacci_loop(n: felt) -> felt {
     return a;
 }
 
-func main() -> felt {
+fn main() -> felt {
     let n = 10;
     let result = fibonacci_loop(n);
     return result;

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_return_values.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_return_values.snap
@@ -9,7 +9,7 @@ expression: codegen_output
 Fixture: return_values.cm
 ============================================================
 Source code:
-func foo(x: felt) -> (felt, felt){
+fn foo(x: felt) -> (felt, felt){
     return (x, 1);
 }
 

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_simple_call.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__functions_simple_call.snap
@@ -9,13 +9,14 @@ expression: codegen_output
 Fixture: simple_call.cm
 ============================================================
 Source code:
-func helper() -> felt {
+fn helper() -> felt {
     return 42;
 }
 
-func main() -> felt {
+fn main() -> felt {
     return helper();
 }
+
 ============================================================
 Generated CASM:
 helper:

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__optimization_args_in_order.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__optimization_args_in_order.snap
@@ -10,16 +10,17 @@ Fixture: args_in_order.cm
 ============================================================
 Source code:
 // Test case where arguments might already be in order
-func process_four(a: felt, b: felt, c: felt, d: felt) -> felt {
+fn process_four(a: felt, b: felt, c: felt, d: felt) -> felt {
     return a + b + c + d;
 }
 
-func wrapper(x: felt, y: felt, z: felt, w: felt) -> felt {
+fn wrapper(x: felt, y: felt, z: felt, w: felt) -> felt {
     // If x, y, z, w are at [fp - 6], [fp - 5], [fp - 4], [fp - 3]
     // and we haven't allocated any locals yet (L = 0),
     // then they might already be in consecutive positions
     return process_four(x, y, z, w);
 }
+
 ============================================================
 Generated CASM:
 process_four:

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__optimization_in_place_update.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__optimization_in_place_update.snap
@@ -9,7 +9,7 @@ expression: codegen_output
 Fixture: in_place_update.cm
 ============================================================
 Source code:
-func test_in_place_update() -> felt {
+fn test_in_place_update() -> felt {
     let a = 5;
     a = a + 1;
     let b = 10;
@@ -17,7 +17,7 @@ func test_in_place_update() -> felt {
     return b;
 }
 
-func test_loop_optimization() -> felt {
+fn test_loop_optimization() -> felt {
     let i = 0;
     let sum = 0;
     while (i != 5) {
@@ -27,11 +27,12 @@ func test_loop_optimization() -> felt {
     return sum;
 }
 
-func main() -> felt {
+fn main() -> felt {
     let x = test_in_place_update();
     let y = test_loop_optimization();
     return x + y;
 }
+
 ============================================================
 Generated CASM:
 test_in_place_update:

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__optimization_single_arg_optimization.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__optimization_single_arg_optimization.snap
@@ -10,17 +10,18 @@ Fixture: single_arg_optimization.cm
 ============================================================
 Source code:
 // Test the optimization for a single argument case
-func increment(x: felt) -> felt {
+fn increment(x: felt) -> felt {
     return x + 1;
 }
 
-func test_single_arg() -> felt {
+fn test_single_arg() -> felt {
     // n is allocated at [fp + 0], and when we call increment(n),
     // it's already at the top of the stack, so no copy is needed
     let n = 10;
     let result = increment(n);
     return result;
 }
+
 ============================================================
 Generated CASM:
 increment:

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__random_instructions_random_instructions.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__random_instructions_random_instructions.snap
@@ -9,7 +9,7 @@ expression: codegen_output
 Fixture: random_instructions.cm
 ============================================================
 Source code:
-func main(){
+fn main(){
     let x = 3;
     let y = 13;
     let even_number = 16;
@@ -30,11 +30,11 @@ func main(){
     return mut_val + eq2 + a + bar() + b + compound1 + compound2;
 }
 
-func foo() -> (felt, felt) {
+fn foo() -> (felt, felt) {
     return (32, 62);
 }
 
-func bar() -> felt {
+fn bar() -> felt {
     return 123;
 }
 

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__simple_function_simple.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__simple_function_simple.snap
@@ -9,9 +9,10 @@ expression: codegen_output
 Fixture: function_simple.cm
 ============================================================
 Source code:
-func test() -> felt {
+fn test() -> felt {
     return 42;
 }
+
 ============================================================
 Generated CASM:
 test:

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__simple_function_with_params.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__simple_function_with_params.snap
@@ -9,9 +9,10 @@ expression: codegen_output
 Fixture: function_with_params.cm
 ============================================================
 Source code:
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
+
 ============================================================
 Generated CASM:
 add:

--- a/crates/compiler/codegen/tests/snapshots/codegen_tests__simple_function_with_return.snap
+++ b/crates/compiler/codegen/tests/snapshots/codegen_tests__simple_function_with_return.snap
@@ -9,10 +9,11 @@ expression: codegen_output
 Fixture: function_with_return.cm
 ============================================================
 Source code:
-func identity(x: felt) -> felt {
+fn identity(x: felt) -> felt {
     let y = x;
     return y;
 }
+
 ============================================================
 Generated CASM:
 identity:

--- a/crates/compiler/codegen/tests/test_cases/arithmetic/add_two_numbers.cm
+++ b/crates/compiler/codegen/tests/test_cases/arithmetic/add_two_numbers.cm
@@ -1,4 +1,4 @@
-func add_two_numbers() -> felt {
+fn add_two_numbers() -> felt {
     let a = 10;
     let b = 32;
     return a + b;

--- a/crates/compiler/codegen/tests/test_cases/arithmetic/and.cm
+++ b/crates/compiler/codegen/tests/test_cases/arithmetic/and.cm
@@ -1,4 +1,4 @@
-func simple_and() -> felt {
+fn simple_and() -> felt {
     let x = 10;
     let y = 20;
     let z = x && y;

--- a/crates/compiler/codegen/tests/test_cases/arithmetic/equality.cm
+++ b/crates/compiler/codegen/tests/test_cases/arithmetic/equality.cm
@@ -1,4 +1,4 @@
-func main() -> felt {
+fn main() -> felt {
     let a = 1;
     let b = 0;
     let c = a == b;

--- a/crates/compiler/codegen/tests/test_cases/arithmetic/equals.cm
+++ b/crates/compiler/codegen/tests/test_cases/arithmetic/equals.cm
@@ -1,4 +1,4 @@
-func simple_eq() -> felt {
+fn simple_eq() -> felt {
     let x = 10;
     let y = 20;
     let z = x == y;

--- a/crates/compiler/codegen/tests/test_cases/arithmetic/left_imm.cm
+++ b/crates/compiler/codegen/tests/test_cases/arithmetic/left_imm.cm
@@ -1,4 +1,4 @@
-func with_left_imm() -> felt {
+fn with_left_imm() -> felt {
     let x = 1+1;
     let y = 2*x;
     let z = 20/x;

--- a/crates/compiler/codegen/tests/test_cases/arithmetic/not_equals.cm
+++ b/crates/compiler/codegen/tests/test_cases/arithmetic/not_equals.cm
@@ -1,4 +1,4 @@
-func simple_neq() -> felt {
+fn simple_neq() -> felt {
     let x = 10;
     let y = 20;
     let z = x != y;

--- a/crates/compiler/codegen/tests/test_cases/arithmetic/or.cm
+++ b/crates/compiler/codegen/tests/test_cases/arithmetic/or.cm
@@ -1,4 +1,4 @@
-func simple_or() -> felt {
+fn simple_or() -> felt {
     let x = 10;
     let y = 20;
     let z = x || y;

--- a/crates/compiler/codegen/tests/test_cases/arithmetic/subtract_numbers.cm
+++ b/crates/compiler/codegen/tests/test_cases/arithmetic/subtract_numbers.cm
@@ -1,4 +1,4 @@
-func subtract_numbers() -> felt {
+fn subtract_numbers() -> felt {
     let a = 100;
     let b = 25;
     return a - b;

--- a/crates/compiler/codegen/tests/test_cases/arithmetic/unary.cm
+++ b/crates/compiler/codegen/tests/test_cases/arithmetic/unary.cm
@@ -1,30 +1,30 @@
 // Tests various unary operations.
-func test_neg(a: felt) -> felt {
+fn test_neg(a: felt) -> felt {
     let c = -a;
     return c;
 }
 
-func test_not(a: felt) -> felt {
+fn test_not(a: felt) -> felt {
     let c = !a;
     return c;
 }
 
-func test_neg_literal() -> felt {
+fn test_neg_literal() -> felt {
     let c = -42;
     return c;
 }
 
-func test_not_literal_nonzero() -> felt {
+fn test_not_literal_nonzero() -> felt {
     let c = !5;
     return c;
 }
 
-func test_double_neg(a: felt) -> felt {
+fn test_double_neg(a: felt) -> felt {
     let c = --a;
     return c;
 }
 
-func test_not_not(a: felt) -> felt {
+fn test_not_not(a: felt) -> felt {
     let c = !!a;
     return c;
 }

--- a/crates/compiler/codegen/tests/test_cases/control_flow/complex_condition.cm
+++ b/crates/compiler/codegen/tests/test_cases/control_flow/complex_condition.cm
@@ -1,4 +1,4 @@
-func complex_condition() -> felt {
+fn complex_condition() -> felt {
     let x = 10;
     let y = 5;
     let cond = x == 2 && y != 3;

--- a/crates/compiler/codegen/tests/test_cases/control_flow/if_else.cm
+++ b/crates/compiler/codegen/tests/test_cases/control_flow/if_else.cm
@@ -1,4 +1,4 @@
-func test_if_else(x: felt) -> felt {
+fn test_if_else(x: felt) -> felt {
     if (x == 0) {
         return 1;
     } else {

--- a/crates/compiler/codegen/tests/test_cases/control_flow/if_else_with_merge.cm
+++ b/crates/compiler/codegen/tests/test_cases/control_flow/if_else_with_merge.cm
@@ -1,4 +1,4 @@
-func test_if_else(x: felt) -> felt {
+fn test_if_else(x: felt) -> felt {
     let y = 0;
     if (x == 0) {
         y = 1;

--- a/crates/compiler/codegen/tests/test_cases/control_flow/simple_if.cm
+++ b/crates/compiler/codegen/tests/test_cases/control_flow/simple_if.cm
@@ -1,4 +1,4 @@
-func test_if(x: felt) -> felt {
+fn test_if(x: felt) -> felt {
     if (x == 0) {
         return 1;
     }

--- a/crates/compiler/codegen/tests/test_cases/expressions/tuple_destructuring.cm
+++ b/crates/compiler/codegen/tests/test_cases/expressions/tuple_destructuring.cm
@@ -1,15 +1,15 @@
 // Test tuple destructuring in MIR generation
 
-func test_basic_tuple_destructuring() -> felt {
+fn test_basic_tuple_destructuring() -> felt {
     let (x, y) = (10, 20);
     return x + y;
 }
 
-func get_pair() -> (felt, felt) {
+fn get_pair() -> (felt, felt) {
     return (100, 200);
 }
 
-func test_tuple_destructuring_from_function() -> felt {
+fn test_tuple_destructuring_from_function() -> felt {
     let (a, b) = get_pair();
     return a + b;
 }

--- a/crates/compiler/codegen/tests/test_cases/functions/fib.cm
+++ b/crates/compiler/codegen/tests/test_cases/functions/fib.cm
@@ -1,10 +1,10 @@
-func main() -> felt {
+fn main() -> felt {
     let n = 10;
     let result = fib(n);
     return result;
 }
 
-func fib(n: felt) -> felt {
+fn fib(n: felt) -> felt {
     if (n == 0) {
         return 0;
     }

--- a/crates/compiler/codegen/tests/test_cases/functions/fib_loop.cm
+++ b/crates/compiler/codegen/tests/test_cases/functions/fib_loop.cm
@@ -1,4 +1,4 @@
-func fibonacci_loop(n: felt) -> felt {
+fn fibonacci_loop(n: felt) -> felt {
     let a = 0;
     let b = 1;
     let i = 0;
@@ -11,7 +11,7 @@ func fibonacci_loop(n: felt) -> felt {
     return a;
 }
 
-func main() -> felt {
+fn main() -> felt {
     let n = 10;
     let result = fibonacci_loop(n);
     return result;

--- a/crates/compiler/codegen/tests/test_cases/functions/return_values.cm
+++ b/crates/compiler/codegen/tests/test_cases/functions/return_values.cm
@@ -1,3 +1,3 @@
-func foo(x: felt) -> (felt, felt){
+fn foo(x: felt) -> (felt, felt){
     return (x, 1);
 }

--- a/crates/compiler/codegen/tests/test_cases/functions/simple_call.cm
+++ b/crates/compiler/codegen/tests/test_cases/functions/simple_call.cm
@@ -1,7 +1,7 @@
-func helper() -> felt {
+fn helper() -> felt {
     return 42;
 }
 
-func main() -> felt {
+fn main() -> felt {
     return helper();
 }

--- a/crates/compiler/codegen/tests/test_cases/optimization/args_in_order.cm
+++ b/crates/compiler/codegen/tests/test_cases/optimization/args_in_order.cm
@@ -1,9 +1,9 @@
 // Test case where arguments might already be in order
-func process_four(a: felt, b: felt, c: felt, d: felt) -> felt {
+fn process_four(a: felt, b: felt, c: felt, d: felt) -> felt {
     return a + b + c + d;
 }
 
-func wrapper(x: felt, y: felt, z: felt, w: felt) -> felt {
+fn wrapper(x: felt, y: felt, z: felt, w: felt) -> felt {
     // If x, y, z, w are at [fp - 6], [fp - 5], [fp - 4], [fp - 3]
     // and we haven't allocated any locals yet (L = 0),
     // then they might already be in consecutive positions

--- a/crates/compiler/codegen/tests/test_cases/optimization/in_place_update.cm
+++ b/crates/compiler/codegen/tests/test_cases/optimization/in_place_update.cm
@@ -1,4 +1,4 @@
-func test_in_place_update() -> felt {
+fn test_in_place_update() -> felt {
     let a = 5;
     a = a + 1;
     let b = 10;
@@ -6,7 +6,7 @@ func test_in_place_update() -> felt {
     return b;
 }
 
-func test_loop_optimization() -> felt {
+fn test_loop_optimization() -> felt {
     let i = 0;
     let sum = 0;
     while (i != 5) {
@@ -16,7 +16,7 @@ func test_loop_optimization() -> felt {
     return sum;
 }
 
-func main() -> felt {
+fn main() -> felt {
     let x = test_in_place_update();
     let y = test_loop_optimization();
     return x + y;

--- a/crates/compiler/codegen/tests/test_cases/optimization/single_arg_optimization.cm
+++ b/crates/compiler/codegen/tests/test_cases/optimization/single_arg_optimization.cm
@@ -1,9 +1,9 @@
 // Test the optimization for a single argument case
-func increment(x: felt) -> felt {
+fn increment(x: felt) -> felt {
     return x + 1;
 }
 
-func test_single_arg() -> felt {
+fn test_single_arg() -> felt {
     // n is allocated at [fp + 0], and when we call increment(n),
     // it's already at the top of the stack, so no copy is needed
     let n = 10;

--- a/crates/compiler/codegen/tests/test_cases/random_instructions/random_instructions.cm
+++ b/crates/compiler/codegen/tests/test_cases/random_instructions/random_instructions.cm
@@ -1,4 +1,4 @@
-func main(){
+fn main(){
     let x = 3;
     let y = 13;
     let even_number = 16;
@@ -19,10 +19,10 @@ func main(){
     return mut_val + eq2 + a + bar() + b + compound1 + compound2;
 }
 
-func foo() -> (felt, felt) {
+fn foo() -> (felt, felt) {
     return (32, 62);
 }
 
-func bar() -> felt {
+fn bar() -> felt {
     return 123;
 }

--- a/crates/compiler/codegen/tests/test_cases/simple/function_simple.cm
+++ b/crates/compiler/codegen/tests/test_cases/simple/function_simple.cm
@@ -1,3 +1,3 @@
-func test() -> felt {
+fn test() -> felt {
     return 42;
 }

--- a/crates/compiler/codegen/tests/test_cases/simple/function_with_params.cm
+++ b/crates/compiler/codegen/tests/test_cases/simple/function_with_params.cm
@@ -1,3 +1,3 @@
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }

--- a/crates/compiler/codegen/tests/test_cases/simple/function_with_return.cm
+++ b/crates/compiler/codegen/tests/test_cases/simple/function_with_return.cm
@@ -1,4 +1,4 @@
-func identity(x: felt) -> felt {
+fn identity(x: felt) -> felt {
     let y = x;
     return y;
 }

--- a/crates/compiler/docs/salsa_api_guide.md
+++ b/crates/compiler/docs/salsa_api_guide.md
@@ -429,7 +429,7 @@ Minimize cross-file dependencies:
 
 ```rust
 // BAD: Direct AST dependency across files
-pub fn analyze_function(db: &dyn Db, func: &ast::FunctionDef) -> Analysis {
+pub fn analyze_function(db: &dyn Db, fn: &ast::FunctionDef) -> Analysis {
     // This creates cross-file AST dependencies
 }
 

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__aggregates_array_access.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__aggregates_array_access.snap
@@ -11,7 +11,7 @@ Fixture: array_access.cm
 Source code:
 // Tests l-value and r-value access for pointer types, mimicking array access.
 // NOTE: `felt*` is a placeholder for a proper array/pointer type.
-func test_array_access(index: felt) -> felt {
+fn test_array_access(index: felt) -> felt {
     let arr: felt* = 42;  // Placeholder for getting a base address.
     arr[index] = 10;      // L-value: getelementptr for assignment.
     return arr[0];        // R-value: getelementptr + load for reading.

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__aggregates_struct_access_mut.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__aggregates_struct_access_mut.snap
@@ -18,7 +18,7 @@ struct Point {
     y: felt,
 }
 
-func test() -> felt {
+fn test() -> felt {
     let p = Point { x: 10, y: 20 };
     p.y = 30; // Should generate getelementptr followed by a store.
     return p.y;

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__aggregates_struct_access_read.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__aggregates_struct_access_read.snap
@@ -18,7 +18,7 @@ struct Point {
     y: felt,
 }
 
-func test() -> felt {
+fn test() -> felt {
     let p = Point { x: 10, y: 20 };
     return p.x; // Should generate getelementptr followed by a load.
 }

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__aggregates_struct_literal.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__aggregates_struct_literal.snap
@@ -18,7 +18,7 @@ struct Point {
     y: felt,
 }
 
-func test() -> felt {
+fn test() -> felt {
     let p = Point { x: 10, y: 20 };
     return 0;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__aggregates_tuple_literal_and_access.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__aggregates_tuple_literal_and_access.snap
@@ -10,7 +10,7 @@ Fixture: tuple_literal_and_access.cm
 ============================================================
 Source code:
 // Tests tuple creation, indexed write, and indexed read.
-func test_tuple() -> felt {
+fn test_tuple() -> felt {
     let t = (100, 200, 300);
     t[1] = 250;
     return t[1];

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_if_both_return.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_if_both_return.snap
@@ -14,7 +14,7 @@ Source code:
 
 // Tests an `if-else` where both branches terminate with a `return`.
 // No merge block should be generated.
-func test(x: felt) -> felt {
+fn test(x: felt) -> felt {
     if (x == 0) {
         return 1;
     } else {

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_if_else.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_if_else.snap
@@ -12,7 +12,7 @@ Source code:
 //!ASSERT BLOCK_COUNT(test): 4 // entry, then, else, merge
 
 // Tests a standard `if-else` statement where both branches continue execution.
-func test(x: felt) -> felt {
+fn test(x: felt) -> felt {
     let a = 0;
     if (x == 10) {
         a = 1;

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_if_no_else.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_if_no_else.snap
@@ -13,7 +13,7 @@ Source code:
 
 // Tests a simple `if` statement without an `else` branch.
 // A merge block must be created for the fall-through path.
-func test(x: felt) -> felt {
+fn test(x: felt) -> felt {
     let a = 10;
     if (x == 5) {
         a = 20;

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_if_partial_return.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_if_partial_return.snap
@@ -14,7 +14,7 @@ Source code:
 
 // Tests an `if-else` where one branch returns and the other continues.
 // This is a critical test for correct merge block generation.
-func test(x: felt) -> felt {
+fn test(x: felt) -> felt {
     if (x == 5) {
         return 10;
     } else {

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_infinite_loop.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_infinite_loop.snap
@@ -9,7 +9,7 @@ expression: mir_output
 Fixture: infinite_loop.cm
 ============================================================
 Source code:
-func test_infinite_loop() -> felt {
+fn test_infinite_loop() -> felt {
     let counter = 0;
 
     loop {

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_loop_with_breaks.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_loop_with_breaks.snap
@@ -9,7 +9,7 @@ expression: mir_output
 Fixture: loop_with_breaks.cm
 ============================================================
 Source code:
-func test_loop_with_breaks() -> felt {
+fn test_loop_with_breaks() -> felt {
     let count = 0;
     let result = 0;
 

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_nested_if.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_nested_if.snap
@@ -12,7 +12,7 @@ Source code:
 //!ASSERT BLOCK_COUNT(test): 5 // entry, outer_then, inner_then, inner_merge, outer_merge
 
 // Tests nested if statements to ensure CFG is built correctly.
-func test(a: felt, b: felt) -> felt {
+fn test(a: felt, b: felt) -> felt {
     let result = 0;
     if (a == 1) {
         if (b == 2) {

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_nested_loops.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_nested_loops.snap
@@ -9,7 +9,7 @@ expression: mir_output
 Fixture: nested_loops.cm
 ============================================================
 Source code:
-func test_nested_loops() -> felt {
+fn test_nested_loops() -> felt {
     let result = 0;
     let i = 0;
 

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_simple_while.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_simple_while.snap
@@ -9,7 +9,7 @@ expression: mir_output
 Fixture: simple_while.cm
 ============================================================
 Source code:
-func test_simple_while() -> felt {
+fn test_simple_while() -> felt {
     let i = 0;
     let sum = 0;
 

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_unreachable_after_return.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__control_flow_unreachable_after_return.snap
@@ -13,7 +13,7 @@ Source code:
 //!ASSERT NOT_CONTAINS: Unreachable code
 
 // Tests that code generation stops after a `return` statement.
-func test() -> felt {
+fn test() -> felt {
     return 42;
 
     // This code should not appear in the MIR.

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_binary_ops.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_binary_ops.snap
@@ -14,27 +14,27 @@ Source code:
 //!ASSERT CONTAINS: Eq
 
 // Tests various binary operations.
-func test_add(a: felt, b: felt) -> felt {
+fn test_add(a: felt, b: felt) -> felt {
     let c = a + b;
     return c;
 }
 
-func test_mul(a: felt, b: felt) -> felt {
+fn test_mul(a: felt, b: felt) -> felt {
     let c = a * b;
     return c;
 }
 
-func test_sub(a: felt, b: felt) -> felt {
+fn test_sub(a: felt, b: felt) -> felt {
     let c = a - b;
     return c;
 }
 
-func test_div(a: felt, b: felt) -> felt {
+fn test_div(a: felt, b: felt) -> felt {
     let c = a / b;
     return c;
 }
 
-func test_eq(a: felt, b: felt) -> felt {
+fn test_eq(a: felt, b: felt) -> felt {
     let c = a == b;
     return c;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_comparison_ops.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_comparison_ops.snap
@@ -15,28 +15,28 @@ Source code:
 //!ASSERT CONTAINS: GreaterEqual
 
 // Tests new comparison operations.
-func test_less(a: felt, b: felt) -> felt {
+fn test_less(a: felt, b: felt) -> felt {
     let c = a < b;
     return c;
 }
 
-func test_greater(a: felt, b: felt) -> felt {
+fn test_greater(a: felt, b: felt) -> felt {
     let c = a > b;
     return c;
 }
 
-func test_less_equal(a: felt, b: felt) -> felt {
+fn test_less_equal(a: felt, b: felt) -> felt {
     let c = a <= b;
     return c;
 }
 
-func test_greater_equal(a: felt, b: felt) -> felt {
+fn test_greater_equal(a: felt, b: felt) -> felt {
     let c = a >= b;
     return c;
 }
 
 // Test comparison operators in conditional context
-func test_comparison_in_if(x: felt, y: felt) -> felt {
+fn test_comparison_in_if(x: felt, y: felt) -> felt {
     if (x < y) {
         return 1;
     } else if (x > y) {
@@ -45,6 +45,7 @@ func test_comparison_in_if(x: felt, y: felt) -> felt {
         return 0;
     }
 }
+
 ============================================================
 Generated MIR:
 module {

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_compound_expr.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_compound_expr.snap
@@ -14,7 +14,7 @@ Source code:
 //!ASSERT CONTAINS: Mul
 
 // Tests a more complex expression involving parentheses and multiple variables.
-func test_complex(x: felt, y: felt) -> felt {
+fn test_complex(x: felt, y: felt) -> felt {
     let temp = x + y;
     let result = temp * (x - y);
     return result;

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_operator_precedence.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_operator_precedence.snap
@@ -14,7 +14,7 @@ Source code:
 
 // Tests that operator precedence (multiplication before addition) is respected.
 // The snapshot will confirm that the `Mul` instruction precedes the `Add` instruction.
-func test_precedence(a: felt, b: felt, c: felt) -> felt {
+fn test_precedence(a: felt, b: felt, c: felt) -> felt {
     return a + b * c;
 }
 

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_tuple_destructuring.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_tuple_destructuring.snap
@@ -11,16 +11,16 @@ Fixture: tuple_destructuring.cm
 Source code:
 // Test tuple destructuring in MIR generation
 
-func test_basic_tuple_destructuring() -> felt {
+fn test_basic_tuple_destructuring() -> felt {
     let (x, y) = (10, 20);
     return x + y;
 }
 
-func get_pair() -> (felt, felt) {
+fn get_pair() -> (felt, felt) {
     return (100, 200);
 }
 
-func test_tuple_destructuring_from_function() -> felt {
+fn test_tuple_destructuring_from_function() -> felt {
     let (a, b) = get_pair();
     return a + b;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_unary_ops.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_unary_ops.snap
@@ -13,32 +13,32 @@ Source code:
 //!ASSERT CONTAINS: Not
 
 // Tests various unary operations.
-func test_neg(a: felt) -> felt {
+fn test_neg(a: felt) -> felt {
     let c = -a;
     return c;
 }
 
-func test_not(a: felt) -> felt {
+fn test_not(a: felt) -> felt {
     let c = !a;
     return c;
 }
 
-func test_neg_literal() -> felt {
+fn test_neg_literal() -> felt {
     let c = -42;
     return c;
 }
 
-func test_not_literal_nonzero() -> felt {
+fn test_not_literal_nonzero() -> felt {
     let c = !5;
     return c;
 }
 
-func test_double_neg(a: felt) -> felt {
+fn test_double_neg(a: felt) -> felt {
     let c = --a;
     return c;
 }
 
-func test_not_not(a: felt) -> felt {
+fn test_not_not(a: felt) -> felt {
     let c = !!a;
     return c;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_call_as_statement.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_call_as_statement.snap
@@ -13,9 +13,9 @@ Source code:
 
 // Tests a function call used as a statement, where the return value is ignored.
 // This generates a call instruction with a destination that is not used.
-func helper() -> felt { return 123; }
+fn helper() -> felt { return 123; }
 
-func main() -> felt {
+fn main() -> felt {
     helper(); // Call in statement context
     return 0;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_call_with_return.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_call_with_return.snap
@@ -13,9 +13,9 @@ Source code:
 
 // Tests a function call where the return value is assigned to a variable.
 // This should generate a `Call` instruction.
-func helper() -> felt { return 123; }
+fn helper() -> felt { return 123; }
 
-func main() -> felt {
+fn main() -> felt {
     let x = helper();
     return x;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_fib.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_fib.snap
@@ -9,13 +9,13 @@ expression: mir_output
 Fixture: fib.cm
 ============================================================
 Source code:
-func main() -> felt {
+fn main() -> felt {
     let n = 10;
     let result = fib(n);
     return result;
 }
 
-func fib(n: felt) -> felt {
+fn fib(n: felt) -> felt {
     if (n == 0) {
         return 0;
     }

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_fib_loop.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_fib_loop.snap
@@ -9,7 +9,7 @@ expression: mir_output
 Fixture: fib_loop.cm
 ============================================================
 Source code:
-func fibonacci_loop(n: felt) -> felt {
+fn fibonacci_loop(n: felt) -> felt {
     let a = 0;
     let b = 1;
     let i = 0;
@@ -22,7 +22,7 @@ func fibonacci_loop(n: felt) -> felt {
     return a;
 }
 
-func main() -> felt {
+fn main() -> felt {
     let n = 10;
     let result = fibonacci_loop(n);
     return result;

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_multiple_functions.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_multiple_functions.snap
@@ -12,9 +12,9 @@ Source code:
 //!ASSERT FUNCTION_COUNT: 3
 
 // Tests that a module can contain multiple function definitions.
-func first() -> felt { return 1; }
-func second() -> felt { return 2; }
-func third() -> felt { return 3; }
+fn first() -> felt { return 1; }
+fn second() -> felt { return 2; }
+fn third() -> felt { return 3; }
 
 ============================================================
 Generated MIR:

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_return_values.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__functions_return_values.snap
@@ -9,7 +9,7 @@ expression: mir_output
 Fixture: return_values.cm
 ============================================================
 Source code:
-func foo(x: felt) -> (felt, felt){
+fn foo(x: felt) -> (felt, felt){
     return (x, 1);
 }
 

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__optimizations_assign_to_binop.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__optimizations_assign_to_binop.snap
@@ -9,7 +9,7 @@ expression: mir_output
 Fixture: assign_to_binop.cm
 ============================================================
 Source code:
-func assign_to_binop() -> felt {
+fn assign_to_binop() -> felt {
     let a = 10;
     let b = 20;
     let c = 0;

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__optimizations_unused_variable_elimination.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__optimizations_unused_variable_elimination.snap
@@ -14,12 +14,13 @@ Source code:
 //!ASSERT NOT_CONTAINS: store %5
 
 // Test that unused variables don't generate allocations
-func test_unused(a: felt, b: felt) -> felt {
+fn test_unused(a: felt, b: felt) -> felt {
     let c = a + b;  // Used - should allocate
     let d = a * b;  // Unused - should NOT allocate
     let e = a == b; // Unused - should NOT allocate
     return c;
 }
+
 ============================================================
 Generated MIR:
 module {

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__simple_function_simple.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__simple_function_simple.snap
@@ -14,7 +14,7 @@ Source code:
 //!ASSERT CONTAINS: return 42
 
 // A very simple function that returns a literal.
-func test() -> felt {
+fn test() -> felt {
     return 42;
 }
 

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__simple_function_with_let.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__simple_function_with_let.snap
@@ -16,7 +16,7 @@ Source code:
 //!ASSERT CONTAINS: return 99
 
 // Tests that a `let` statement correctly generates stack allocation and storage.
-func test() -> felt {
+fn test() -> felt {
     let x = 10;
     return 99;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__simple_function_with_params.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__simple_function_with_params.snap
@@ -14,7 +14,7 @@ Source code:
 //!ASSERT CONTAINS: Add
 
 // Tests that function parameters are correctly allocated on the stack, loaded, and used.
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__variables_assignment.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__variables_assignment.snap
@@ -13,7 +13,7 @@ Source code:
 //!ASSERT CONTAINS: store %0, 20
 
 // Tests a simple variable reassignment.
-func test() -> felt {
+fn test() -> felt {
     let x = 10;
     x = 20;
     return x;

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__variables_reassignment_from_var.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__variables_reassignment_from_var.snap
@@ -10,7 +10,7 @@ Fixture: reassignment_from_var.cm
 ============================================================
 Source code:
 // Tests reassigning one variable with the value of another.
-func test_reassignment() -> felt {
+fn test_reassignment() -> felt {
     let x = 10;
     let y = 20;
     x = y; // Should generate a load from y's address and a store to x's address.

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/aggregates/array_access.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/aggregates/array_access.cm
@@ -1,6 +1,6 @@
 // Tests l-value and r-value access for pointer types, mimicking array access.
 // NOTE: `felt*` is a placeholder for a proper array/pointer type.
-func test_array_access(index: felt) -> felt {
+fn test_array_access(index: felt) -> felt {
     let arr: felt* = 42;  // Placeholder for getting a base address.
     arr[index] = 10;      // L-value: getelementptr for assignment.
     return arr[0];        // R-value: getelementptr + load for reading.

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/aggregates/struct_access_mut.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/aggregates/struct_access_mut.cm
@@ -7,7 +7,7 @@ struct Point {
     y: felt,
 }
 
-func test() -> felt {
+fn test() -> felt {
     let p = Point { x: 10, y: 20 };
     p.y = 30; // Should generate getelementptr followed by a store.
     return p.y;

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/aggregates/struct_access_read.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/aggregates/struct_access_read.cm
@@ -7,7 +7,7 @@ struct Point {
     y: felt,
 }
 
-func test() -> felt {
+fn test() -> felt {
     let p = Point { x: 10, y: 20 };
     return p.x; // Should generate getelementptr followed by a load.
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/aggregates/struct_literal.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/aggregates/struct_literal.cm
@@ -7,7 +7,7 @@ struct Point {
     y: felt,
 }
 
-func test() -> felt {
+fn test() -> felt {
     let p = Point { x: 10, y: 20 };
     return 0;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/aggregates/tuple_literal_and_access.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/aggregates/tuple_literal_and_access.cm
@@ -1,5 +1,5 @@
 // Tests tuple creation, indexed write, and indexed read.
-func test_tuple() -> felt {
+fn test_tuple() -> felt {
     let t = (100, 200, 300);
     t[1] = 250;
     return t[1];

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/if_both_return.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/if_both_return.cm
@@ -3,7 +3,7 @@
 
 // Tests an `if-else` where both branches terminate with a `return`.
 // No merge block should be generated.
-func test(x: felt) -> felt {
+fn test(x: felt) -> felt {
     if (x == 0) {
         return 1;
     } else {

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/if_else.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/if_else.cm
@@ -1,7 +1,7 @@
 //!ASSERT BLOCK_COUNT(test): 4 // entry, then, else, merge
 
 // Tests a standard `if-else` statement where both branches continue execution.
-func test(x: felt) -> felt {
+fn test(x: felt) -> felt {
     let a = 0;
     if (x == 10) {
         a = 1;

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/if_no_else.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/if_no_else.cm
@@ -2,7 +2,7 @@
 
 // Tests a simple `if` statement without an `else` branch.
 // A merge block must be created for the fall-through path.
-func test(x: felt) -> felt {
+fn test(x: felt) -> felt {
     let a = 10;
     if (x == 5) {
         a = 20;

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/if_partial_return.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/if_partial_return.cm
@@ -3,7 +3,7 @@
 
 // Tests an `if-else` where one branch returns and the other continues.
 // This is a critical test for correct merge block generation.
-func test(x: felt) -> felt {
+fn test(x: felt) -> felt {
     if (x == 5) {
         return 10;
     } else {

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/infinite_loop.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/infinite_loop.cm
@@ -1,4 +1,4 @@
-func test_infinite_loop() -> felt {
+fn test_infinite_loop() -> felt {
     let counter = 0;
 
     loop {

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/loop_with_breaks.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/loop_with_breaks.cm
@@ -1,4 +1,4 @@
-func test_loop_with_breaks() -> felt {
+fn test_loop_with_breaks() -> felt {
     let count = 0;
     let result = 0;
 

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/nested_if.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/nested_if.cm
@@ -1,7 +1,7 @@
 //!ASSERT BLOCK_COUNT(test): 5 // entry, outer_then, inner_then, inner_merge, outer_merge
 
 // Tests nested if statements to ensure CFG is built correctly.
-func test(a: felt, b: felt) -> felt {
+fn test(a: felt, b: felt) -> felt {
     let result = 0;
     if (a == 1) {
         if (b == 2) {

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/nested_loops.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/nested_loops.cm
@@ -1,4 +1,4 @@
-func test_nested_loops() -> felt {
+fn test_nested_loops() -> felt {
     let result = 0;
     let i = 0;
 

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/simple_while.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/simple_while.cm
@@ -1,4 +1,4 @@
-func test_simple_while() -> felt {
+fn test_simple_while() -> felt {
     let i = 0;
     let sum = 0;
 

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/unreachable_after_return.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/control_flow/unreachable_after_return.cm
@@ -2,7 +2,7 @@
 //!ASSERT NOT_CONTAINS: Unreachable code
 
 // Tests that code generation stops after a `return` statement.
-func test() -> felt {
+fn test() -> felt {
     return 42;
 
     // This code should not appear in the MIR.

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/binary_ops.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/binary_ops.cm
@@ -3,27 +3,27 @@
 //!ASSERT CONTAINS: Eq
 
 // Tests various binary operations.
-func test_add(a: felt, b: felt) -> felt {
+fn test_add(a: felt, b: felt) -> felt {
     let c = a + b;
     return c;
 }
 
-func test_mul(a: felt, b: felt) -> felt {
+fn test_mul(a: felt, b: felt) -> felt {
     let c = a * b;
     return c;
 }
 
-func test_sub(a: felt, b: felt) -> felt {
+fn test_sub(a: felt, b: felt) -> felt {
     let c = a - b;
     return c;
 }
 
-func test_div(a: felt, b: felt) -> felt {
+fn test_div(a: felt, b: felt) -> felt {
     let c = a / b;
     return c;
 }
 
-func test_eq(a: felt, b: felt) -> felt {
+fn test_eq(a: felt, b: felt) -> felt {
     let c = a == b;
     return c;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/comparison_ops.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/comparison_ops.cm
@@ -4,28 +4,28 @@
 //!ASSERT CONTAINS: GreaterEqual
 
 // Tests new comparison operations.
-func test_less(a: felt, b: felt) -> felt {
+fn test_less(a: felt, b: felt) -> felt {
     let c = a < b;
     return c;
 }
 
-func test_greater(a: felt, b: felt) -> felt {
+fn test_greater(a: felt, b: felt) -> felt {
     let c = a > b;
     return c;
 }
 
-func test_less_equal(a: felt, b: felt) -> felt {
+fn test_less_equal(a: felt, b: felt) -> felt {
     let c = a <= b;
     return c;
 }
 
-func test_greater_equal(a: felt, b: felt) -> felt {
+fn test_greater_equal(a: felt, b: felt) -> felt {
     let c = a >= b;
     return c;
 }
 
 // Test comparison operators in conditional context
-func test_comparison_in_if(x: felt, y: felt) -> felt {
+fn test_comparison_in_if(x: felt, y: felt) -> felt {
     if (x < y) {
         return 1;
     } else if (x > y) {

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/compound_expr.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/compound_expr.cm
@@ -3,7 +3,7 @@
 //!ASSERT CONTAINS: Mul
 
 // Tests a more complex expression involving parentheses and multiple variables.
-func test_complex(x: felt, y: felt) -> felt {
+fn test_complex(x: felt, y: felt) -> felt {
     let temp = x + y;
     let result = temp * (x - y);
     return result;

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/operator_precedence.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/operator_precedence.cm
@@ -3,6 +3,6 @@
 
 // Tests that operator precedence (multiplication before addition) is respected.
 // The snapshot will confirm that the `Mul` instruction precedes the `Add` instruction.
-func test_precedence(a: felt, b: felt, c: felt) -> felt {
+fn test_precedence(a: felt, b: felt, c: felt) -> felt {
     return a + b * c;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/tuple_destructuring.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/tuple_destructuring.cm
@@ -1,15 +1,15 @@
 // Test tuple destructuring in MIR generation
 
-func test_basic_tuple_destructuring() -> felt {
+fn test_basic_tuple_destructuring() -> felt {
     let (x, y) = (10, 20);
     return x + y;
 }
 
-func get_pair() -> (felt, felt) {
+fn get_pair() -> (felt, felt) {
     return (100, 200);
 }
 
-func test_tuple_destructuring_from_function() -> felt {
+fn test_tuple_destructuring_from_function() -> felt {
     let (a, b) = get_pair();
     return a + b;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/unary_ops.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/unary_ops.cm
@@ -2,32 +2,32 @@
 //!ASSERT CONTAINS: Not
 
 // Tests various unary operations.
-func test_neg(a: felt) -> felt {
+fn test_neg(a: felt) -> felt {
     let c = -a;
     return c;
 }
 
-func test_not(a: felt) -> felt {
+fn test_not(a: felt) -> felt {
     let c = !a;
     return c;
 }
 
-func test_neg_literal() -> felt {
+fn test_neg_literal() -> felt {
     let c = -42;
     return c;
 }
 
-func test_not_literal_nonzero() -> felt {
+fn test_not_literal_nonzero() -> felt {
     let c = !5;
     return c;
 }
 
-func test_double_neg(a: felt) -> felt {
+fn test_double_neg(a: felt) -> felt {
     let c = --a;
     return c;
 }
 
-func test_not_not(a: felt) -> felt {
+fn test_not_not(a: felt) -> felt {
     let c = !!a;
     return c;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/functions/call_as_statement.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/functions/call_as_statement.cm
@@ -2,9 +2,9 @@
 
 // Tests a function call used as a statement, where the return value is ignored.
 // This generates a call instruction with a destination that is not used.
-func helper() -> felt { return 123; }
+fn helper() -> felt { return 123; }
 
-func main() -> felt {
+fn main() -> felt {
     helper(); // Call in statement context
     return 0;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/functions/call_with_return.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/functions/call_with_return.cm
@@ -2,9 +2,9 @@
 
 // Tests a function call where the return value is assigned to a variable.
 // This should generate a `Call` instruction.
-func helper() -> felt { return 123; }
+fn helper() -> felt { return 123; }
 
-func main() -> felt {
+fn main() -> felt {
     let x = helper();
     return x;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/functions/fib.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/functions/fib.cm
@@ -1,10 +1,10 @@
-func main() -> felt {
+fn main() -> felt {
     let n = 10;
     let result = fib(n);
     return result;
 }
 
-func fib(n: felt) -> felt {
+fn fib(n: felt) -> felt {
     if (n == 0) {
         return 0;
     }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/functions/fib_loop.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/functions/fib_loop.cm
@@ -1,4 +1,4 @@
-func fibonacci_loop(n: felt) -> felt {
+fn fibonacci_loop(n: felt) -> felt {
     let a = 0;
     let b = 1;
     let i = 0;
@@ -11,7 +11,7 @@ func fibonacci_loop(n: felt) -> felt {
     return a;
 }
 
-func main() -> felt {
+fn main() -> felt {
     let n = 10;
     let result = fibonacci_loop(n);
     return result;

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/functions/multiple_functions.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/functions/multiple_functions.cm
@@ -1,6 +1,6 @@
 //!ASSERT FUNCTION_COUNT: 3
 
 // Tests that a module can contain multiple function definitions.
-func first() -> felt { return 1; }
-func second() -> felt { return 2; }
-func third() -> felt { return 3; }
+fn first() -> felt { return 1; }
+fn second() -> felt { return 2; }
+fn third() -> felt { return 3; }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/functions/return_values.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/functions/return_values.cm
@@ -1,3 +1,3 @@
-func foo(x: felt) -> (felt, felt){
+fn foo(x: felt) -> (felt, felt){
     return (x, 1);
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/optimizations/assign_to_binop.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/optimizations/assign_to_binop.cm
@@ -1,4 +1,4 @@
-func assign_to_binop() -> felt {
+fn assign_to_binop() -> felt {
     let a = 10;
     let b = 20;
     let c = 0;

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/optimizations/unused_variable_elimination.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/optimizations/unused_variable_elimination.cm
@@ -3,7 +3,7 @@
 //!ASSERT NOT_CONTAINS: store %5
 
 // Test that unused variables don't generate allocations
-func test_unused(a: felt, b: felt) -> felt {
+fn test_unused(a: felt, b: felt) -> felt {
     let c = a + b;  // Used - should allocate
     let d = a * b;  // Unused - should NOT allocate
     let e = a == b; // Unused - should NOT allocate

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/simple/function_simple.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/simple/function_simple.cm
@@ -3,6 +3,6 @@
 //!ASSERT CONTAINS: return 42
 
 // A very simple function that returns a literal.
-func test() -> felt {
+fn test() -> felt {
     return 42;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/simple/function_with_let.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/simple/function_with_let.cm
@@ -5,7 +5,7 @@
 //!ASSERT CONTAINS: return 99
 
 // Tests that a `let` statement correctly generates stack allocation and storage.
-func test() -> felt {
+fn test() -> felt {
     let x = 10;
     return 99;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/simple/function_with_params.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/simple/function_with_params.cm
@@ -3,6 +3,6 @@
 //!ASSERT CONTAINS: Add
 
 // Tests that function parameters are correctly allocated on the stack, loaded, and used.
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/variables/assignment.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/variables/assignment.cm
@@ -2,7 +2,7 @@
 //!ASSERT CONTAINS: store %0, 20
 
 // Tests a simple variable reassignment.
-func test() -> felt {
+fn test() -> felt {
     let x = 10;
     x = 20;
     return x;

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/variables/reassignment_from_var.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/variables/reassignment_from_var.cm
@@ -1,5 +1,5 @@
 // Tests reassigning one variable with the value of another.
-func test_reassignment() -> felt {
+fn test_reassignment() -> felt {
     let x = 10;
     let y = 20;
     x = y; // Should generate a load from y's address and a store to x's address.

--- a/crates/compiler/mir/tests/file_id_collision_test.rs
+++ b/crates/compiler/mir/tests/file_id_collision_test.rs
@@ -55,11 +55,11 @@ fn test_identical_content_different_paths_unique_file_ids() {
 
     // Same exact source code content
     let identical_source = r#"
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 
-func main() -> felt {
+fn main() -> felt {
     return add(10, 20);
 }
 "#;
@@ -180,7 +180,7 @@ fn test_same_file_consistent_file_id() {
     let db = TestDatabase::default();
 
     let source = r#"
-func test() -> felt {
+fn test() -> felt {
     return 42;
 }
 "#;

--- a/crates/compiler/mir/tests/multi_file_integration.rs
+++ b/crates/compiler/mir/tests/multi_file_integration.rs
@@ -58,28 +58,28 @@ fn test_cross_module_function_calls() {
 use math::add;
 use math::multiply;
 
-func main() -> felt {
+fn main() -> felt {
     let x = add(2, 3);
     let y = multiply(x, 4);
     return y;
 }
 
-func local_helper() -> felt {
+fn local_helper() -> felt {
     return add(1, 1);
 }
 "#;
 
     // Math module with utility functions
     let math_source = r#"
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 
-func multiply(a: felt, b: felt) -> felt {
+fn multiply(a: felt, b: felt) -> felt {
     return a * b;
 }
 
-func subtract(a: felt, b: felt) -> felt {
+fn subtract(a: felt, b: felt) -> felt {
     return a - b;
 }
 "#;
@@ -171,17 +171,17 @@ fn test_unused_imports_in_mir() {
     let main_source = r#"
 use utils::used_function;
 
-func main() -> felt {
+fn main() -> felt {
     return used_function(42);
 }
 "#;
 
     let utils_source = r#"
-func used_function(x: felt) -> felt {
+fn used_function(x: felt) -> felt {
     return x * 2;
 }
 
-func unused_function(x: felt) -> felt {
+fn unused_function(x: felt) -> felt {
     return x + 1;
 }
 "#;
@@ -227,7 +227,7 @@ fn test_cyclic_import_detection() {
     let module_a_source = r#"
 use module_b::even;
 
-func odd(n: felt) -> felt {
+fn odd(n: felt) -> felt {
     if (n == 0) {
         return 0;
     } else {
@@ -239,7 +239,7 @@ func odd(n: felt) -> felt {
     let module_b_source = r#"
 use module_a::odd;
 
-func even(n: felt) -> felt {
+fn even(n: felt) -> felt {
     if (n == 0) {
         return 1;
     } else {
@@ -252,7 +252,7 @@ func even(n: felt) -> felt {
 use module_a::odd;
 use module_b::even;
 
-func main() -> felt {
+fn main() -> felt {
     let result1 = odd(5);
     let result2 = even(4);
     return result1 + result2;
@@ -319,7 +319,7 @@ fn test_missing_imported_function_error() {
     let main_source = r#"
 use nonexistent::missing_function;
 
-func main() -> felt {
+fn main() -> felt {
     return missing_function(42);
 }
 "#;
@@ -364,13 +364,13 @@ fn test_dependency_order_independence() {
     let caller_source = r#"
 use callee::helper;
 
-func main() -> felt {
+fn main() -> felt {
     return helper(10);
 }
 "#;
 
     let callee_source = r#"
-func helper(x: felt) -> felt {
+fn helper(x: felt) -> felt {
     return x * 2;
 }
 "#;

--- a/crates/compiler/parser/README.md
+++ b/crates/compiler/parser/README.md
@@ -142,7 +142,7 @@ for beautiful error reporting. These error snapshots help ensure that:
 #[test]
 fn test_function_declaration() {
     assert_parse_snapshot!(
-        "func add(x: felt, y: felt) -> felt { return x + y; }",
+        "fn add(x: felt, y: felt) -> felt { return x + y; }",
         "function_declaration"
     );
 }

--- a/crates/compiler/parser/src/lexer.rs
+++ b/crates/compiler/parser/src/lexer.rs
@@ -123,7 +123,7 @@ pub enum TokenType<'a> {
     Else,
     #[token("false")]
     False,
-    #[token("func")]
+    #[token("fn")]
     Function,
     #[token("if")]
     If,
@@ -221,7 +221,7 @@ impl<'a> fmt::Display for TokenType<'a> {
             TokenType::Const => write!(f, "const"),
             TokenType::Else => write!(f, "else"),
             TokenType::False => write!(f, "false"),
-            TokenType::Function => write!(f, "func"),
+            TokenType::Function => write!(f, "fn"),
             TokenType::If => write!(f, "if"),
             TokenType::Let => write!(f, "let"),
             TokenType::Local => write!(f, "local"),
@@ -275,7 +275,7 @@ mod tests {
         let input = r#"
             use std::math::add;
 
-            func add(x: felt, y: felt) -> felt {
+            fn add(x: felt, y: felt) -> felt {
                 let result = x + y;
                 if result == 0 {
                     return result;

--- a/crates/compiler/parser/src/parser.rs
+++ b/crates/compiler/parser/src/parser.rs
@@ -982,7 +982,7 @@ where
     let type_expr = type_expr_parser();
     let statement = statement_parser();
 
-    // Function definition: func name(param1: type1, param2: type2) -> return_type { body }
+    // Function definition: fn name(param1: type1, param2: type2) -> return_type { body }
     just(TokenType::Function)
         .ignore_then(spanned_ident) // function name
         .then(

--- a/crates/compiler/parser/tests/common.rs
+++ b/crates/compiler/parser/tests/common.rs
@@ -156,5 +156,5 @@ macro_rules! assert_parses_err {
 
 /// Helper to wrap statement code inside a function, since most statements are not top-level.
 pub fn in_function(code: &str) -> String {
-    format!("func test() {{ {code} }}")
+    format!("fn test() {{ {code} }}")
 }

--- a/crates/compiler/parser/tests/parser/toplevel.rs
+++ b/crates/compiler/parser/tests/parser/toplevel.rs
@@ -6,49 +6,49 @@ use crate::{assert_parses_err, assert_parses_ok};
 
 #[test]
 fn simple_function() {
-    assert_parses_ok!("func add(a: felt, b: felt) -> felt { return a + b; }");
+    assert_parses_ok!("fn add(a: felt, b: felt) -> felt { return a + b; }");
 }
 
 #[test]
 fn function_no_params() {
-    assert_parses_ok!("func get_constant() -> felt { return 42; }");
+    assert_parses_ok!("fn get_constant() -> felt { return 42; }");
 }
 
 #[test]
 fn function_no_return() {
-    assert_parses_ok!("func print_hello() { let msg = hello; }");
+    assert_parses_ok!("fn print_hello() { let msg = hello; }");
 }
 
 #[test]
 fn function_multiple_params() {
-    assert_parses_ok!("func complex(a: felt, b: felt*, c: (felt, felt)) { }");
+    assert_parses_ok!("fn complex(a: felt, b: felt*, c: (felt, felt)) { }");
 }
 
 #[test]
 fn many_parameters() {
     assert_parses_ok!(
-        "func complex_function(a: felt, b: felt*, c: (felt, felt), d: MyStruct, e: MyStruct*) -> (felt, felt) { return (a, b); }"
+        "fn complex_function(a: felt, b: felt*, c: (felt, felt), d: MyStruct, e: MyStruct*) -> (felt, felt) { return (a, b); }"
     );
 }
 
 #[test]
 fn trailing_comma_function_params() {
-    assert_parses_ok!("func test(a: felt, b: felt,) { }");
+    assert_parses_ok!("fn test(a: felt, b: felt,) { }");
 }
 
 #[test]
 fn missing_function_name() {
-    assert_parses_err!("func (a: felt) -> felt { }");
+    assert_parses_err!("fn (a: felt) -> felt { }");
 }
 
 #[test]
 fn invalid_parameter() {
-    assert_parses_err!("func test(: felt) { }");
+    assert_parses_err!("fn test(: felt) { }");
 }
 
 #[test]
 fn missing_function_body() {
-    assert_parses_err!("func test() -> felt");
+    assert_parses_err!("fn test() -> felt");
 }
 
 // ===================
@@ -106,7 +106,7 @@ fn simple_namespace() {
 
 #[test]
 fn namespace_with_function() {
-    assert_parses_ok!("namespace Utils { func helper() -> felt { return 1; } }");
+    assert_parses_ok!("namespace Utils { fn helper() -> felt { return 1; } }");
 }
 
 #[test]
@@ -205,11 +205,11 @@ fn complete_program() {
         }
 
         namespace MathUtils {
-            func magnitude(v: Vector) -> felt {
+            fn magnitude(v: Vector) -> felt {
                 return (v.x * v.x + v.y * v.y);
             }
 
-            func rfib(n: felt) -> felt {
+            fn rfib(n: felt) -> felt {
                 if (n == 0) {
                     return 0;
                 }
@@ -237,7 +237,7 @@ fn imports_and_functions() {
             y: felt
         }
 
-        func distance(p1: Point, p2: Point) -> felt {
+        fn distance(p1: Point, p2: Point) -> felt {
             local dx: felt = p1.x - p2.x;
             local dy: felt = p1.y - p2.y;
             return sqrt(dx * dx + dy * dy);
@@ -268,8 +268,8 @@ fn whitespace_only() {
 fn multiple_syntax_errors() {
     assert_parses_err!(
         r#"
-        func bad1( { }
-        func good() { return 1; }
+        fn bad1( { }
+        fn good() { return 1; }
         struct bad2 x: felt }
         struct Good { x: felt }
     "#
@@ -295,7 +295,7 @@ fn mixed_valid_invalid() {
 fn function_with_loops() {
     assert_parses_ok!(
         r#"
-        func test_loops() {
+        fn test_loops() {
             loop {
                 let x = 1;
                 if (x == 1) {

--- a/crates/compiler/parser/tests/parser/types.rs
+++ b/crates/compiler/parser/tests/parser/types.rs
@@ -2,7 +2,7 @@ use crate::assert_parses_ok;
 
 // Helper to wrap type expressions in function parameters for testing
 fn with_param(type_expr: &str) -> String {
-    format!("func test(x: {type_expr}) {{ }}")
+    format!("fn test(x: {type_expr}) {{ }}")
 }
 
 // ===================

--- a/crates/compiler/parser/tests/snapshots/diagnostics__expressions::invalid_binary_op.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__expressions::invalid_binary_op.snap
@@ -3,12 +3,12 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { a +; }
+fn test() { a +; }
 --- Diagnostics ---
 [02] Error: found ';' expected '!', '-', something else, identifier, or '('
-   ╭─[ test.cairo:1:18 ]
+   ╭─[ test.cairo:1:16 ]
    │
- 1 │ func test() { a +; }
-   │                  ┬  
-   │                  ╰── found ';' expected '!', '-', something else, identifier, or '('
+ 1 │ fn test() { a +; }
+   │                ┬  
+   │                ╰── found ';' expected '!', '-', something else, identifier, or '('
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__expressions::invalid_number_format.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__expressions::invalid_number_format.snap
@@ -3,12 +3,12 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { 0xGG; }
+fn test() { 0xGG; }
 --- Diagnostics ---
 [01] Error: Invalid number '0xGG': Invalid number format
-   ╭─[ test.cairo:1:15 ]
+   ╭─[ test.cairo:1:13 ]
    │
- 1 │ func test() { 0xGG; }
-   │               ──┬─  
-   │                 ╰─── Invalid number '0xGG': Invalid number format
+ 1 │ fn test() { 0xGG; }
+   │             ──┬─  
+   │               ╰─── Invalid number '0xGG': Invalid number format
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__expressions::large_number.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__expressions::large_number.snap
@@ -3,12 +3,12 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { 4294967295; }
+fn test() { 4294967295; }
 --- Diagnostics ---
 [01] Error: Invalid number '4294967295': Number overflows 2**31 - 1
-   ╭─[ test.cairo:1:15 ]
+   ╭─[ test.cairo:1:13 ]
    │
- 1 │ func test() { 4294967295; }
-   │               ─────┬────  
-   │                    ╰────── Invalid number '4294967295': Number overflows 2**31 - 1
+ 1 │ fn test() { 4294967295; }
+   │             ─────┬────  
+   │                  ╰────── Invalid number '4294967295': Number overflows 2**31 - 1
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__expressions::number_overflow.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__expressions::number_overflow.snap
@@ -3,12 +3,12 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { 0x80000000; }
+fn test() { 0x80000000; }
 --- Diagnostics ---
 [01] Error: Invalid number '0x80000000': Number overflows 2**31 - 1
-   ╭─[ test.cairo:1:15 ]
+   ╭─[ test.cairo:1:13 ]
    │
- 1 │ func test() { 0x80000000; }
-   │               ─────┬────  
-   │                    ╰────── Invalid number '0x80000000': Number overflows 2**31 - 1
+ 1 │ fn test() { 0x80000000; }
+   │             ─────┬────  
+   │                  ╰────── Invalid number '0x80000000': Number overflows 2**31 - 1
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__expressions::unclosed_paren.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__expressions::unclosed_paren.snap
@@ -3,12 +3,12 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { foo(a, b; }
+fn test() { foo(a, b; }
 --- Diagnostics ---
 [02] Error: found ';' expected '{', '(', '.', '[', '*', '/', '+', '-', '==', '!=', '<', '>', '<=', '>=', '&&', '||', ',', or ')'
-   ╭─[ test.cairo:1:23 ]
+   ╭─[ test.cairo:1:21 ]
    │
- 1 │ func test() { foo(a, b; }
-   │                       ┬  
-   │                       ╰── found ';' expected '{', '(', '.', '[', '*', '/', '+', '-', '==', '!=', '<', '>', '<=', '>=', '&&', '||', ',', or ')'
+ 1 │ fn test() { foo(a, b; }
+   │                     ┬  
+   │                     ╰── found ';' expected '{', '(', '.', '[', '*', '/', '+', '-', '==', '!=', '<', '>', '<=', '>=', '&&', '||', ',', or ')'
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__statements::if_statement_invalid_condition.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__statements::if_statement_invalid_condition.snap
@@ -3,12 +3,12 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { if { x = 1; } }
+fn test() { if { x = 1; } }
 --- Diagnostics ---
 [02] Error: found '{' expected '('
-   ╭─[ test.cairo:1:18 ]
+   ╭─[ test.cairo:1:16 ]
    │
- 1 │ func test() { if { x = 1; } }
-   │                  ┬  
-   │                  ╰── found '{' expected '('
+ 1 │ fn test() { if { x = 1; } }
+   │                ┬  
+   │                ╰── found '{' expected '('
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__statements::let_statement_missing_semicolon.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__statements::let_statement_missing_semicolon.snap
@@ -3,12 +3,12 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { let x = 5 }
+fn test() { let x = 5 }
 --- Diagnostics ---
 [02] Error: found '}' expected '(', '.', '[', '*', '/', '+', '-', '==', '!=', '<', '>', '<=', '>=', '&&', '||', or ';'
-   ╭─[ test.cairo:1:25 ]
+   ╭─[ test.cairo:1:23 ]
    │
- 1 │ func test() { let x = 5 }
-   │                         ┬  
-   │                         ╰── found '}' expected '(', '.', '[', '*', '/', '+', '-', '==', '!=', '<', '>', '<=', '>=', '&&', '||', or ';'
+ 1 │ fn test() { let x = 5 }
+   │                       ┬  
+   │                       ╰── found '}' expected '(', '.', '[', '*', '/', '+', '-', '==', '!=', '<', '>', '<=', '>=', '&&', '||', or ';'
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__statements::missing_assignment_target.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__statements::missing_assignment_target.snap
@@ -3,12 +3,12 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { = 5; }
+fn test() { = 5; }
 --- Diagnostics ---
 [02] Error: found '=' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'local', 'const', 'return', '!', '-', something else, identifier, '(', or '}'
-   ╭─[ test.cairo:1:15 ]
+   ╭─[ test.cairo:1:13 ]
    │
- 1 │ func test() { = 5; }
-   │               ┬  
-   │               ╰── found '=' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'local', 'const', 'return', '!', '-', something else, identifier, '(', or '}'
+ 1 │ fn test() { = 5; }
+   │             ┬  
+   │             ╰── found '=' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'local', 'const', 'return', '!', '-', something else, identifier, '(', or '}'
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_parameter.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_parameter.snap
@@ -3,12 +3,12 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(: felt) { }
+fn test(: felt) { }
 --- Diagnostics ---
 [02] Error: found ':' expected identifier, or ')'
-   ╭─[ test.cairo:1:11 ]
+   ╭─[ test.cairo:1:9 ]
    │
- 1 │ func test(: felt) { }
-   │           ┬  
-   │           ╰── found ':' expected identifier, or ')'
+ 1 │ fn test(: felt) { }
+   │         ┬  
+   │         ╰── found ':' expected identifier, or ')'
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_assignment.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_assignment.snap
@@ -5,10 +5,10 @@ expression: snapshot
 --- Code ---
 x = 10;
 --- Diagnostics ---
-[02] Error: found 'x' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+[02] Error: found 'x' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
    ╭─[ test.cairo:1:1 ]
    │
  1 │ x = 10;
    │ ┬  
-   │ ╰── found 'x' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+   │ ╰── found 'x' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_block.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_block.snap
@@ -5,10 +5,10 @@ expression: snapshot
 --- Code ---
 { let x = 1; }
 --- Diagnostics ---
-[02] Error: found '{' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+[02] Error: found '{' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
    ╭─[ test.cairo:1:1 ]
    │
  1 │ { let x = 1; }
    │ ┬  
-   │ ╰── found '{' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+   │ ╰── found '{' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_expression.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_expression.snap
@@ -5,10 +5,10 @@ expression: snapshot
 --- Code ---
 42;
 --- Diagnostics ---
-[02] Error: found '42' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+[02] Error: found '42' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
    ╭─[ test.cairo:1:1 ]
    │
  1 │ 42;
    │ ─┬  
-   │  ╰── found '42' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+   │  ╰── found '42' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_if.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_if.snap
@@ -5,10 +5,10 @@ expression: snapshot
 --- Code ---
 if (true) { x = 1; }
 --- Diagnostics ---
-[02] Error: found 'if' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+[02] Error: found 'if' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
    ╭─[ test.cairo:1:1 ]
    │
  1 │ if (true) { x = 1; }
    │ ─┬  
-   │  ╰── found 'if' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+   │  ╰── found 'if' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_let.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_let.snap
@@ -5,10 +5,10 @@ expression: snapshot
 --- Code ---
 let x = 5;
 --- Diagnostics ---
-[02] Error: found 'let' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+[02] Error: found 'let' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
    ╭─[ test.cairo:1:1 ]
    │
  1 │ let x = 5;
    │ ─┬─  
-   │  ╰─── found 'let' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+   │  ╰─── found 'let' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_local.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_local.snap
@@ -5,10 +5,10 @@ expression: snapshot
 --- Code ---
 local x: felt = 42;
 --- Diagnostics ---
-[02] Error: found 'local' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+[02] Error: found 'local' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
    ╭─[ test.cairo:1:1 ]
    │
  1 │ local x: felt = 42;
    │ ──┬──  
-   │   ╰──── found 'local' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+   │   ╰──── found 'local' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_return.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::invalid_toplevel_return.snap
@@ -5,10 +5,10 @@ expression: snapshot
 --- Code ---
 return 5;
 --- Diagnostics ---
-[02] Error: found 'return' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+[02] Error: found 'return' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
    ╭─[ test.cairo:1:1 ]
    │
  1 │ return 5;
    │ ───┬──  
-   │    ╰──── found 'return' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+   │    ╰──── found 'return' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::missing_function_body.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::missing_function_body.snap
@@ -3,12 +3,12 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() -> felt
+fn test() -> felt
 --- Diagnostics ---
 [02] Error: found end of input expected '*', or '{'
-   ╭─[ test.cairo:1:20 ]
+   ╭─[ test.cairo:1:18 ]
    │
- 1 │ func test() -> felt
-   │                    │ 
-   │                    ╰─ found end of input expected '*', or '{'
+ 1 │ fn test() -> felt
+   │                  │ 
+   │                  ╰─ found end of input expected '*', or '{'
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::missing_function_name.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::missing_function_name.snap
@@ -3,12 +3,12 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func (a: felt) -> felt { }
+fn (a: felt) -> felt { }
 --- Diagnostics ---
 [02] Error: found '(' expected identifier
-   ╭─[ test.cairo:1:6 ]
+   ╭─[ test.cairo:1:4 ]
    │
- 1 │ func (a: felt) -> felt { }
-   │      ┬  
-   │      ╰── found '(' expected identifier
+ 1 │ fn (a: felt) -> felt { }
+   │    ┬  
+   │    ╰── found '(' expected identifier
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::mixed_valid_invalid.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::mixed_valid_invalid.snap
@@ -9,10 +9,10 @@ expression: snapshot
         const ALSO_GOOD = 2;
     
 --- Diagnostics ---
-[02] Error: found 'let' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+[02] Error: found 'let' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
    ╭─[ test.cairo:3:9 ]
    │
  3 │         let bad = 42;
    │         ─┬─  
-   │          ╰─── found 'let' expected 'func', 'struct', 'const', 'namespace', 'use', or end of input
+   │          ╰─── found 'let' expected 'fn', 'struct', 'const', 'namespace', 'use', or end of input
 ───╯

--- a/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::multiple_syntax_errors.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__toplevel::multiple_syntax_errors.snap
@@ -4,16 +4,16 @@ expression: snapshot
 ---
 --- Code ---
 
-        func bad1( { }
-        func good() { return 1; }
+        fn bad1( { }
+        fn good() { return 1; }
         struct bad2 x: felt }
         struct Good { x: felt }
     
 --- Diagnostics ---
 [02] Error: found '{' expected identifier, or ')'
-   ╭─[ test.cairo:2:20 ]
+   ╭─[ test.cairo:2:18 ]
    │
- 2 │         func bad1( { }
-   │                    ┬  
-   │                    ╰── found '{' expected identifier, or ')'
+ 2 │         fn bad1( { }
+   │                  ┬  
+   │                  ╰── found '{' expected identifier, or ')'
 ───╯

--- a/crates/compiler/parser/tests/snapshots/expressions::addition.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::addition.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { a + b; }
+fn test() { a + b; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { a + b; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -27,29 +27,29 @@ func test() { a + b; }
                                         Identifier(
                                             Spanned(
                                                 "a",
-                                                14..15,
+                                                12..13,
                                             ),
                                         ),
-                                        14..15,
+                                        12..13,
                                     ),
                                     right: Spanned(
                                         Identifier(
                                             Spanned(
                                                 "b",
-                                                18..19,
+                                                16..17,
                                             ),
                                         ),
-                                        18..19,
+                                        16..17,
                                     ),
                                 },
-                                14..19,
+                                12..17,
                             ),
                         ),
-                        14..20,
+                        12..18,
                     ),
                 ],
             },
-            0..22,
+            0..20,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::array_index.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::array_index.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { arr[0]; }
+fn test() { arr[0]; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { arr[0]; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -26,26 +26,26 @@ func test() { arr[0]; }
                                         Identifier(
                                             Spanned(
                                                 "arr",
-                                                14..17,
+                                                12..15,
                                             ),
                                         ),
-                                        14..17,
+                                        12..15,
                                     ),
                                     index: Spanned(
                                         Literal(
                                             0,
                                         ),
-                                        18..19,
+                                        16..17,
                                     ),
                                 },
-                                14..19,
+                                12..17,
                             ),
                         ),
-                        14..21,
+                        12..19,
                     ),
                 ],
             },
-            0..23,
+            0..21,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::chained_calls.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::chained_calls.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { obj.method().another(); }
+fn test() { obj.method().another(); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { obj.method().another(); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -32,39 +32,39 @@ func test() { obj.method().another(); }
                                                                 Identifier(
                                                                     Spanned(
                                                                         "obj",
-                                                                        14..17,
+                                                                        12..15,
                                                                     ),
                                                                 ),
-                                                                14..17,
+                                                                12..15,
                                                             ),
                                                             field: Spanned(
                                                                 "method",
-                                                                18..24,
+                                                                16..22,
                                                             ),
                                                         },
-                                                        14..24,
+                                                        12..22,
                                                     ),
                                                     args: [],
                                                 },
-                                                14..26,
+                                                12..24,
                                             ),
                                             field: Spanned(
                                                 "another",
-                                                27..34,
+                                                25..32,
                                             ),
                                         },
-                                        14..34,
+                                        12..32,
                                     ),
                                     args: [],
                                 },
-                                14..36,
+                                12..34,
                             ),
                         ),
-                        14..37,
+                        12..35,
                     ),
                 ],
             },
-            0..39,
+            0..37,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::chained_operations.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::chained_operations.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { obj.method1().field.method2()[0].final_field; }
+fn test() { obj.method1().field.method2()[0].final_field; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { obj.method1().field.method2()[0].final_field; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -38,62 +38,62 @@ func test() { obj.method1().field.method2()[0].final_field; }
                                                                                         Identifier(
                                                                                             Spanned(
                                                                                                 "obj",
-                                                                                                14..17,
+                                                                                                12..15,
                                                                                             ),
                                                                                         ),
-                                                                                        14..17,
+                                                                                        12..15,
                                                                                     ),
                                                                                     field: Spanned(
                                                                                         "method1",
-                                                                                        18..25,
+                                                                                        16..23,
                                                                                     ),
                                                                                 },
-                                                                                14..25,
+                                                                                12..23,
                                                                             ),
                                                                             args: [],
                                                                         },
-                                                                        14..27,
+                                                                        12..25,
                                                                     ),
                                                                     field: Spanned(
                                                                         "field",
-                                                                        28..33,
+                                                                        26..31,
                                                                     ),
                                                                 },
-                                                                14..33,
+                                                                12..31,
                                                             ),
                                                             field: Spanned(
                                                                 "method2",
-                                                                34..41,
+                                                                32..39,
                                                             ),
                                                         },
-                                                        14..41,
+                                                        12..39,
                                                     ),
                                                     args: [],
                                                 },
-                                                14..43,
+                                                12..41,
                                             ),
                                             index: Spanned(
                                                 Literal(
                                                     0,
                                                 ),
-                                                44..45,
+                                                42..43,
                                             ),
                                         },
-                                        14..45,
+                                        12..43,
                                     ),
                                     field: Spanned(
                                         "final_field",
-                                        47..58,
+                                        45..56,
                                     ),
                                 },
-                                14..58,
+                                12..56,
                             ),
                         ),
-                        14..59,
+                        12..57,
                     ),
                 ],
             },
-            0..61,
+            0..59,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::comparison_and_logical.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::comparison_and_logical.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { a == b && c != d; }
+fn test() { a == b && c != d; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { a == b && c != d; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -30,22 +30,22 @@ func test() { a == b && c != d; }
                                                 Identifier(
                                                     Spanned(
                                                         "a",
-                                                        14..15,
+                                                        12..13,
                                                     ),
                                                 ),
-                                                14..15,
+                                                12..13,
                                             ),
                                             right: Spanned(
                                                 Identifier(
                                                     Spanned(
                                                         "b",
-                                                        19..20,
+                                                        17..18,
                                                     ),
                                                 ),
-                                                19..20,
+                                                17..18,
                                             ),
                                         },
-                                        14..20,
+                                        12..18,
                                     ),
                                     right: Spanned(
                                         BinaryOp {
@@ -54,32 +54,32 @@ func test() { a == b && c != d; }
                                                 Identifier(
                                                     Spanned(
                                                         "c",
-                                                        24..25,
+                                                        22..23,
                                                     ),
                                                 ),
-                                                24..25,
+                                                22..23,
                                             ),
                                             right: Spanned(
                                                 Identifier(
                                                     Spanned(
                                                         "d",
-                                                        29..30,
+                                                        27..28,
                                                     ),
                                                 ),
-                                                29..30,
+                                                27..28,
                                             ),
                                         },
-                                        24..30,
+                                        22..28,
                                     ),
                                 },
-                                14..30,
+                                12..28,
                             ),
                         ),
-                        14..31,
+                        12..29,
                     ),
                 ],
             },
-            0..33,
+            0..31,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::complex_expression_precedence.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::complex_expression_precedence.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { result = a.field[0].method(b + c * d, e && f || g).value; }
+fn test() { result = a.field[0].method(b + c * d, e && f || g).value; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { result = a.field[0].method(b + c * d, e && f || g).value; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,10 +24,10 @@ func test() { result = a.field[0].method(b + c * d, e && f || g).value; }
                                 Identifier(
                                     Spanned(
                                         "result",
-                                        14..20,
+                                        12..18,
                                     ),
                                 ),
-                                14..20,
+                                12..18,
                             ),
                             rhs: Spanned(
                                 MemberAccess {
@@ -43,33 +43,33 @@ func test() { result = a.field[0].method(b + c * d, e && f || g).value; }
                                                                         Identifier(
                                                                             Spanned(
                                                                                 "a",
-                                                                                23..24,
+                                                                                21..22,
                                                                             ),
                                                                         ),
-                                                                        23..24,
+                                                                        21..22,
                                                                     ),
                                                                     field: Spanned(
                                                                         "field",
-                                                                        25..30,
+                                                                        23..28,
                                                                     ),
                                                                 },
-                                                                23..30,
+                                                                21..28,
                                                             ),
                                                             index: Spanned(
                                                                 Literal(
                                                                     0,
                                                                 ),
-                                                                31..32,
+                                                                29..30,
                                                             ),
                                                         },
-                                                        23..32,
+                                                        21..30,
                                                     ),
                                                     field: Spanned(
                                                         "method",
-                                                        34..40,
+                                                        32..38,
                                                     ),
                                                 },
-                                                23..40,
+                                                21..38,
                                             ),
                                             args: [
                                                 Spanned(
@@ -79,10 +79,10 @@ func test() { result = a.field[0].method(b + c * d, e && f || g).value; }
                                                             Identifier(
                                                                 Spanned(
                                                                     "b",
-                                                                    41..42,
+                                                                    39..40,
                                                                 ),
                                                             ),
-                                                            41..42,
+                                                            39..40,
                                                         ),
                                                         right: Spanned(
                                                             BinaryOp {
@@ -91,25 +91,25 @@ func test() { result = a.field[0].method(b + c * d, e && f || g).value; }
                                                                     Identifier(
                                                                         Spanned(
                                                                             "c",
-                                                                            45..46,
+                                                                            43..44,
                                                                         ),
                                                                     ),
-                                                                    45..46,
+                                                                    43..44,
                                                                 ),
                                                                 right: Spanned(
                                                                     Identifier(
                                                                         Spanned(
                                                                             "d",
-                                                                            49..50,
+                                                                            47..48,
                                                                         ),
                                                                     ),
-                                                                    49..50,
+                                                                    47..48,
                                                                 ),
                                                             },
-                                                            45..50,
+                                                            43..48,
                                                         ),
                                                     },
-                                                    41..50,
+                                                    39..48,
                                                 ),
                                                 Spanned(
                                                     BinaryOp {
@@ -121,52 +121,52 @@ func test() { result = a.field[0].method(b + c * d, e && f || g).value; }
                                                                     Identifier(
                                                                         Spanned(
                                                                             "e",
-                                                                            52..53,
+                                                                            50..51,
                                                                         ),
                                                                     ),
-                                                                    52..53,
+                                                                    50..51,
                                                                 ),
                                                                 right: Spanned(
                                                                     Identifier(
                                                                         Spanned(
                                                                             "f",
-                                                                            57..58,
+                                                                            55..56,
                                                                         ),
                                                                     ),
-                                                                    57..58,
+                                                                    55..56,
                                                                 ),
                                                             },
-                                                            52..58,
+                                                            50..56,
                                                         ),
                                                         right: Spanned(
                                                             Identifier(
                                                                 Spanned(
                                                                     "g",
-                                                                    62..63,
+                                                                    60..61,
                                                                 ),
                                                             ),
-                                                            62..63,
+                                                            60..61,
                                                         ),
                                                     },
-                                                    52..63,
+                                                    50..61,
                                                 ),
                                             ],
                                         },
-                                        23..63,
+                                        21..61,
                                     ),
                                     field: Spanned(
                                         "value",
-                                        65..70,
+                                        63..68,
                                     ),
                                 },
-                                23..70,
+                                21..68,
                             ),
                         },
-                        14..71,
+                        12..69,
                     ),
                 ],
             },
-            0..73,
+            0..71,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::complex_precedence.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::complex_precedence.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { a + b * c == d && e || f; }
+fn test() { a + b * c == d && e || f; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { a + b * c == d && e || f; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -36,10 +36,10 @@ func test() { a + b * c == d && e || f; }
                                                                 Identifier(
                                                                     Spanned(
                                                                         "a",
-                                                                        14..15,
+                                                                        12..13,
                                                                     ),
                                                                 ),
-                                                                14..15,
+                                                                12..13,
                                                             ),
                                                             right: Spanned(
                                                                 BinaryOp {
@@ -48,68 +48,68 @@ func test() { a + b * c == d && e || f; }
                                                                         Identifier(
                                                                             Spanned(
                                                                                 "b",
-                                                                                18..19,
+                                                                                16..17,
                                                                             ),
                                                                         ),
-                                                                        18..19,
+                                                                        16..17,
                                                                     ),
                                                                     right: Spanned(
                                                                         Identifier(
                                                                             Spanned(
                                                                                 "c",
-                                                                                22..23,
+                                                                                20..21,
                                                                             ),
                                                                         ),
-                                                                        22..23,
+                                                                        20..21,
                                                                     ),
                                                                 },
-                                                                18..23,
+                                                                16..21,
                                                             ),
                                                         },
-                                                        14..23,
+                                                        12..21,
                                                     ),
                                                     right: Spanned(
                                                         Identifier(
                                                             Spanned(
                                                                 "d",
-                                                                27..28,
+                                                                25..26,
                                                             ),
                                                         ),
-                                                        27..28,
+                                                        25..26,
                                                     ),
                                                 },
-                                                14..28,
+                                                12..26,
                                             ),
                                             right: Spanned(
                                                 Identifier(
                                                     Spanned(
                                                         "e",
-                                                        32..33,
+                                                        30..31,
                                                     ),
                                                 ),
-                                                32..33,
+                                                30..31,
                                             ),
                                         },
-                                        14..33,
+                                        12..31,
                                     ),
                                     right: Spanned(
                                         Identifier(
                                             Spanned(
                                                 "f",
-                                                37..38,
+                                                35..36,
                                             ),
                                         ),
-                                        37..38,
+                                        35..36,
                                     ),
                                 },
-                                14..38,
+                                12..36,
                             ),
                         ),
-                        14..39,
+                        12..37,
                     ),
                 ],
             },
-            0..41,
+            0..39,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::deeply_nested.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::deeply_nested.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { ((((((a + b) * c) - d) / e) == f) && g); }
+fn test() { ((((((a + b) * c) - d) / e) == f) && g); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { ((((((a + b) * c) - d) / e) == f) && g); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -42,89 +42,89 @@ func test() { ((((((a + b) * c) - d) / e) == f) && g); }
                                                                                 Identifier(
                                                                                     Spanned(
                                                                                         "a",
-                                                                                        20..21,
+                                                                                        18..19,
                                                                                     ),
                                                                                 ),
-                                                                                20..21,
+                                                                                18..19,
                                                                             ),
                                                                             right: Spanned(
                                                                                 Identifier(
                                                                                     Spanned(
                                                                                         "b",
-                                                                                        24..25,
+                                                                                        22..23,
                                                                                     ),
                                                                                 ),
-                                                                                24..25,
+                                                                                22..23,
                                                                             ),
                                                                         },
-                                                                        19..26,
+                                                                        17..24,
                                                                     ),
                                                                     right: Spanned(
                                                                         Identifier(
                                                                             Spanned(
                                                                                 "c",
-                                                                                29..30,
+                                                                                27..28,
                                                                             ),
                                                                         ),
-                                                                        29..30,
+                                                                        27..28,
                                                                     ),
                                                                 },
-                                                                18..31,
+                                                                16..29,
                                                             ),
                                                             right: Spanned(
                                                                 Identifier(
                                                                     Spanned(
                                                                         "d",
-                                                                        34..35,
+                                                                        32..33,
                                                                     ),
                                                                 ),
-                                                                34..35,
+                                                                32..33,
                                                             ),
                                                         },
-                                                        17..36,
+                                                        15..34,
                                                     ),
                                                     right: Spanned(
                                                         Identifier(
                                                             Spanned(
                                                                 "e",
-                                                                39..40,
+                                                                37..38,
                                                             ),
                                                         ),
-                                                        39..40,
+                                                        37..38,
                                                     ),
                                                 },
-                                                16..41,
+                                                14..39,
                                             ),
                                             right: Spanned(
                                                 Identifier(
                                                     Spanned(
                                                         "f",
-                                                        45..46,
+                                                        43..44,
                                                     ),
                                                 ),
-                                                45..46,
+                                                43..44,
                                             ),
                                         },
-                                        15..47,
+                                        13..45,
                                     ),
                                     right: Spanned(
                                         Identifier(
                                             Spanned(
                                                 "g",
-                                                51..52,
+                                                49..50,
                                             ),
                                         ),
-                                        51..52,
+                                        49..50,
                                     ),
                                 },
-                                14..53,
+                                12..51,
                             ),
                         ),
-                        14..54,
+                        12..52,
                     ),
                 ],
             },
-            0..56,
+            0..54,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::empty_struct_literal.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::empty_struct_literal.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { Unit {}; }
+fn test() { Unit {}; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { Unit {}; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,18 +24,18 @@ func test() { Unit {}; }
                                 StructLiteral {
                                     name: Spanned(
                                         "Unit",
-                                        14..18,
+                                        12..16,
                                     ),
                                     fields: [],
                                 },
-                                14..21,
+                                12..19,
                             ),
                         ),
-                        14..22,
+                        12..20,
                     ),
                 ],
             },
-            0..24,
+            0..22,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::function_call_with_args.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::function_call_with_args.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { add(a, b, c); }
+fn test() { add(a, b, c); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { add(a, b, c); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -26,49 +26,49 @@ func test() { add(a, b, c); }
                                         Identifier(
                                             Spanned(
                                                 "add",
-                                                14..17,
+                                                12..15,
                                             ),
                                         ),
-                                        14..17,
+                                        12..15,
                                     ),
                                     args: [
                                         Spanned(
                                             Identifier(
                                                 Spanned(
                                                     "a",
-                                                    18..19,
+                                                    16..17,
                                                 ),
                                             ),
-                                            18..19,
+                                            16..17,
                                         ),
                                         Spanned(
                                             Identifier(
                                                 Spanned(
                                                     "b",
-                                                    21..22,
+                                                    19..20,
                                                 ),
                                             ),
-                                            21..22,
+                                            19..20,
                                         ),
                                         Spanned(
                                             Identifier(
                                                 Spanned(
                                                     "c",
-                                                    24..25,
+                                                    22..23,
                                                 ),
                                             ),
-                                            24..25,
+                                            22..23,
                                         ),
                                     ],
                                 },
-                                14..25,
+                                12..23,
                             ),
                         ),
-                        14..27,
+                        12..25,
                     ),
                 ],
             },
-            0..29,
+            0..27,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::integer_literal.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::integer_literal.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { 42; }
+fn test() { 42; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { 42; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,14 +24,14 @@ func test() { 42; }
                                 Literal(
                                     42,
                                 ),
-                                14..16,
+                                12..14,
                             ),
                         ),
-                        14..17,
+                        12..15,
                     ),
                 ],
             },
-            0..19,
+            0..17,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::long_identifier.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::long_identifier.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { very_long_variable_name_that_tests_identifier_parsing; }
+fn test() { very_long_variable_name_that_tests_identifier_parsing; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { very_long_variable_name_that_tests_identifier_parsing; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,17 +24,17 @@ func test() { very_long_variable_name_that_tests_identifier_parsing; }
                                 Identifier(
                                     Spanned(
                                         "very_long_variable_name_that_tests_identifier_parsing",
-                                        14..67,
+                                        12..65,
                                     ),
                                 ),
-                                14..67,
+                                12..65,
                             ),
                         ),
-                        14..68,
+                        12..66,
                     ),
                 ],
             },
-            0..70,
+            0..68,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::multiplication_precedence.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::multiplication_precedence.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { a + b * c; }
+fn test() { a + b * c; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { a + b * c; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -27,10 +27,10 @@ func test() { a + b * c; }
                                         Identifier(
                                             Spanned(
                                                 "a",
-                                                14..15,
+                                                12..13,
                                             ),
                                         ),
-                                        14..15,
+                                        12..13,
                                     ),
                                     right: Spanned(
                                         BinaryOp {
@@ -39,32 +39,32 @@ func test() { a + b * c; }
                                                 Identifier(
                                                     Spanned(
                                                         "b",
-                                                        18..19,
+                                                        16..17,
                                                     ),
                                                 ),
-                                                18..19,
+                                                16..17,
                                             ),
                                             right: Spanned(
                                                 Identifier(
                                                     Spanned(
                                                         "c",
-                                                        22..23,
+                                                        20..21,
                                                     ),
                                                 ),
-                                                22..23,
+                                                20..21,
                                             ),
                                         },
-                                        18..23,
+                                        16..21,
                                     ),
                                 },
-                                14..23,
+                                12..21,
                             ),
                         ),
-                        14..24,
+                        12..22,
                     ),
                 ],
             },
-            0..26,
+            0..24,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::nested_index.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::nested_index.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { matrix[i][j]; }
+fn test() { matrix[i][j]; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { matrix[i][j]; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -28,41 +28,41 @@ func test() { matrix[i][j]; }
                                                 Identifier(
                                                     Spanned(
                                                         "matrix",
-                                                        14..20,
+                                                        12..18,
                                                     ),
                                                 ),
-                                                14..20,
+                                                12..18,
                                             ),
                                             index: Spanned(
                                                 Identifier(
                                                     Spanned(
                                                         "i",
-                                                        21..22,
+                                                        19..20,
                                                     ),
                                                 ),
-                                                21..22,
+                                                19..20,
                                             ),
                                         },
-                                        14..22,
+                                        12..20,
                                     ),
                                     index: Spanned(
                                         Identifier(
                                             Spanned(
                                                 "j",
-                                                24..25,
+                                                22..23,
                                             ),
                                         ),
-                                        24..25,
+                                        22..23,
                                     ),
                                 },
-                                14..25,
+                                12..23,
                             ),
                         ),
-                        14..27,
+                        12..25,
                     ),
                 ],
             },
-            0..29,
+            0..27,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::nested_member_access.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::nested_member_access.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { obj.inner.field; }
+fn test() { obj.inner.field; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { obj.inner.field; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -28,31 +28,31 @@ func test() { obj.inner.field; }
                                                 Identifier(
                                                     Spanned(
                                                         "obj",
-                                                        14..17,
+                                                        12..15,
                                                     ),
                                                 ),
-                                                14..17,
+                                                12..15,
                                             ),
                                             field: Spanned(
                                                 "inner",
-                                                18..23,
+                                                16..21,
                                             ),
                                         },
-                                        14..23,
+                                        12..21,
                                     ),
                                     field: Spanned(
                                         "field",
-                                        24..29,
+                                        22..27,
                                     ),
                                 },
-                                14..29,
+                                12..27,
                             ),
                         ),
-                        14..30,
+                        12..28,
                     ),
                 ],
             },
-            0..32,
+            0..30,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::nested_struct_literal.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::nested_struct_literal.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { Rectangle { top_left: Point { x: 0, y: 0 }, width: 10 }; }
+fn test() { Rectangle { top_left: Point { x: 0, y: 0 }, width: 10 }; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { Rectangle { top_left: Point { x: 0, y: 0 }, width: 10 }; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,72 +24,72 @@ func test() { Rectangle { top_left: Point { x: 0, y: 0 }, width: 10 }; }
                                 StructLiteral {
                                     name: Spanned(
                                         "Rectangle",
-                                        14..23,
+                                        12..21,
                                     ),
                                     fields: [
                                         (
                                             Spanned(
                                                 "top_left",
-                                                26..34,
+                                                24..32,
                                             ),
                                             Spanned(
                                                 StructLiteral {
                                                     name: Spanned(
                                                         "Point",
-                                                        36..41,
+                                                        34..39,
                                                     ),
                                                     fields: [
                                                         (
                                                             Spanned(
                                                                 "x",
-                                                                44..45,
+                                                                42..43,
                                                             ),
                                                             Spanned(
                                                                 Literal(
                                                                     0,
                                                                 ),
-                                                                47..48,
+                                                                45..46,
                                                             ),
                                                         ),
                                                         (
                                                             Spanned(
                                                                 "y",
-                                                                50..51,
+                                                                48..49,
                                                             ),
                                                             Spanned(
                                                                 Literal(
                                                                     0,
                                                                 ),
-                                                                53..54,
+                                                                51..52,
                                                             ),
                                                         ),
                                                     ],
                                                 },
-                                                36..56,
+                                                34..54,
                                             ),
                                         ),
                                         (
                                             Spanned(
                                                 "width",
-                                                58..63,
+                                                56..61,
                                             ),
                                             Spanned(
                                                 Literal(
                                                     10,
                                                 ),
-                                                65..67,
+                                                63..65,
                                             ),
                                         ),
                                     ],
                                 },
-                                14..69,
+                                12..67,
                             ),
                         ),
-                        14..70,
+                        12..68,
                     ),
                 ],
             },
-            0..72,
+            0..70,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::nested_tuple.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::nested_tuple.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { ((1, 2), (3, 4)); }
+fn test() { ((1, 2), (3, 4)); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { ((1, 2), (3, 4)); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -30,17 +30,17 @@ func test() { ((1, 2), (3, 4)); }
                                                         Literal(
                                                             1,
                                                         ),
-                                                        16..17,
+                                                        14..15,
                                                     ),
                                                     Spanned(
                                                         Literal(
                                                             2,
                                                         ),
-                                                        19..20,
+                                                        17..18,
                                                     ),
                                                 ],
                                             ),
-                                            15..21,
+                                            13..19,
                                         ),
                                         Spanned(
                                             Tuple(
@@ -49,28 +49,28 @@ func test() { ((1, 2), (3, 4)); }
                                                         Literal(
                                                             3,
                                                         ),
-                                                        24..25,
+                                                        22..23,
                                                     ),
                                                     Spanned(
                                                         Literal(
                                                             4,
                                                         ),
-                                                        27..28,
+                                                        25..26,
                                                     ),
                                                 ],
                                             ),
-                                            23..29,
+                                            21..27,
                                         ),
                                     ],
                                 ),
-                                14..30,
+                                12..28,
                             ),
                         ),
-                        14..31,
+                        12..29,
                     ),
                 ],
             },
-            0..33,
+            0..31,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::parenthesized_expr.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::parenthesized_expr.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { (a + b); }
+fn test() { (a + b); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { (a + b); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -27,29 +27,29 @@ func test() { (a + b); }
                                         Identifier(
                                             Spanned(
                                                 "a",
-                                                15..16,
+                                                13..14,
                                             ),
                                         ),
-                                        15..16,
+                                        13..14,
                                     ),
                                     right: Spanned(
                                         Identifier(
                                             Spanned(
                                                 "b",
-                                                19..20,
+                                                17..18,
                                             ),
                                         ),
-                                        19..20,
+                                        17..18,
                                     ),
                                 },
-                                14..21,
+                                12..19,
                             ),
                         ),
-                        14..22,
+                        12..20,
                     ),
                 ],
             },
-            0..24,
+            0..22,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::precedence_chain.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::precedence_chain.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { a || b && c == d + e * f / g - h; }
+fn test() { a || b && c == d + e * f / g - h; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { a || b && c == d + e * f / g - h; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -27,10 +27,10 @@ func test() { a || b && c == d + e * f / g - h; }
                                         Identifier(
                                             Spanned(
                                                 "a",
-                                                14..15,
+                                                12..13,
                                             ),
                                         ),
-                                        14..15,
+                                        12..13,
                                     ),
                                     right: Spanned(
                                         BinaryOp {
@@ -39,10 +39,10 @@ func test() { a || b && c == d + e * f / g - h; }
                                                 Identifier(
                                                     Spanned(
                                                         "b",
-                                                        19..20,
+                                                        17..18,
                                                     ),
                                                 ),
-                                                19..20,
+                                                17..18,
                                             ),
                                             right: Spanned(
                                                 BinaryOp {
@@ -51,10 +51,10 @@ func test() { a || b && c == d + e * f / g - h; }
                                                         Identifier(
                                                             Spanned(
                                                                 "c",
-                                                                24..25,
+                                                                22..23,
                                                             ),
                                                         ),
-                                                        24..25,
+                                                        22..23,
                                                     ),
                                                     right: Spanned(
                                                         BinaryOp {
@@ -66,10 +66,10 @@ func test() { a || b && c == d + e * f / g - h; }
                                                                         Identifier(
                                                                             Spanned(
                                                                                 "d",
-                                                                                29..30,
+                                                                                27..28,
                                                                             ),
                                                                         ),
-                                                                        29..30,
+                                                                        27..28,
                                                                     ),
                                                                     right: Spanned(
                                                                         BinaryOp {
@@ -81,65 +81,65 @@ func test() { a || b && c == d + e * f / g - h; }
                                                                                         Identifier(
                                                                                             Spanned(
                                                                                                 "e",
-                                                                                                33..34,
+                                                                                                31..32,
                                                                                             ),
                                                                                         ),
-                                                                                        33..34,
+                                                                                        31..32,
                                                                                     ),
                                                                                     right: Spanned(
                                                                                         Identifier(
                                                                                             Spanned(
                                                                                                 "f",
-                                                                                                37..38,
+                                                                                                35..36,
                                                                                             ),
                                                                                         ),
-                                                                                        37..38,
+                                                                                        35..36,
                                                                                     ),
                                                                                 },
-                                                                                33..38,
+                                                                                31..36,
                                                                             ),
                                                                             right: Spanned(
                                                                                 Identifier(
                                                                                     Spanned(
                                                                                         "g",
-                                                                                        41..42,
+                                                                                        39..40,
                                                                                     ),
                                                                                 ),
-                                                                                41..42,
+                                                                                39..40,
                                                                             ),
                                                                         },
-                                                                        33..42,
+                                                                        31..40,
                                                                     ),
                                                                 },
-                                                                29..42,
+                                                                27..40,
                                                             ),
                                                             right: Spanned(
                                                                 Identifier(
                                                                     Spanned(
                                                                         "h",
-                                                                        45..46,
+                                                                        43..44,
                                                                     ),
                                                                 ),
-                                                                45..46,
+                                                                43..44,
                                                             ),
                                                         },
-                                                        29..46,
+                                                        27..44,
                                                     ),
                                                 },
-                                                24..46,
+                                                22..44,
                                             ),
                                         },
-                                        19..46,
+                                        17..44,
                                     ),
                                 },
-                                14..46,
+                                12..44,
                             ),
                         ),
-                        14..47,
+                        12..45,
                     ),
                 ],
             },
-            0..49,
+            0..47,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::simple_function_call.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::simple_function_call.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { foo(); }
+fn test() { foo(); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { foo(); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -26,21 +26,21 @@ func test() { foo(); }
                                         Identifier(
                                             Spanned(
                                                 "foo",
-                                                14..17,
+                                                12..15,
                                             ),
                                         ),
-                                        14..17,
+                                        12..15,
                                     ),
                                     args: [],
                                 },
-                                14..19,
+                                12..17,
                             ),
                         ),
-                        14..20,
+                        12..18,
                     ),
                 ],
             },
-            0..22,
+            0..20,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::simple_identifier.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::simple_identifier.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { my_var; }
+fn test() { my_var; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { my_var; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,17 +24,17 @@ func test() { my_var; }
                                 Identifier(
                                     Spanned(
                                         "my_var",
-                                        14..20,
+                                        12..18,
                                     ),
                                 ),
-                                14..20,
+                                12..18,
                             ),
                         ),
-                        14..21,
+                        12..19,
                     ),
                 ],
             },
-            0..23,
+            0..21,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::simple_member_access.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::simple_member_access.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { obj.field; }
+fn test() { obj.field; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { obj.field; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -26,24 +26,24 @@ func test() { obj.field; }
                                         Identifier(
                                             Spanned(
                                                 "obj",
-                                                14..17,
+                                                12..15,
                                             ),
                                         ),
-                                        14..17,
+                                        12..15,
                                     ),
                                     field: Spanned(
                                         "field",
-                                        18..23,
+                                        16..21,
                                     ),
                                 },
-                                14..23,
+                                12..21,
                             ),
                         ),
-                        14..24,
+                        12..22,
                     ),
                 ],
             },
-            0..26,
+            0..24,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::simple_struct_literal.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::simple_struct_literal.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { Point { x: 1, y: 2 }; }
+fn test() { Point { x: 1, y: 2 }; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { Point { x: 1, y: 2 }; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,43 +24,43 @@ func test() { Point { x: 1, y: 2 }; }
                                 StructLiteral {
                                     name: Spanned(
                                         "Point",
-                                        14..19,
+                                        12..17,
                                     ),
                                     fields: [
                                         (
                                             Spanned(
                                                 "x",
-                                                22..23,
+                                                20..21,
                                             ),
                                             Spanned(
                                                 Literal(
                                                     1,
                                                 ),
-                                                25..26,
+                                                23..24,
                                             ),
                                         ),
                                         (
                                             Spanned(
                                                 "y",
-                                                28..29,
+                                                26..27,
                                             ),
                                             Spanned(
                                                 Literal(
                                                     2,
                                                 ),
-                                                31..32,
+                                                29..30,
                                             ),
                                         ),
                                     ],
                                 },
-                                14..34,
+                                12..32,
                             ),
                         ),
-                        14..35,
+                        12..33,
                     ),
                 ],
             },
-            0..37,
+            0..35,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::simple_tuple.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::simple_tuple.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { (1, 2, 3); }
+fn test() { (1, 2, 3); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { (1, 2, 3); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -27,30 +27,30 @@ func test() { (1, 2, 3); }
                                             Literal(
                                                 1,
                                             ),
-                                            15..16,
+                                            13..14,
                                         ),
                                         Spanned(
                                             Literal(
                                                 2,
                                             ),
-                                            18..19,
+                                            16..17,
                                         ),
                                         Spanned(
                                             Literal(
                                                 3,
                                             ),
-                                            21..22,
+                                            19..20,
                                         ),
                                     ],
                                 ),
-                                14..23,
+                                12..21,
                             ),
                         ),
-                        14..24,
+                        12..22,
                     ),
                 ],
             },
-            0..26,
+            0..24,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::single_element_tuple.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::single_element_tuple.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { (single_element,); }
+fn test() { (single_element,); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { (single_element,); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,17 +24,17 @@ func test() { (single_element,); }
                                 Identifier(
                                     Spanned(
                                         "single_element",
-                                        15..29,
+                                        13..27,
                                     ),
                                 ),
-                                14..31,
+                                12..29,
                             ),
                         ),
-                        14..32,
+                        12..30,
                     ),
                 ],
             },
-            0..34,
+            0..32,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::trailing_comma_function_call.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::trailing_comma_function_call.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { foo(a, b, c,); }
+fn test() { foo(a, b, c,); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { foo(a, b, c,); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -26,49 +26,49 @@ func test() { foo(a, b, c,); }
                                         Identifier(
                                             Spanned(
                                                 "foo",
-                                                14..17,
+                                                12..15,
                                             ),
                                         ),
-                                        14..17,
+                                        12..15,
                                     ),
                                     args: [
                                         Spanned(
                                             Identifier(
                                                 Spanned(
                                                     "a",
-                                                    18..19,
+                                                    16..17,
                                                 ),
                                             ),
-                                            18..19,
+                                            16..17,
                                         ),
                                         Spanned(
                                             Identifier(
                                                 Spanned(
                                                     "b",
-                                                    21..22,
+                                                    19..20,
                                                 ),
                                             ),
-                                            21..22,
+                                            19..20,
                                         ),
                                         Spanned(
                                             Identifier(
                                                 Spanned(
                                                     "c",
-                                                    24..25,
+                                                    22..23,
                                                 ),
                                             ),
-                                            24..25,
+                                            22..23,
                                         ),
                                     ],
                                 },
-                                14..25,
+                                12..23,
                             ),
                         ),
-                        14..28,
+                        12..26,
                     ),
                 ],
             },
-            0..30,
+            0..28,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::trailing_comma_struct_literal.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::trailing_comma_struct_literal.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { Point { x: 1, y: 2, }; }
+fn test() { Point { x: 1, y: 2, }; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { Point { x: 1, y: 2, }; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,43 +24,43 @@ func test() { Point { x: 1, y: 2, }; }
                                 StructLiteral {
                                     name: Spanned(
                                         "Point",
-                                        14..19,
+                                        12..17,
                                     ),
                                     fields: [
                                         (
                                             Spanned(
                                                 "x",
-                                                22..23,
+                                                20..21,
                                             ),
                                             Spanned(
                                                 Literal(
                                                     1,
                                                 ),
-                                                25..26,
+                                                23..24,
                                             ),
                                         ),
                                         (
                                             Spanned(
                                                 "y",
-                                                28..29,
+                                                26..27,
                                             ),
                                             Spanned(
                                                 Literal(
                                                     2,
                                                 ),
-                                                31..32,
+                                                29..30,
                                             ),
                                         ),
                                     ],
                                 },
-                                14..35,
+                                12..33,
                             ),
                         ),
-                        14..36,
+                        12..34,
                     ),
                 ],
             },
-            0..38,
+            0..36,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::unary_neg.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::unary_neg.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { -a; }
+fn test() { -a; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { -a; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -27,20 +27,20 @@ func test() { -a; }
                                         Identifier(
                                             Spanned(
                                                 "a",
-                                                15..16,
+                                                13..14,
                                             ),
                                         ),
-                                        15..16,
+                                        13..14,
                                     ),
                                 },
-                                14..16,
+                                12..14,
                             ),
                         ),
-                        14..17,
+                        12..15,
                     ),
                 ],
             },
-            0..19,
+            0..17,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/expressions::unary_not.snap
+++ b/crates/compiler/parser/tests/snapshots/expressions::unary_not.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { !a; }
+fn test() { !a; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { !a; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -27,20 +27,20 @@ func test() { !a; }
                                         Identifier(
                                             Spanned(
                                                 "a",
-                                                15..16,
+                                                13..14,
                                             ),
                                         ),
-                                        15..16,
+                                        13..14,
                                     ),
                                 },
-                                14..16,
+                                12..14,
                             ),
                         ),
-                        14..17,
+                        12..15,
                     ),
                 ],
             },
-            0..19,
+            0..17,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::break_outside_loop.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::break_outside_loop.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { break; }
+fn test() { break; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { break; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -20,11 +20,11 @@ func test() { break; }
                 body: [
                     Spanned(
                         Break,
-                        14..20,
+                        12..18,
                     ),
                 ],
             },
-            0..22,
+            0..20,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::complex_expression_statement.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::complex_expression_statement.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { obj.method().another(); }
+fn test() { obj.method().another(); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { obj.method().another(); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -32,39 +32,39 @@ func test() { obj.method().another(); }
                                                                 Identifier(
                                                                     Spanned(
                                                                         "obj",
-                                                                        14..17,
+                                                                        12..15,
                                                                     ),
                                                                 ),
-                                                                14..17,
+                                                                12..15,
                                                             ),
                                                             field: Spanned(
                                                                 "method",
-                                                                18..24,
+                                                                16..22,
                                                             ),
                                                         },
-                                                        14..24,
+                                                        12..22,
                                                     ),
                                                     args: [],
                                                 },
-                                                14..26,
+                                                12..24,
                                             ),
                                             field: Spanned(
                                                 "another",
-                                                27..34,
+                                                25..32,
                                             ),
                                         },
-                                        14..34,
+                                        12..32,
                                     ),
                                     args: [],
                                 },
-                                14..36,
+                                12..34,
                             ),
                         ),
-                        14..37,
+                        12..35,
                     ),
                 ],
             },
-            0..39,
+            0..37,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::const_statement.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::const_statement.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { const PI = 314; }
+fn test() { const PI = 314; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { const PI = 314; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -23,21 +23,21 @@ func test() { const PI = 314; }
                             ConstDef {
                                 name: Spanned(
                                     "PI",
-                                    20..22,
+                                    18..20,
                                 ),
                                 value: Spanned(
                                     Literal(
                                         314,
                                     ),
-                                    25..28,
+                                    23..26,
                                 ),
                             },
                         ),
-                        14..29,
+                        12..27,
                     ),
                 ],
             },
-            0..31,
+            0..29,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::continue_outside_loop.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::continue_outside_loop.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { continue; }
+fn test() { continue; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { continue; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -20,11 +20,11 @@ func test() { continue; }
                 body: [
                     Spanned(
                         Continue,
-                        14..23,
+                        12..21,
                     ),
                 ],
             },
-            0..25,
+            0..23,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::deep_nesting.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::deep_nesting.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { if (true) { if (false) { if (true) { if (true) { if (true) { let x = 1; } } } } } }
+fn test() { if (true) { if (false) { if (true) { if (true) { if (true) { let x = 1; } } } } } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { if (true) { if (false) { if (true) { if (true) { if (true) { let x
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,7 +24,7 @@ func test() { if (true) { if (false) { if (true) { if (true) { if (true) { let x
                                 BooleanLiteral(
                                     true,
                                 ),
-                                18..22,
+                                16..20,
                             ),
                             then_block: Spanned(
                                 Block(
@@ -35,7 +35,7 @@ func test() { if (true) { if (false) { if (true) { if (true) { if (true) { let x
                                                     BooleanLiteral(
                                                         false,
                                                     ),
-                                                    30..35,
+                                                    28..33,
                                                 ),
                                                 then_block: Spanned(
                                                     Block(
@@ -46,7 +46,7 @@ func test() { if (true) { if (false) { if (true) { if (true) { if (true) { let x
                                                                         BooleanLiteral(
                                                                             true,
                                                                         ),
-                                                                        43..47,
+                                                                        41..45,
                                                                     ),
                                                                     then_block: Spanned(
                                                                         Block(
@@ -57,7 +57,7 @@ func test() { if (true) { if (false) { if (true) { if (true) { if (true) { let x
                                                                                             BooleanLiteral(
                                                                                                 true,
                                                                                             ),
-                                                                                            55..59,
+                                                                                            53..57,
                                                                                         ),
                                                                                         then_block: Spanned(
                                                                                             Block(
@@ -68,7 +68,7 @@ func test() { if (true) { if (false) { if (true) { if (true) { if (true) { let x
                                                                                                                 BooleanLiteral(
                                                                                                                     true,
                                                                                                                 ),
-                                                                                                                67..71,
+                                                                                                                65..69,
                                                                                                             ),
                                                                                                             then_block: Spanned(
                                                                                                                 Block(
@@ -78,7 +78,7 @@ func test() { if (true) { if (false) { if (true) { if (true) { if (true) { let x
                                                                                                                                 pattern: Identifier(
                                                                                                                                     Spanned(
                                                                                                                                         "x",
-                                                                                                                                        79..80,
+                                                                                                                                        77..78,
                                                                                                                                     ),
                                                                                                                                 ),
                                                                                                                                 statement_type: None,
@@ -86,54 +86,54 @@ func test() { if (true) { if (false) { if (true) { if (true) { if (true) { let x
                                                                                                                                     Literal(
                                                                                                                                         1,
                                                                                                                                     ),
-                                                                                                                                    83..84,
+                                                                                                                                    81..82,
                                                                                                                                 ),
                                                                                                                             },
-                                                                                                                            75..85,
+                                                                                                                            73..83,
                                                                                                                         ),
                                                                                                                     ],
                                                                                                                 ),
-                                                                                                                73..87,
+                                                                                                                71..85,
                                                                                                             ),
                                                                                                             else_block: None,
                                                                                                         },
-                                                                                                        63..87,
+                                                                                                        61..85,
                                                                                                     ),
                                                                                                 ],
                                                                                             ),
-                                                                                            61..89,
+                                                                                            59..87,
                                                                                         ),
                                                                                         else_block: None,
                                                                                     },
-                                                                                    51..89,
+                                                                                    49..87,
                                                                                 ),
                                                                             ],
                                                                         ),
-                                                                        49..91,
+                                                                        47..89,
                                                                     ),
                                                                     else_block: None,
                                                                 },
-                                                                39..91,
+                                                                37..89,
                                                             ),
                                                         ],
                                                     ),
-                                                    37..93,
+                                                    35..91,
                                                 ),
                                                 else_block: None,
                                             },
-                                            26..93,
+                                            24..91,
                                         ),
                                     ],
                                 ),
-                                24..95,
+                                22..93,
                             ),
                             else_block: None,
                         },
-                        14..95,
+                        12..93,
                     ),
                 ],
             },
-            0..97,
+            0..95,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::expression_statement.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::expression_statement.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { foo(); }
+fn test() { foo(); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { foo(); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -26,21 +26,21 @@ func test() { foo(); }
                                         Identifier(
                                             Spanned(
                                                 "foo",
-                                                14..17,
+                                                12..15,
                                             ),
                                         ),
-                                        14..17,
+                                        12..15,
                                     ),
                                     args: [],
                                 },
-                                14..19,
+                                12..17,
                             ),
                         ),
-                        14..20,
+                        12..18,
                     ),
                 ],
             },
-            0..22,
+            0..20,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::for_loop_simple.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::for_loop_simple.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { for i in range { let x = i; } }
+fn test() { for i in range { let x = i; } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { for i in range { let x = i; } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -22,16 +22,16 @@ func test() { for i in range { let x = i; } }
                         For {
                             variable: Spanned(
                                 "i",
-                                18..19,
+                                16..17,
                             ),
                             iterable: Spanned(
                                 Identifier(
                                     Spanned(
                                         "range",
-                                        23..28,
+                                        21..26,
                                     ),
                                 ),
-                                23..28,
+                                21..26,
                             ),
                             body: Spanned(
                                 Block(
@@ -41,7 +41,7 @@ func test() { for i in range { let x = i; } }
                                                 pattern: Identifier(
                                                     Spanned(
                                                         "x",
-                                                        35..36,
+                                                        33..34,
                                                     ),
                                                 ),
                                                 statement_type: None,
@@ -49,24 +49,24 @@ func test() { for i in range { let x = i; } }
                                                     Identifier(
                                                         Spanned(
                                                             "i",
-                                                            39..40,
+                                                            37..38,
                                                         ),
                                                     ),
-                                                    39..40,
+                                                    37..38,
                                                 ),
                                             },
-                                            31..41,
+                                            29..39,
                                         ),
                                     ],
                                 ),
-                                29..43,
+                                27..41,
                             ),
                         },
-                        14..43,
+                        12..41,
                     ),
                 ],
             },
-            0..45,
+            0..43,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::for_loop_with_continue.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::for_loop_with_continue.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { for item in items { if (skip) { continue; } process(item); } }
+fn test() { for item in items { if (skip) { continue; } process(item); } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { for item in items { if (skip) { continue; } process(item); } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -22,16 +22,16 @@ func test() { for item in items { if (skip) { continue; } process(item); } }
                         For {
                             variable: Spanned(
                                 "item",
-                                18..22,
+                                16..20,
                             ),
                             iterable: Spanned(
                                 Identifier(
                                     Spanned(
                                         "items",
-                                        26..31,
+                                        24..29,
                                     ),
                                 ),
-                                26..31,
+                                24..29,
                             ),
                             body: Spanned(
                                 Block(
@@ -42,25 +42,25 @@ func test() { for item in items { if (skip) { continue; } process(item); } }
                                                     Identifier(
                                                         Spanned(
                                                             "skip",
-                                                            38..42,
+                                                            36..40,
                                                         ),
                                                     ),
-                                                    38..42,
+                                                    36..40,
                                                 ),
                                                 then_block: Spanned(
                                                     Block(
                                                         [
                                                             Spanned(
                                                                 Continue,
-                                                                46..55,
+                                                                44..53,
                                                             ),
                                                         ],
                                                     ),
-                                                    44..57,
+                                                    42..55,
                                                 ),
                                                 else_block: None,
                                             },
-                                            34..57,
+                                            32..55,
                                         ),
                                         Spanned(
                                             Expression(
@@ -70,38 +70,38 @@ func test() { for item in items { if (skip) { continue; } process(item); } }
                                                             Identifier(
                                                                 Spanned(
                                                                     "process",
-                                                                    58..65,
+                                                                    56..63,
                                                                 ),
                                                             ),
-                                                            58..65,
+                                                            56..63,
                                                         ),
                                                         args: [
                                                             Spanned(
                                                                 Identifier(
                                                                     Spanned(
                                                                         "item",
-                                                                        66..70,
+                                                                        64..68,
                                                                     ),
                                                                 ),
-                                                                66..70,
+                                                                64..68,
                                                             ),
                                                         ],
                                                     },
-                                                    58..70,
+                                                    56..68,
                                                 ),
                                             ),
-                                            58..72,
+                                            56..70,
                                         ),
                                     ],
                                 ),
-                                32..74,
+                                30..72,
                             ),
                         },
-                        14..74,
+                        12..72,
                     ),
                 ],
             },
-            0..76,
+            0..74,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::if_statement_nested.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::if_statement_nested.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { if (a) { if (b) { c = 1; } else { c = 2; } } }
+fn test() { if (a) { if (b) { c = 1; } else { c = 2; } } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { if (a) { if (b) { c = 1; } else { c = 2; } } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,10 +24,10 @@ func test() { if (a) { if (b) { c = 1; } else { c = 2; } } }
                                 Identifier(
                                     Spanned(
                                         "a",
-                                        18..19,
+                                        16..17,
                                     ),
                                 ),
-                                18..19,
+                                16..17,
                             ),
                             then_block: Spanned(
                                 Block(
@@ -38,10 +38,10 @@ func test() { if (a) { if (b) { c = 1; } else { c = 2; } } }
                                                     Identifier(
                                                         Spanned(
                                                             "b",
-                                                            27..28,
+                                                            25..26,
                                                         ),
                                                     ),
-                                                    27..28,
+                                                    25..26,
                                                 ),
                                                 then_block: Spanned(
                                                     Block(
@@ -52,23 +52,23 @@ func test() { if (a) { if (b) { c = 1; } else { c = 2; } } }
                                                                         Identifier(
                                                                             Spanned(
                                                                                 "c",
-                                                                                32..33,
+                                                                                30..31,
                                                                             ),
                                                                         ),
-                                                                        32..33,
+                                                                        30..31,
                                                                     ),
                                                                     rhs: Spanned(
                                                                         Literal(
                                                                             1,
                                                                         ),
-                                                                        36..37,
+                                                                        34..35,
                                                                     ),
                                                                 },
-                                                                32..38,
+                                                                30..36,
                                                             ),
                                                         ],
                                                     ),
-                                                    30..40,
+                                                    28..38,
                                                 ),
                                                 else_block: Some(
                                                     Spanned(
@@ -80,39 +80,39 @@ func test() { if (a) { if (b) { c = 1; } else { c = 2; } } }
                                                                             Identifier(
                                                                                 Spanned(
                                                                                     "c",
-                                                                                    48..49,
+                                                                                    46..47,
                                                                                 ),
                                                                             ),
-                                                                            48..49,
+                                                                            46..47,
                                                                         ),
                                                                         rhs: Spanned(
                                                                             Literal(
                                                                                 2,
                                                                             ),
-                                                                            52..53,
+                                                                            50..51,
                                                                         ),
                                                                     },
-                                                                    48..54,
+                                                                    46..52,
                                                                 ),
                                                             ],
                                                         ),
-                                                        46..56,
+                                                        44..54,
                                                     ),
                                                 ),
                                             },
-                                            23..56,
+                                            21..54,
                                         ),
                                     ],
                                 ),
-                                21..58,
+                                19..56,
                             ),
                             else_block: None,
                         },
-                        14..58,
+                        12..56,
                     ),
                 ],
             },
-            0..60,
+            0..58,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::if_statement_simple.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::if_statement_simple.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { if (condition) { x = 1; } }
+fn test() { if (condition) { x = 1; } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { if (condition) { x = 1; } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,10 +24,10 @@ func test() { if (condition) { x = 1; } }
                                 Identifier(
                                     Spanned(
                                         "condition",
-                                        18..27,
+                                        16..25,
                                     ),
                                 ),
-                                18..27,
+                                16..25,
                             ),
                             then_block: Spanned(
                                 Block(
@@ -38,31 +38,31 @@ func test() { if (condition) { x = 1; } }
                                                     Identifier(
                                                         Spanned(
                                                             "x",
-                                                            31..32,
+                                                            29..30,
                                                         ),
                                                     ),
-                                                    31..32,
+                                                    29..30,
                                                 ),
                                                 rhs: Spanned(
                                                     Literal(
                                                         1,
                                                     ),
-                                                    35..36,
+                                                    33..34,
                                                 ),
                                             },
-                                            31..37,
+                                            29..35,
                                         ),
                                     ],
                                 ),
-                                29..39,
+                                27..37,
                             ),
                             else_block: None,
                         },
-                        14..39,
+                        12..37,
                     ),
                 ],
             },
-            0..41,
+            0..39,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::if_statement_with_else.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::if_statement_with_else.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { if (a == b) { return a; } else { return b; } }
+fn test() { if (a == b) { return a; } else { return b; } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { if (a == b) { return a; } else { return b; } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -27,22 +27,22 @@ func test() { if (a == b) { return a; } else { return b; } }
                                         Identifier(
                                             Spanned(
                                                 "a",
-                                                18..19,
+                                                16..17,
                                             ),
                                         ),
-                                        18..19,
+                                        16..17,
                                     ),
                                     right: Spanned(
                                         Identifier(
                                             Spanned(
                                                 "b",
-                                                23..24,
+                                                21..22,
                                             ),
                                         ),
-                                        23..24,
+                                        21..22,
                                     ),
                                 },
-                                18..24,
+                                16..22,
                             ),
                             then_block: Spanned(
                                 Block(
@@ -54,18 +54,18 @@ func test() { if (a == b) { return a; } else { return b; } }
                                                         Identifier(
                                                             Spanned(
                                                                 "a",
-                                                                35..36,
+                                                                33..34,
                                                             ),
                                                         ),
-                                                        35..36,
+                                                        33..34,
                                                     ),
                                                 ),
                                             },
-                                            28..37,
+                                            26..35,
                                         ),
                                     ],
                                 ),
-                                26..39,
+                                24..37,
                             ),
                             else_block: Some(
                                 Spanned(
@@ -78,26 +78,26 @@ func test() { if (a == b) { return a; } else { return b; } }
                                                             Identifier(
                                                                 Spanned(
                                                                     "b",
-                                                                    54..55,
+                                                                    52..53,
                                                                 ),
                                                             ),
-                                                            54..55,
+                                                            52..53,
                                                         ),
                                                     ),
                                                 },
-                                                47..56,
+                                                45..54,
                                             ),
                                         ],
                                     ),
-                                    45..58,
+                                    43..56,
                                 ),
                             ),
                         },
-                        14..58,
+                        12..56,
                     ),
                 ],
             },
-            0..60,
+            0..58,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::index_assignment.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::index_assignment.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { arr[0] = item; }
+fn test() { arr[0] = item; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { arr[0] = item; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -26,35 +26,35 @@ func test() { arr[0] = item; }
                                         Identifier(
                                             Spanned(
                                                 "arr",
-                                                14..17,
+                                                12..15,
                                             ),
                                         ),
-                                        14..17,
+                                        12..15,
                                     ),
                                     index: Spanned(
                                         Literal(
                                             0,
                                         ),
-                                        18..19,
+                                        16..17,
                                     ),
                                 },
-                                14..19,
+                                12..17,
                             ),
                             rhs: Spanned(
                                 Identifier(
                                     Spanned(
                                         "item",
-                                        23..27,
+                                        21..25,
                                     ),
                                 ),
-                                23..27,
+                                21..25,
                             ),
                         },
-                        14..28,
+                        12..26,
                     ),
                 ],
             },
-            0..30,
+            0..28,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::let_statement_simple.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::let_statement_simple.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { let x = 5; }
+fn test() { let x = 5; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { let x = 5; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -23,7 +23,7 @@ func test() { let x = 5; }
                             pattern: Identifier(
                                 Spanned(
                                     "x",
-                                    18..19,
+                                    16..17,
                                 ),
                             ),
                             statement_type: None,
@@ -31,14 +31,14 @@ func test() { let x = 5; }
                                 Literal(
                                     5,
                                 ),
-                                22..23,
+                                20..21,
                             ),
                         },
-                        14..24,
+                        12..22,
                     ),
                 ],
             },
-            0..26,
+            0..24,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::let_statement_with_expression.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::let_statement_with_expression.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { let result = a + b * c; }
+fn test() { let result = a + b * c; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { let result = a + b * c; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -23,7 +23,7 @@ func test() { let result = a + b * c; }
                             pattern: Identifier(
                                 Spanned(
                                     "result",
-                                    18..24,
+                                    16..22,
                                 ),
                             ),
                             statement_type: None,
@@ -34,10 +34,10 @@ func test() { let result = a + b * c; }
                                         Identifier(
                                             Spanned(
                                                 "a",
-                                                27..28,
+                                                25..26,
                                             ),
                                         ),
-                                        27..28,
+                                        25..26,
                                     ),
                                     right: Spanned(
                                         BinaryOp {
@@ -46,32 +46,32 @@ func test() { let result = a + b * c; }
                                                 Identifier(
                                                     Spanned(
                                                         "b",
-                                                        31..32,
+                                                        29..30,
                                                     ),
                                                 ),
-                                                31..32,
+                                                29..30,
                                             ),
                                             right: Spanned(
                                                 Identifier(
                                                     Spanned(
                                                         "c",
-                                                        35..36,
+                                                        33..34,
                                                     ),
                                                 ),
-                                                35..36,
+                                                33..34,
                                             ),
                                         },
-                                        31..36,
+                                        29..34,
                                     ),
                                 },
-                                27..36,
+                                25..34,
                             ),
                         },
-                        14..37,
+                        12..35,
                     ),
                 ],
             },
-            0..39,
+            0..37,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::let_statement_with_type.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::let_statement_with_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { let x: felt = 5; }
+fn test() { let x: felt = 5; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { let x: felt = 5; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -23,7 +23,7 @@ func test() { let x: felt = 5; }
                             pattern: Identifier(
                                 Spanned(
                                     "x",
-                                    18..19,
+                                    16..17,
                                 ),
                             ),
                             statement_type: Some(
@@ -35,14 +35,14 @@ func test() { let x: felt = 5; }
                                 Literal(
                                     5,
                                 ),
-                                28..29,
+                                26..27,
                             ),
                         },
-                        14..30,
+                        12..28,
                     ),
                 ],
             },
-            0..32,
+            0..30,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::let_tuple_destructuring_two_elements.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::let_tuple_destructuring_two_elements.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { let (x, y) = (1, 2); }
+fn test() { let (x, y) = (1, 2); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { let (x, y) = (1, 2); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,11 +24,11 @@ func test() { let (x, y) = (1, 2); }
                                 [
                                     Spanned(
                                         "x",
-                                        19..20,
+                                        17..18,
                                     ),
                                     Spanned(
                                         "y",
-                                        22..23,
+                                        20..21,
                                     ),
                                 ],
                             ),
@@ -40,24 +40,24 @@ func test() { let (x, y) = (1, 2); }
                                             Literal(
                                                 1,
                                             ),
-                                            28..29,
+                                            26..27,
                                         ),
                                         Spanned(
                                             Literal(
                                                 2,
                                             ),
-                                            31..32,
+                                            29..30,
                                         ),
                                     ],
                                 ),
-                                27..33,
+                                25..31,
                             ),
                         },
-                        14..34,
+                        12..32,
                     ),
                 ],
             },
-            0..36,
+            0..34,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::let_tuple_destructuring_with_type.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::let_tuple_destructuring_with_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { let (x, y): (felt, felt) = (1, 2); }
+fn test() { let (x, y): (felt, felt) = (1, 2); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { let (x, y): (felt, felt) = (1, 2); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,11 +24,11 @@ func test() { let (x, y): (felt, felt) = (1, 2); }
                                 [
                                     Spanned(
                                         "x",
-                                        19..20,
+                                        17..18,
                                     ),
                                     Spanned(
                                         "y",
-                                        22..23,
+                                        20..21,
                                     ),
                                 ],
                             ),
@@ -51,24 +51,24 @@ func test() { let (x, y): (felt, felt) = (1, 2); }
                                             Literal(
                                                 1,
                                             ),
-                                            42..43,
+                                            40..41,
                                         ),
                                         Spanned(
                                             Literal(
                                                 2,
                                             ),
-                                            45..46,
+                                            43..44,
                                         ),
                                     ],
                                 ),
-                                41..47,
+                                39..45,
                             ),
                         },
-                        14..48,
+                        12..46,
                     ),
                 ],
             },
-            0..50,
+            0..48,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::local_statement_with_type.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::local_statement_with_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { local x: felt = 42; }
+fn test() { local x: felt = 42; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { local x: felt = 42; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -23,7 +23,7 @@ func test() { local x: felt = 42; }
                             pattern: Identifier(
                                 Spanned(
                                     "x",
-                                    20..21,
+                                    18..19,
                                 ),
                             ),
                             ty: Some(
@@ -35,14 +35,14 @@ func test() { local x: felt = 42; }
                                 Literal(
                                     42,
                                 ),
-                                30..32,
+                                28..30,
                             ),
                         },
-                        14..33,
+                        12..31,
                     ),
                 ],
             },
-            0..35,
+            0..33,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::local_statement_without_type.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::local_statement_without_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { local x = infer_me; }
+fn test() { local x = infer_me; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { local x = infer_me; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -23,7 +23,7 @@ func test() { local x = infer_me; }
                             pattern: Identifier(
                                 Spanned(
                                     "x",
-                                    20..21,
+                                    18..19,
                                 ),
                             ),
                             ty: None,
@@ -31,17 +31,17 @@ func test() { local x = infer_me; }
                                 Identifier(
                                     Spanned(
                                         "infer_me",
-                                        24..32,
+                                        22..30,
                                     ),
                                 ),
-                                24..32,
+                                22..30,
                             ),
                         },
-                        14..33,
+                        12..31,
                     ),
                 ],
             },
-            0..35,
+            0..33,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::local_tuple_destructuring.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::local_tuple_destructuring.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { local (x, y) = (5, 10); }
+fn test() { local (x, y) = (5, 10); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { local (x, y) = (5, 10); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,11 +24,11 @@ func test() { local (x, y) = (5, 10); }
                                 [
                                     Spanned(
                                         "x",
-                                        21..22,
+                                        19..20,
                                     ),
                                     Spanned(
                                         "y",
-                                        24..25,
+                                        22..23,
                                     ),
                                 ],
                             ),
@@ -40,24 +40,24 @@ func test() { local (x, y) = (5, 10); }
                                             Literal(
                                                 5,
                                             ),
-                                            30..31,
+                                            28..29,
                                         ),
                                         Spanned(
                                             Literal(
                                                 10,
                                             ),
-                                            33..35,
+                                            31..33,
                                         ),
                                     ],
                                 ),
-                                29..36,
+                                27..34,
                             ),
                         },
-                        14..37,
+                        12..35,
                     ),
                 ],
             },
-            0..39,
+            0..37,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::local_tuple_destructuring_with_type.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::local_tuple_destructuring_with_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { local (a, b): (felt, felt) = (100, 200); }
+fn test() { local (a, b): (felt, felt) = (100, 200); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { local (a, b): (felt, felt) = (100, 200); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,11 +24,11 @@ func test() { local (a, b): (felt, felt) = (100, 200); }
                                 [
                                     Spanned(
                                         "a",
-                                        21..22,
+                                        19..20,
                                     ),
                                     Spanned(
                                         "b",
-                                        24..25,
+                                        22..23,
                                     ),
                                 ],
                             ),
@@ -51,24 +51,24 @@ func test() { local (a, b): (felt, felt) = (100, 200); }
                                             Literal(
                                                 100,
                                             ),
-                                            44..47,
+                                            42..45,
                                         ),
                                         Spanned(
                                             Literal(
                                                 200,
                                             ),
-                                            49..52,
+                                            47..50,
                                         ),
                                     ],
                                 ),
-                                43..53,
+                                41..51,
                             ),
                         },
-                        14..54,
+                        12..52,
                     ),
                 ],
             },
-            0..56,
+            0..54,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::loop_in_if.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::loop_in_if.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { if (condition) { loop { work(); if (done) { break; } } } }
+fn test() { if (condition) { loop { work(); if (done) { break; } } } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { if (condition) { loop { work(); if (done) { break; } } } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,10 +24,10 @@ func test() { if (condition) { loop { work(); if (done) { break; } } } }
                                 Identifier(
                                     Spanned(
                                         "condition",
-                                        18..27,
+                                        16..25,
                                     ),
                                 ),
-                                18..27,
+                                16..25,
                             ),
                             then_block: Spanned(
                                 Block(
@@ -45,17 +45,17 @@ func test() { if (condition) { loop { work(); if (done) { break; } } } }
                                                                                 Identifier(
                                                                                     Spanned(
                                                                                         "work",
-                                                                                        38..42,
+                                                                                        36..40,
                                                                                     ),
                                                                                 ),
-                                                                                38..42,
+                                                                                36..40,
                                                                             ),
                                                                             args: [],
                                                                         },
-                                                                        38..44,
+                                                                        36..42,
                                                                     ),
                                                                 ),
-                                                                38..45,
+                                                                36..43,
                                                             ),
                                                             Spanned(
                                                                 If {
@@ -63,44 +63,44 @@ func test() { if (condition) { loop { work(); if (done) { break; } } } }
                                                                         Identifier(
                                                                             Spanned(
                                                                                 "done",
-                                                                                50..54,
+                                                                                48..52,
                                                                             ),
                                                                         ),
-                                                                        50..54,
+                                                                        48..52,
                                                                     ),
                                                                     then_block: Spanned(
                                                                         Block(
                                                                             [
                                                                                 Spanned(
                                                                                     Break,
-                                                                                    58..64,
+                                                                                    56..62,
                                                                                 ),
                                                                             ],
                                                                         ),
-                                                                        56..66,
+                                                                        54..64,
                                                                     ),
                                                                     else_block: None,
                                                                 },
-                                                                46..66,
+                                                                44..64,
                                                             ),
                                                         ],
                                                     ),
-                                                    36..68,
+                                                    34..66,
                                                 ),
                                             },
-                                            31..68,
+                                            29..66,
                                         ),
                                     ],
                                 ),
-                                29..70,
+                                27..68,
                             ),
                             else_block: None,
                         },
-                        14..70,
+                        12..68,
                     ),
                 ],
             },
-            0..72,
+            0..70,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::loop_with_break.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::loop_with_break.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { loop { break; } }
+fn test() { loop { break; } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { loop { break; } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -25,18 +25,18 @@ func test() { loop { break; } }
                                     [
                                         Spanned(
                                             Break,
-                                            21..27,
+                                            19..25,
                                         ),
                                     ],
                                 ),
-                                19..29,
+                                17..27,
                             ),
                         },
-                        14..29,
+                        12..27,
                     ),
                 ],
             },
-            0..31,
+            0..29,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::loop_with_continue.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::loop_with_continue.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { loop { continue; } }
+fn test() { loop { continue; } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { loop { continue; } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -25,18 +25,18 @@ func test() { loop { continue; } }
                                     [
                                         Spanned(
                                             Continue,
-                                            21..30,
+                                            19..28,
                                         ),
                                     ],
                                 ),
-                                19..32,
+                                17..30,
                             ),
                         },
-                        14..32,
+                        12..30,
                     ),
                 ],
             },
-            0..34,
+            0..32,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::member_assignment.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::member_assignment.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { obj.field = value; }
+fn test() { obj.field = value; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { obj.field = value; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -26,33 +26,33 @@ func test() { obj.field = value; }
                                         Identifier(
                                             Spanned(
                                                 "obj",
-                                                14..17,
+                                                12..15,
                                             ),
                                         ),
-                                        14..17,
+                                        12..15,
                                     ),
                                     field: Spanned(
                                         "field",
-                                        18..23,
+                                        16..21,
                                     ),
                                 },
-                                14..23,
+                                12..21,
                             ),
                             rhs: Spanned(
                                 Identifier(
                                     Spanned(
                                         "value",
-                                        26..31,
+                                        24..29,
                                     ),
                                 ),
-                                26..31,
+                                24..29,
                             ),
                         },
-                        14..32,
+                        12..30,
                     ),
                 ],
             },
-            0..34,
+            0..32,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::nested_blocks.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::nested_blocks.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { { { let inner = 1; } let outer = 2; } }
+fn test() { { { let inner = 1; } let outer = 2; } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { { { let inner = 1; } let outer = 2; } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -29,7 +29,7 @@ func test() { { { let inner = 1; } let outer = 2; } }
                                                     pattern: Identifier(
                                                         Spanned(
                                                             "inner",
-                                                            22..27,
+                                                            20..25,
                                                         ),
                                                     ),
                                                     statement_type: None,
@@ -37,21 +37,21 @@ func test() { { { let inner = 1; } let outer = 2; } }
                                                         Literal(
                                                             1,
                                                         ),
-                                                        30..31,
+                                                        28..29,
                                                     ),
                                                 },
-                                                18..32,
+                                                16..30,
                                             ),
                                         ],
                                     ),
-                                    16..34,
+                                    14..32,
                                 ),
                                 Spanned(
                                     Let {
                                         pattern: Identifier(
                                             Spanned(
                                                 "outer",
-                                                39..44,
+                                                37..42,
                                             ),
                                         ),
                                         statement_type: None,
@@ -59,18 +59,18 @@ func test() { { { let inner = 1; } let outer = 2; } }
                                             Literal(
                                                 2,
                                             ),
-                                            47..48,
+                                            45..46,
                                         ),
                                     },
-                                    35..49,
+                                    33..47,
                                 ),
                             ],
                         ),
-                        14..51,
+                        12..49,
                     ),
                 ],
             },
-            0..53,
+            0..51,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::nested_loops.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::nested_loops.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { while (outer) { for inner in items { if (found) { break; } } } }
+fn test() { while (outer) { for inner in items { if (found) { break; } } } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { while (outer) { for inner in items { if (found) { break; } } } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,10 +24,10 @@ func test() { while (outer) { for inner in items { if (found) { break; } } } }
                                 Identifier(
                                     Spanned(
                                         "outer",
-                                        21..26,
+                                        19..24,
                                     ),
                                 ),
-                                21..26,
+                                19..24,
                             ),
                             body: Spanned(
                                 Block(
@@ -36,16 +36,16 @@ func test() { while (outer) { for inner in items { if (found) { break; } } } }
                                             For {
                                                 variable: Spanned(
                                                     "inner",
-                                                    34..39,
+                                                    32..37,
                                                 ),
                                                 iterable: Spanned(
                                                     Identifier(
                                                         Spanned(
                                                             "items",
-                                                            43..48,
+                                                            41..46,
                                                         ),
                                                     ),
-                                                    43..48,
+                                                    41..46,
                                                 ),
                                                 body: Spanned(
                                                     Block(
@@ -56,43 +56,43 @@ func test() { while (outer) { for inner in items { if (found) { break; } } } }
                                                                         Identifier(
                                                                             Spanned(
                                                                                 "found",
-                                                                                55..60,
+                                                                                53..58,
                                                                             ),
                                                                         ),
-                                                                        55..60,
+                                                                        53..58,
                                                                     ),
                                                                     then_block: Spanned(
                                                                         Block(
                                                                             [
                                                                                 Spanned(
                                                                                     Break,
-                                                                                    64..70,
+                                                                                    62..68,
                                                                                 ),
                                                                             ],
                                                                         ),
-                                                                        62..72,
+                                                                        60..70,
                                                                     ),
                                                                     else_block: None,
                                                                 },
-                                                                51..72,
+                                                                49..70,
                                                             ),
                                                         ],
                                                     ),
-                                                    49..74,
+                                                    47..72,
                                                 ),
                                             },
-                                            30..74,
+                                            28..72,
                                         ),
                                     ],
                                 ),
-                                28..76,
+                                26..74,
                             ),
                         },
-                        14..76,
+                        12..74,
                     ),
                 ],
             },
-            0..78,
+            0..76,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::return_with_value.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::return_with_value.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { return 42; }
+fn test() { return 42; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { return 42; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -25,15 +25,15 @@ func test() { return 42; }
                                     Literal(
                                         42,
                                     ),
-                                    21..23,
+                                    19..21,
                                 ),
                             ),
                         },
-                        14..24,
+                        12..22,
                     ),
                 ],
             },
-            0..26,
+            0..24,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::return_without_value.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::return_without_value.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { return; }
+fn test() { return; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { return; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -22,11 +22,11 @@ func test() { return; }
                         Return {
                             value: None,
                         },
-                        14..21,
+                        12..19,
                     ),
                 ],
             },
-            0..23,
+            0..21,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::simple_assignment.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::simple_assignment.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { x = 5; }
+fn test() { x = 5; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { x = 5; }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,23 +24,23 @@ func test() { x = 5; }
                                 Identifier(
                                     Spanned(
                                         "x",
-                                        14..15,
+                                        12..13,
                                     ),
                                 ),
-                                14..15,
+                                12..13,
                             ),
                             rhs: Spanned(
                                 Literal(
                                     5,
                                 ),
-                                18..19,
+                                16..17,
                             ),
                         },
-                        14..20,
+                        12..18,
                     ),
                 ],
             },
-            0..22,
+            0..20,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::simple_block.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::simple_block.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { { let x = 1; let y = 2; } }
+fn test() { { let x = 1; let y = 2; } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { { let x = 1; let y = 2; } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -26,7 +26,7 @@ func test() { { let x = 1; let y = 2; } }
                                         pattern: Identifier(
                                             Spanned(
                                                 "x",
-                                                20..21,
+                                                18..19,
                                             ),
                                         ),
                                         statement_type: None,
@@ -34,17 +34,17 @@ func test() { { let x = 1; let y = 2; } }
                                             Literal(
                                                 1,
                                             ),
-                                            24..25,
+                                            22..23,
                                         ),
                                     },
-                                    16..26,
+                                    14..24,
                                 ),
                                 Spanned(
                                     Let {
                                         pattern: Identifier(
                                             Spanned(
                                                 "y",
-                                                31..32,
+                                                29..30,
                                             ),
                                         ),
                                         statement_type: None,
@@ -52,18 +52,18 @@ func test() { { let x = 1; let y = 2; } }
                                             Literal(
                                                 2,
                                             ),
-                                            35..36,
+                                            33..34,
                                         ),
                                     },
-                                    27..37,
+                                    25..35,
                                 ),
                             ],
                         ),
-                        14..39,
+                        12..37,
                     ),
                 ],
             },
-            0..41,
+            0..39,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::simple_loop.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::simple_loop.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { loop { let x = 1; } }
+fn test() { loop { let x = 1; } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { loop { let x = 1; } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -28,7 +28,7 @@ func test() { loop { let x = 1; } }
                                                 pattern: Identifier(
                                                     Spanned(
                                                         "x",
-                                                        25..26,
+                                                        23..24,
                                                     ),
                                                 ),
                                                 statement_type: None,
@@ -36,21 +36,21 @@ func test() { loop { let x = 1; } }
                                                     Literal(
                                                         1,
                                                     ),
-                                                    29..30,
+                                                    27..28,
                                                 ),
                                             },
-                                            21..31,
+                                            19..29,
                                         ),
                                     ],
                                 ),
-                                19..33,
+                                17..31,
                             ),
                         },
-                        14..33,
+                        12..31,
                     ),
                 ],
             },
-            0..35,
+            0..33,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::tuple_destructuring_complex_rhs.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::tuple_destructuring_complex_rhs.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { let (sum, diff) = (a + b, a - b); }
+fn test() { let (sum, diff) = (a + b, a - b); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { let (sum, diff) = (a + b, a - b); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,11 +24,11 @@ func test() { let (sum, diff) = (a + b, a - b); }
                                 [
                                     Spanned(
                                         "sum",
-                                        19..22,
+                                        17..20,
                                     ),
                                     Spanned(
                                         "diff",
-                                        24..28,
+                                        22..26,
                                     ),
                                 ],
                             ),
@@ -43,22 +43,22 @@ func test() { let (sum, diff) = (a + b, a - b); }
                                                     Identifier(
                                                         Spanned(
                                                             "a",
-                                                            33..34,
+                                                            31..32,
                                                         ),
                                                     ),
-                                                    33..34,
+                                                    31..32,
                                                 ),
                                                 right: Spanned(
                                                     Identifier(
                                                         Spanned(
                                                             "b",
-                                                            37..38,
+                                                            35..36,
                                                         ),
                                                     ),
-                                                    37..38,
+                                                    35..36,
                                                 ),
                                             },
-                                            33..38,
+                                            31..36,
                                         ),
                                         Spanned(
                                             BinaryOp {
@@ -67,33 +67,33 @@ func test() { let (sum, diff) = (a + b, a - b); }
                                                     Identifier(
                                                         Spanned(
                                                             "a",
-                                                            40..41,
+                                                            38..39,
                                                         ),
                                                     ),
-                                                    40..41,
+                                                    38..39,
                                                 ),
                                                 right: Spanned(
                                                     Identifier(
                                                         Spanned(
                                                             "b",
-                                                            44..45,
+                                                            42..43,
                                                         ),
                                                     ),
-                                                    44..45,
+                                                    42..43,
                                                 ),
                                             },
-                                            40..45,
+                                            38..43,
                                         ),
                                     ],
                                 ),
-                                32..46,
+                                30..44,
                             ),
                         },
-                        14..47,
+                        12..45,
                     ),
                 ],
             },
-            0..49,
+            0..47,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::tuple_destructuring_from_function_call.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::tuple_destructuring_from_function_call.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { let (x, y) = get_pair(); }
+fn test() { let (x, y) = get_pair(); }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { let (x, y) = get_pair(); }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,11 +24,11 @@ func test() { let (x, y) = get_pair(); }
                                 [
                                     Spanned(
                                         "x",
-                                        19..20,
+                                        17..18,
                                     ),
                                     Spanned(
                                         "y",
-                                        22..23,
+                                        20..21,
                                     ),
                                 ],
                             ),
@@ -39,21 +39,21 @@ func test() { let (x, y) = get_pair(); }
                                         Identifier(
                                             Spanned(
                                                 "get_pair",
-                                                27..35,
+                                                25..33,
                                             ),
                                         ),
-                                        27..35,
+                                        25..33,
                                     ),
                                     args: [],
                                 },
-                                27..37,
+                                25..35,
                             ),
                         },
-                        14..38,
+                        12..36,
                     ),
                 ],
             },
-            0..40,
+            0..38,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::while_loop_simple.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::while_loop_simple.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { while (x != 10) { x = x + 1; } }
+fn test() { while (x != 10) { x = x + 1; } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { while (x != 10) { x = x + 1; } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -27,19 +27,19 @@ func test() { while (x != 10) { x = x + 1; } }
                                         Identifier(
                                             Spanned(
                                                 "x",
-                                                21..22,
+                                                19..20,
                                             ),
                                         ),
-                                        21..22,
+                                        19..20,
                                     ),
                                     right: Spanned(
                                         Literal(
                                             10,
                                         ),
-                                        26..28,
+                                        24..26,
                                     ),
                                 },
-                                21..28,
+                                19..26,
                             ),
                             body: Spanned(
                                 Block(
@@ -50,10 +50,10 @@ func test() { while (x != 10) { x = x + 1; } }
                                                     Identifier(
                                                         Spanned(
                                                             "x",
-                                                            32..33,
+                                                            30..31,
                                                         ),
                                                     ),
-                                                    32..33,
+                                                    30..31,
                                                 ),
                                                 rhs: Spanned(
                                                     BinaryOp {
@@ -62,33 +62,33 @@ func test() { while (x != 10) { x = x + 1; } }
                                                             Identifier(
                                                                 Spanned(
                                                                     "x",
-                                                                    36..37,
+                                                                    34..35,
                                                                 ),
                                                             ),
-                                                            36..37,
+                                                            34..35,
                                                         ),
                                                         right: Spanned(
                                                             Literal(
                                                                 1,
                                                             ),
-                                                            40..41,
+                                                            38..39,
                                                         ),
                                                     },
-                                                    36..41,
+                                                    34..39,
                                                 ),
                                             },
-                                            32..42,
+                                            30..40,
                                         ),
                                     ],
                                 ),
-                                30..44,
+                                28..42,
                             ),
                         },
-                        14..44,
+                        12..42,
                     ),
                 ],
             },
-            0..46,
+            0..44,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/statements::while_loop_with_break.snap
+++ b/crates/compiler/parser/tests/snapshots/statements::while_loop_with_break.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test() { while (true) { if (done) { break; } } }
+fn test() { while (true) { if (done) { break; } } }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func test() { while (true) { if (done) { break; } } }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -24,7 +24,7 @@ func test() { while (true) { if (done) { break; } } }
                                 BooleanLiteral(
                                     true,
                                 ),
-                                21..25,
+                                19..23,
                             ),
                             body: Spanned(
                                 Block(
@@ -35,36 +35,36 @@ func test() { while (true) { if (done) { break; } } }
                                                     Identifier(
                                                         Spanned(
                                                             "done",
-                                                            33..37,
+                                                            31..35,
                                                         ),
                                                     ),
-                                                    33..37,
+                                                    31..35,
                                                 ),
                                                 then_block: Spanned(
                                                     Block(
                                                         [
                                                             Spanned(
                                                                 Break,
-                                                                41..47,
+                                                                39..45,
                                                             ),
                                                         ],
                                                     ),
-                                                    39..49,
+                                                    37..47,
                                                 ),
                                                 else_block: None,
                                             },
-                                            29..49,
+                                            27..47,
                                         ),
                                     ],
                                 ),
-                                27..51,
+                                25..49,
                             ),
                         },
-                        14..51,
+                        12..49,
                     ),
                 ],
             },
-            0..53,
+            0..51,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/toplevel::complete_program.snap
+++ b/crates/compiler/parser/tests/snapshots/toplevel::complete_program.snap
@@ -10,11 +10,11 @@ expression: snapshot
         }
 
         namespace MathUtils {
-            func magnitude(v: Vector) -> felt {
+            fn magnitude(v: Vector) -> felt {
                 return (v.x * v.x + v.y * v.y);
             }
 
-            func rfib(n: felt) -> felt {
+            fn rfib(n: felt) -> felt {
                 if (n == 0) {
                     return 0;
                 }
@@ -73,13 +73,13 @@ expression: snapshot
                             FunctionDef {
                                 name: Spanned(
                                     "magnitude",
-                                    124..133,
+                                    122..131,
                                 ),
                                 params: [
                                     Parameter {
                                         name: Spanned(
                                             "v",
-                                            134..135,
+                                            132..133,
                                         ),
                                         type_expr: Named(
                                             "Vector",
@@ -105,17 +105,17 @@ expression: snapshot
                                                                             Identifier(
                                                                                 Spanned(
                                                                                     "v",
-                                                                                    179..180,
+                                                                                    177..178,
                                                                                 ),
                                                                             ),
-                                                                            179..180,
+                                                                            177..178,
                                                                         ),
                                                                         field: Spanned(
                                                                             "x",
-                                                                            181..182,
+                                                                            179..180,
                                                                         ),
                                                                     },
-                                                                    179..182,
+                                                                    177..180,
                                                                 ),
                                                                 right: Spanned(
                                                                     MemberAccess {
@@ -123,20 +123,20 @@ expression: snapshot
                                                                             Identifier(
                                                                                 Spanned(
                                                                                     "v",
-                                                                                    185..186,
+                                                                                    183..184,
                                                                                 ),
                                                                             ),
-                                                                            185..186,
+                                                                            183..184,
                                                                         ),
                                                                         field: Spanned(
                                                                             "x",
-                                                                            187..188,
+                                                                            185..186,
                                                                         ),
                                                                     },
-                                                                    185..188,
+                                                                    183..186,
                                                                 ),
                                                             },
-                                                            179..188,
+                                                            177..186,
                                                         ),
                                                         right: Spanned(
                                                             BinaryOp {
@@ -147,17 +147,17 @@ expression: snapshot
                                                                             Identifier(
                                                                                 Spanned(
                                                                                     "v",
-                                                                                    191..192,
+                                                                                    189..190,
                                                                                 ),
                                                                             ),
-                                                                            191..192,
+                                                                            189..190,
                                                                         ),
                                                                         field: Spanned(
                                                                             "y",
-                                                                            193..194,
+                                                                            191..192,
                                                                         ),
                                                                     },
-                                                                    191..194,
+                                                                    189..192,
                                                                 ),
                                                                 right: Spanned(
                                                                     MemberAccess {
@@ -165,31 +165,31 @@ expression: snapshot
                                                                             Identifier(
                                                                                 Spanned(
                                                                                     "v",
-                                                                                    197..198,
+                                                                                    195..196,
                                                                                 ),
                                                                             ),
-                                                                            197..198,
+                                                                            195..196,
                                                                         ),
                                                                         field: Spanned(
                                                                             "y",
-                                                                            199..200,
+                                                                            197..198,
                                                                         ),
                                                                     },
-                                                                    197..200,
+                                                                    195..198,
                                                                 ),
                                                             },
-                                                            191..200,
+                                                            189..198,
                                                         ),
                                                     },
-                                                    178..201,
+                                                    176..199,
                                                 ),
                                             ),
                                         },
-                                        171..202,
+                                        169..200,
                                     ),
                                 ],
                             },
-                            119..216,
+                            119..214,
                         ),
                     ),
                     Function(
@@ -197,13 +197,13 @@ expression: snapshot
                             FunctionDef {
                                 name: Spanned(
                                     "rfib",
-                                    235..239,
+                                    231..235,
                                 ),
                                 params: [
                                     Parameter {
                                         name: Spanned(
                                             "n",
-                                            240..241,
+                                            236..237,
                                         ),
                                         type_expr: Named(
                                             "felt",
@@ -223,19 +223,19 @@ expression: snapshot
                                                         Identifier(
                                                             Spanned(
                                                                 "n",
-                                                                279..280,
+                                                                275..276,
                                                             ),
                                                         ),
-                                                        279..280,
+                                                        275..276,
                                                     ),
                                                     right: Spanned(
                                                         Literal(
                                                             0,
                                                         ),
-                                                        284..285,
+                                                        280..281,
                                                     ),
                                                 },
-                                                279..285,
+                                                275..281,
                                             ),
                                             then_block: Spanned(
                                                 Block(
@@ -247,19 +247,19 @@ expression: snapshot
                                                                         Literal(
                                                                             0,
                                                                         ),
-                                                                        316..317,
+                                                                        312..313,
                                                                     ),
                                                                 ),
                                                             },
-                                                            309..318,
+                                                            305..314,
                                                         ),
                                                     ],
                                                 ),
-                                                287..336,
+                                                283..332,
                                             ),
                                             else_block: None,
                                         },
-                                        275..336,
+                                        271..332,
                                     ),
                                     Spanned(
                                         If {
@@ -270,19 +270,19 @@ expression: snapshot
                                                         Identifier(
                                                             Spanned(
                                                                 "n",
-                                                                357..358,
+                                                                353..354,
                                                             ),
                                                         ),
-                                                        357..358,
+                                                        353..354,
                                                     ),
                                                     right: Spanned(
                                                         Literal(
                                                             1,
                                                         ),
-                                                        362..363,
+                                                        358..359,
                                                     ),
                                                 },
-                                                357..363,
+                                                353..359,
                                             ),
                                             then_block: Spanned(
                                                 Block(
@@ -294,19 +294,19 @@ expression: snapshot
                                                                         Literal(
                                                                             1,
                                                                         ),
-                                                                        394..395,
+                                                                        390..391,
                                                                     ),
                                                                 ),
                                                             },
-                                                            387..396,
+                                                            383..392,
                                                         ),
                                                     ],
                                                 ),
-                                                365..414,
+                                                361..410,
                                             ),
                                             else_block: None,
                                         },
-                                        353..414,
+                                        349..410,
                                     ),
                                     Spanned(
                                         Return {
@@ -320,10 +320,10 @@ expression: snapshot
                                                                     Identifier(
                                                                         Spanned(
                                                                             "rfib",
-                                                                            438..442,
+                                                                            434..438,
                                                                         ),
                                                                     ),
-                                                                    438..442,
+                                                                    434..438,
                                                                 ),
                                                                 args: [
                                                                     Spanned(
@@ -333,23 +333,23 @@ expression: snapshot
                                                                                 Identifier(
                                                                                     Spanned(
                                                                                         "n",
-                                                                                        443..444,
+                                                                                        439..440,
                                                                                     ),
                                                                                 ),
-                                                                                443..444,
+                                                                                439..440,
                                                                             ),
                                                                             right: Spanned(
                                                                                 Literal(
                                                                                     1,
                                                                                 ),
-                                                                                447..448,
+                                                                                443..444,
                                                                             ),
                                                                         },
-                                                                        443..448,
+                                                                        439..444,
                                                                     ),
                                                                 ],
                                                             },
-                                                            438..448,
+                                                            434..444,
                                                         ),
                                                         right: Spanned(
                                                             FunctionCall {
@@ -357,10 +357,10 @@ expression: snapshot
                                                                     Identifier(
                                                                         Spanned(
                                                                             "rfib",
-                                                                            452..456,
+                                                                            448..452,
                                                                         ),
                                                                     ),
-                                                                    452..456,
+                                                                    448..452,
                                                                 ),
                                                                 args: [
                                                                     Spanned(
@@ -370,39 +370,39 @@ expression: snapshot
                                                                                 Identifier(
                                                                                     Spanned(
                                                                                         "n",
-                                                                                        457..458,
+                                                                                        453..454,
                                                                                     ),
                                                                                 ),
-                                                                                457..458,
+                                                                                453..454,
                                                                             ),
                                                                             right: Spanned(
                                                                                 Literal(
                                                                                     2,
                                                                                 ),
-                                                                                461..462,
+                                                                                457..458,
                                                                             ),
                                                                         },
-                                                                        457..462,
+                                                                        453..458,
                                                                     ),
                                                                 ],
                                                             },
-                                                            452..462,
+                                                            448..458,
                                                         ),
                                                     },
-                                                    438..462,
+                                                    434..458,
                                                 ),
                                             ),
                                         },
-                                        431..464,
+                                        427..460,
                                     ),
                                 ],
                             },
-                            230..478,
+                            228..474,
                         ),
                     ),
                 ],
             },
-            85..488,
+            85..484,
         ),
     ),
     Const(
@@ -410,16 +410,16 @@ expression: snapshot
             ConstDef {
                 name: Spanned(
                     "TOP_LEVEL_CONST",
-                    504..519,
+                    500..515,
                 ),
                 value: Spanned(
                     Literal(
                         100,
                     ),
-                    522..525,
+                    518..521,
                 ),
             },
-            498..526,
+            494..522,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/toplevel::function_multiple_params.snap
+++ b/crates/compiler/parser/tests/snapshots/toplevel::function_multiple_params.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func complex(a: felt, b: felt*, c: (felt, felt)) { }
+fn complex(a: felt, b: felt*, c: (felt, felt)) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func complex(a: felt, b: felt*, c: (felt, felt)) { }
             FunctionDef {
                 name: Spanned(
                     "complex",
-                    5..12,
+                    3..10,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "a",
-                            13..14,
+                            11..12,
                         ),
                         type_expr: Named(
                             "felt",
@@ -26,7 +26,7 @@ func complex(a: felt, b: felt*, c: (felt, felt)) { }
                     Parameter {
                         name: Spanned(
                             "b",
-                            22..23,
+                            20..21,
                         ),
                         type_expr: Pointer(
                             Named(
@@ -37,7 +37,7 @@ func complex(a: felt, b: felt*, c: (felt, felt)) { }
                     Parameter {
                         name: Spanned(
                             "c",
-                            32..33,
+                            30..31,
                         ),
                         type_expr: Tuple(
                             [
@@ -56,7 +56,7 @@ func complex(a: felt, b: felt*, c: (felt, felt)) { }
                 ),
                 body: [],
             },
-            0..52,
+            0..50,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/toplevel::function_no_params.snap
+++ b/crates/compiler/parser/tests/snapshots/toplevel::function_no_params.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func get_constant() -> felt { return 42; }
+fn get_constant() -> felt { return 42; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func get_constant() -> felt { return 42; }
             FunctionDef {
                 name: Spanned(
                     "get_constant",
-                    5..17,
+                    3..15,
                 ),
                 params: [],
                 return_type: Named(
@@ -25,15 +25,15 @@ func get_constant() -> felt { return 42; }
                                     Literal(
                                         42,
                                     ),
-                                    37..39,
+                                    35..37,
                                 ),
                             ),
                         },
-                        30..40,
+                        28..38,
                     ),
                 ],
             },
-            0..42,
+            0..40,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/toplevel::function_no_return.snap
+++ b/crates/compiler/parser/tests/snapshots/toplevel::function_no_return.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func print_hello() { let msg = hello; }
+fn print_hello() { let msg = hello; }
 --- AST ---
 [
     Function(
@@ -11,7 +11,7 @@ func print_hello() { let msg = hello; }
             FunctionDef {
                 name: Spanned(
                     "print_hello",
-                    5..16,
+                    3..14,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -23,7 +23,7 @@ func print_hello() { let msg = hello; }
                             pattern: Identifier(
                                 Spanned(
                                     "msg",
-                                    25..28,
+                                    23..26,
                                 ),
                             ),
                             statement_type: None,
@@ -31,17 +31,17 @@ func print_hello() { let msg = hello; }
                                 Identifier(
                                     Spanned(
                                         "hello",
-                                        31..36,
+                                        29..34,
                                     ),
                                 ),
-                                31..36,
+                                29..34,
                             ),
                         },
-                        21..37,
+                        19..35,
                     ),
                 ],
             },
-            0..39,
+            0..37,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/toplevel::function_with_loops.snap
+++ b/crates/compiler/parser/tests/snapshots/toplevel::function_with_loops.snap
@@ -4,7 +4,7 @@ expression: snapshot
 ---
 --- Code ---
 
-        func test_loops() {
+        fn test_loops() {
             loop {
                 let x = 1;
                 if (x == 1) {
@@ -29,7 +29,7 @@ expression: snapshot
             FunctionDef {
                 name: Spanned(
                     "test_loops",
-                    14..24,
+                    12..22,
                 ),
                 params: [],
                 return_type: Tuple(
@@ -46,7 +46,7 @@ expression: snapshot
                                                 pattern: Identifier(
                                                     Spanned(
                                                         "x",
-                                                        68..69,
+                                                        66..67,
                                                     ),
                                                 ),
                                                 statement_type: None,
@@ -54,10 +54,10 @@ expression: snapshot
                                                     Literal(
                                                         1,
                                                     ),
-                                                    72..73,
+                                                    70..71,
                                                 ),
                                             },
-                                            64..74,
+                                            62..72,
                                         ),
                                         Spanned(
                                             If {
@@ -68,48 +68,48 @@ expression: snapshot
                                                             Identifier(
                                                                 Spanned(
                                                                     "x",
-                                                                    95..96,
+                                                                    93..94,
                                                                 ),
                                                             ),
-                                                            95..96,
+                                                            93..94,
                                                         ),
                                                         right: Spanned(
                                                             Literal(
                                                                 1,
                                                             ),
-                                                            100..101,
+                                                            98..99,
                                                         ),
                                                     },
-                                                    95..101,
+                                                    93..99,
                                                 ),
                                                 then_block: Spanned(
                                                     Block(
                                                         [
                                                             Spanned(
                                                                 Break,
-                                                                125..131,
+                                                                123..129,
                                                             ),
                                                         ],
                                                     ),
-                                                    103..149,
+                                                    101..147,
                                                 ),
                                                 else_block: None,
                                             },
-                                            91..149,
+                                            89..147,
                                         ),
                                     ],
                                 ),
-                                46..163,
+                                44..161,
                             ),
                         },
-                        41..163,
+                        39..161,
                     ),
                     Spanned(
                         Let {
                             pattern: Identifier(
                                 Spanned(
                                     "counter",
-                                    181..188,
+                                    179..186,
                                 ),
                             ),
                             statement_type: None,
@@ -117,10 +117,10 @@ expression: snapshot
                                 Literal(
                                     0,
                                 ),
-                                191..192,
+                                189..190,
                             ),
                         },
-                        177..193,
+                        175..191,
                     ),
                     Spanned(
                         While {
@@ -131,19 +131,19 @@ expression: snapshot
                                         Identifier(
                                             Spanned(
                                                 "counter",
-                                                213..220,
+                                                211..218,
                                             ),
                                         ),
-                                        213..220,
+                                        211..218,
                                     ),
                                     right: Spanned(
                                         Literal(
                                             10,
                                         ),
-                                        224..226,
+                                        222..224,
                                     ),
                                 },
-                                213..226,
+                                211..224,
                             ),
                             body: Spanned(
                                 Block(
@@ -154,10 +154,10 @@ expression: snapshot
                                                     Identifier(
                                                         Spanned(
                                                             "counter",
-                                                            246..253,
+                                                            244..251,
                                                         ),
                                                     ),
-                                                    246..253,
+                                                    244..251,
                                                 ),
                                                 rhs: Spanned(
                                                     BinaryOp {
@@ -166,44 +166,44 @@ expression: snapshot
                                                             Identifier(
                                                                 Spanned(
                                                                     "counter",
-                                                                    256..263,
+                                                                    254..261,
                                                                 ),
                                                             ),
-                                                            256..263,
+                                                            254..261,
                                                         ),
                                                         right: Spanned(
                                                             Literal(
                                                                 1,
                                                             ),
-                                                            266..267,
+                                                            264..265,
                                                         ),
                                                     },
-                                                    256..267,
+                                                    254..265,
                                                 ),
                                             },
-                                            246..268,
+                                            244..266,
                                         ),
                                     ],
                                 ),
-                                228..282,
+                                226..280,
                             ),
                         },
-                        206..282,
+                        204..280,
                     ),
                     Spanned(
                         For {
                             variable: Spanned(
                                 "i",
-                                300..301,
+                                298..299,
                             ),
                             iterable: Spanned(
                                 Identifier(
                                     Spanned(
                                         "range",
-                                        305..310,
+                                        303..308,
                                     ),
                                 ),
-                                305..310,
+                                303..308,
                             ),
                             body: Spanned(
                                 Block(
@@ -213,7 +213,7 @@ expression: snapshot
                                                 pattern: Identifier(
                                                     Spanned(
                                                         "squared",
-                                                        333..340,
+                                                        331..338,
                                                     ),
                                                 ),
                                                 statement_type: None,
@@ -224,36 +224,36 @@ expression: snapshot
                                                             Identifier(
                                                                 Spanned(
                                                                     "i",
-                                                                    343..344,
+                                                                    341..342,
                                                                 ),
                                                             ),
-                                                            343..344,
+                                                            341..342,
                                                         ),
                                                         right: Spanned(
                                                             Identifier(
                                                                 Spanned(
                                                                     "i",
-                                                                    347..348,
+                                                                    345..346,
                                                                 ),
                                                             ),
-                                                            347..348,
+                                                            345..346,
                                                         ),
                                                     },
-                                                    343..348,
+                                                    341..346,
                                                 ),
                                             },
-                                            329..349,
+                                            327..347,
                                         ),
                                     ],
                                 ),
-                                311..363,
+                                309..361,
                             ),
                         },
-                        296..363,
+                        294..361,
                     ),
                 ],
             },
-            9..373,
+            9..371,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/toplevel::imports_and_functions.snap
+++ b/crates/compiler/parser/tests/snapshots/toplevel::imports_and_functions.snap
@@ -12,7 +12,7 @@ expression: snapshot
             y: felt
         }
 
-        func distance(p1: Point, p2: Point) -> felt {
+        fn distance(p1: Point, p2: Point) -> felt {
             local dx: felt = p1.x - p2.x;
             local dy: felt = p1.y - p2.y;
             return sqrt(dx * dx + dy * dy);
@@ -102,13 +102,13 @@ expression: snapshot
             FunctionDef {
                 name: Spanned(
                     "distance",
-                    147..155,
+                    145..153,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "p1",
-                            156..158,
+                            154..156,
                         ),
                         type_expr: Named(
                             "Point",
@@ -117,7 +117,7 @@ expression: snapshot
                     Parameter {
                         name: Spanned(
                             "p2",
-                            167..169,
+                            165..167,
                         ),
                         type_expr: Named(
                             "Point",
@@ -133,7 +133,7 @@ expression: snapshot
                             pattern: Identifier(
                                 Spanned(
                                     "dx",
-                                    206..208,
+                                    204..206,
                                 ),
                             ),
                             ty: Some(
@@ -150,17 +150,17 @@ expression: snapshot
                                                 Identifier(
                                                     Spanned(
                                                         "p1",
-                                                        217..219,
+                                                        215..217,
                                                     ),
                                                 ),
-                                                217..219,
+                                                215..217,
                                             ),
                                             field: Spanned(
                                                 "x",
-                                                220..221,
+                                                218..219,
                                             ),
                                         },
-                                        217..221,
+                                        215..219,
                                     ),
                                     right: Spanned(
                                         MemberAccess {
@@ -168,30 +168,30 @@ expression: snapshot
                                                 Identifier(
                                                     Spanned(
                                                         "p2",
-                                                        224..226,
+                                                        222..224,
                                                     ),
                                                 ),
-                                                224..226,
+                                                222..224,
                                             ),
                                             field: Spanned(
                                                 "x",
-                                                227..228,
+                                                225..226,
                                             ),
                                         },
-                                        224..228,
+                                        222..226,
                                     ),
                                 },
-                                217..228,
+                                215..226,
                             ),
                         },
-                        200..229,
+                        198..227,
                     ),
                     Spanned(
                         Local {
                             pattern: Identifier(
                                 Spanned(
                                     "dy",
-                                    248..250,
+                                    246..248,
                                 ),
                             ),
                             ty: Some(
@@ -208,17 +208,17 @@ expression: snapshot
                                                 Identifier(
                                                     Spanned(
                                                         "p1",
-                                                        259..261,
+                                                        257..259,
                                                     ),
                                                 ),
-                                                259..261,
+                                                257..259,
                                             ),
                                             field: Spanned(
                                                 "y",
-                                                262..263,
+                                                260..261,
                                             ),
                                         },
-                                        259..263,
+                                        257..261,
                                     ),
                                     right: Spanned(
                                         MemberAccess {
@@ -226,23 +226,23 @@ expression: snapshot
                                                 Identifier(
                                                     Spanned(
                                                         "p2",
-                                                        266..268,
+                                                        264..266,
                                                     ),
                                                 ),
-                                                266..268,
+                                                264..266,
                                             ),
                                             field: Spanned(
                                                 "y",
-                                                269..270,
+                                                267..268,
                                             ),
                                         },
-                                        266..270,
+                                        264..268,
                                     ),
                                 },
-                                259..270,
+                                257..268,
                             ),
                         },
-                        242..271,
+                        240..269,
                     ),
                     Spanned(
                         Return {
@@ -253,10 +253,10 @@ expression: snapshot
                                             Identifier(
                                                 Spanned(
                                                     "sqrt",
-                                                    291..295,
+                                                    289..293,
                                                 ),
                                             ),
-                                            291..295,
+                                            289..293,
                                         ),
                                         args: [
                                             Spanned(
@@ -269,22 +269,22 @@ expression: snapshot
                                                                 Identifier(
                                                                     Spanned(
                                                                         "dx",
-                                                                        296..298,
+                                                                        294..296,
                                                                     ),
                                                                 ),
-                                                                296..298,
+                                                                294..296,
                                                             ),
                                                             right: Spanned(
                                                                 Identifier(
                                                                     Spanned(
                                                                         "dx",
-                                                                        301..303,
+                                                                        299..301,
                                                                     ),
                                                                 ),
-                                                                301..303,
+                                                                299..301,
                                                             ),
                                                         },
-                                                        296..303,
+                                                        294..301,
                                                     ),
                                                     right: Spanned(
                                                         BinaryOp {
@@ -293,37 +293,37 @@ expression: snapshot
                                                                 Identifier(
                                                                     Spanned(
                                                                         "dy",
-                                                                        306..308,
+                                                                        304..306,
                                                                     ),
                                                                 ),
-                                                                306..308,
+                                                                304..306,
                                                             ),
                                                             right: Spanned(
                                                                 Identifier(
                                                                     Spanned(
                                                                         "dy",
-                                                                        311..313,
+                                                                        309..311,
                                                                     ),
                                                                 ),
-                                                                311..313,
+                                                                309..311,
                                                             ),
                                                         },
-                                                        306..313,
+                                                        304..311,
                                                     ),
                                                 },
-                                                296..313,
+                                                294..311,
                                             ),
                                         ],
                                     },
-                                    291..313,
+                                    289..311,
                                 ),
                             ),
                         },
-                        284..315,
+                        282..313,
                     ),
                 ],
             },
-            142..325,
+            142..323,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/toplevel::many_parameters.snap
+++ b/crates/compiler/parser/tests/snapshots/toplevel::many_parameters.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func complex_function(a: felt, b: felt*, c: (felt, felt), d: MyStruct, e: MyStruct*) -> (felt, felt) { return (a, b); }
+fn complex_function(a: felt, b: felt*, c: (felt, felt), d: MyStruct, e: MyStruct*) -> (felt, felt) { return (a, b); }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func complex_function(a: felt, b: felt*, c: (felt, felt), d: MyStruct, e: MyStru
             FunctionDef {
                 name: Spanned(
                     "complex_function",
-                    5..21,
+                    3..19,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "a",
-                            22..23,
+                            20..21,
                         ),
                         type_expr: Named(
                             "felt",
@@ -26,7 +26,7 @@ func complex_function(a: felt, b: felt*, c: (felt, felt), d: MyStruct, e: MyStru
                     Parameter {
                         name: Spanned(
                             "b",
-                            31..32,
+                            29..30,
                         ),
                         type_expr: Pointer(
                             Named(
@@ -37,7 +37,7 @@ func complex_function(a: felt, b: felt*, c: (felt, felt), d: MyStruct, e: MyStru
                     Parameter {
                         name: Spanned(
                             "c",
-                            41..42,
+                            39..40,
                         ),
                         type_expr: Tuple(
                             [
@@ -53,7 +53,7 @@ func complex_function(a: felt, b: felt*, c: (felt, felt), d: MyStruct, e: MyStru
                     Parameter {
                         name: Spanned(
                             "d",
-                            58..59,
+                            56..57,
                         ),
                         type_expr: Named(
                             "MyStruct",
@@ -62,7 +62,7 @@ func complex_function(a: felt, b: felt*, c: (felt, felt), d: MyStruct, e: MyStru
                     Parameter {
                         name: Spanned(
                             "e",
-                            71..72,
+                            69..70,
                         ),
                         type_expr: Pointer(
                             Named(
@@ -92,31 +92,31 @@ func complex_function(a: felt, b: felt*, c: (felt, felt), d: MyStruct, e: MyStru
                                                 Identifier(
                                                     Spanned(
                                                         "a",
-                                                        111..112,
+                                                        109..110,
                                                     ),
                                                 ),
-                                                111..112,
+                                                109..110,
                                             ),
                                             Spanned(
                                                 Identifier(
                                                     Spanned(
                                                         "b",
-                                                        114..115,
+                                                        112..113,
                                                     ),
                                                 ),
-                                                114..115,
+                                                112..113,
                                             ),
                                         ],
                                     ),
-                                    110..116,
+                                    108..114,
                                 ),
                             ),
                         },
-                        103..117,
+                        101..115,
                     ),
                 ],
             },
-            0..119,
+            0..117,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/toplevel::namespace_with_function.snap
+++ b/crates/compiler/parser/tests/snapshots/toplevel::namespace_with_function.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-namespace Utils { func helper() -> felt { return 1; } }
+namespace Utils { fn helper() -> felt { return 1; } }
 --- AST ---
 [
     Namespace(
@@ -19,7 +19,7 @@ namespace Utils { func helper() -> felt { return 1; } }
                             FunctionDef {
                                 name: Spanned(
                                     "helper",
-                                    23..29,
+                                    21..27,
                                 ),
                                 params: [],
                                 return_type: Named(
@@ -33,20 +33,20 @@ namespace Utils { func helper() -> felt { return 1; } }
                                                     Literal(
                                                         1,
                                                     ),
-                                                    49..50,
+                                                    47..48,
                                                 ),
                                             ),
                                         },
-                                        42..51,
+                                        40..49,
                                     ),
                                 ],
                             },
-                            18..53,
+                            18..51,
                         ),
                     ),
                 ],
             },
-            0..55,
+            0..53,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/toplevel::simple_function.snap
+++ b/crates/compiler/parser/tests/snapshots/toplevel::simple_function.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func add(a: felt, b: felt) -> felt { return a + b; }
+fn add(a: felt, b: felt) -> felt { return a + b; }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func add(a: felt, b: felt) -> felt { return a + b; }
             FunctionDef {
                 name: Spanned(
                     "add",
-                    5..8,
+                    3..6,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "a",
-                            9..10,
+                            7..8,
                         ),
                         type_expr: Named(
                             "felt",
@@ -26,7 +26,7 @@ func add(a: felt, b: felt) -> felt { return a + b; }
                     Parameter {
                         name: Spanned(
                             "b",
-                            18..19,
+                            16..17,
                         ),
                         type_expr: Named(
                             "felt",
@@ -47,30 +47,30 @@ func add(a: felt, b: felt) -> felt { return a + b; }
                                             Identifier(
                                                 Spanned(
                                                     "a",
-                                                    44..45,
+                                                    42..43,
                                                 ),
                                             ),
-                                            44..45,
+                                            42..43,
                                         ),
                                         right: Spanned(
                                             Identifier(
                                                 Spanned(
                                                     "b",
-                                                    48..49,
+                                                    46..47,
                                                 ),
                                             ),
-                                            48..49,
+                                            46..47,
                                         ),
                                     },
-                                    44..49,
+                                    42..47,
                                 ),
                             ),
                         },
-                        37..50,
+                        35..48,
                     ),
                 ],
             },
-            0..52,
+            0..50,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/toplevel::trailing_comma_function_params.snap
+++ b/crates/compiler/parser/tests/snapshots/toplevel::trailing_comma_function_params.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(a: felt, b: felt,) { }
+fn test(a: felt, b: felt,) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(a: felt, b: felt,) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "a",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Named(
                             "felt",
@@ -26,7 +26,7 @@ func test(a: felt, b: felt,) { }
                     Parameter {
                         name: Spanned(
                             "b",
-                            19..20,
+                            17..18,
                         ),
                         type_expr: Named(
                             "felt",
@@ -38,7 +38,7 @@ func test(a: felt, b: felt,) { }
                 ),
                 body: [],
             },
-            0..32,
+            0..30,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/types::complex_tuple_type.snap
+++ b/crates/compiler/parser/tests/snapshots/types::complex_tuple_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(x: (felt, felt*, (felt, felt))) { }
+fn test(x: (felt, felt*, (felt, felt))) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(x: (felt, felt*, (felt, felt))) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "x",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Tuple(
                             [
@@ -48,7 +48,7 @@ func test(x: (felt, felt*, (felt, felt))) { }
                 ),
                 body: [],
             },
-            0..45,
+            0..43,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/types::custom_type.snap
+++ b/crates/compiler/parser/tests/snapshots/types::custom_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(x: MyStruct) { }
+fn test(x: MyStruct) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(x: MyStruct) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "x",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Named(
                             "MyStruct",
@@ -29,7 +29,7 @@ func test(x: MyStruct) { }
                 ),
                 body: [],
             },
-            0..26,
+            0..24,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/types::deeply_nested_types.snap
+++ b/crates/compiler/parser/tests/snapshots/types::deeply_nested_types.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(x: ((felt*, felt), (felt, felt*))*) { }
+fn test(x: ((felt*, felt), (felt, felt*))*) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(x: ((felt*, felt), (felt, felt*))*) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "x",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Pointer(
                             Tuple(
@@ -56,7 +56,7 @@ func test(x: ((felt*, felt), (felt, felt*))*) { }
                 ),
                 body: [],
             },
-            0..49,
+            0..47,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/types::named_type.snap
+++ b/crates/compiler/parser/tests/snapshots/types::named_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(x: felt) { }
+fn test(x: felt) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(x: felt) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "x",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Named(
                             "felt",
@@ -29,7 +29,7 @@ func test(x: felt) { }
                 ),
                 body: [],
             },
-            0..22,
+            0..20,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/types::nested_pointer.snap
+++ b/crates/compiler/parser/tests/snapshots/types::nested_pointer.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(x: felt**) { }
+fn test(x: felt**) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(x: felt**) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "x",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Pointer(
                             Pointer(
@@ -33,7 +33,7 @@ func test(x: felt**) { }
                 ),
                 body: [],
             },
-            0..24,
+            0..22,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/types::nested_tuple_type.snap
+++ b/crates/compiler/parser/tests/snapshots/types::nested_tuple_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(x: ((felt, felt), felt)) { }
+fn test(x: ((felt, felt), felt)) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(x: ((felt, felt), felt)) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "x",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Tuple(
                             [
@@ -43,7 +43,7 @@ func test(x: ((felt, felt), felt)) { }
                 ),
                 body: [],
             },
-            0..38,
+            0..36,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/types::pointer_to_custom_type.snap
+++ b/crates/compiler/parser/tests/snapshots/types::pointer_to_custom_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(x: MyStruct*) { }
+fn test(x: MyStruct*) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(x: MyStruct*) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "x",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Pointer(
                             Named(
@@ -31,7 +31,7 @@ func test(x: MyStruct*) { }
                 ),
                 body: [],
             },
-            0..27,
+            0..25,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/types::pointer_to_tuple.snap
+++ b/crates/compiler/parser/tests/snapshots/types::pointer_to_tuple.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(x: (felt, felt)*) { }
+fn test(x: (felt, felt)*) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(x: (felt, felt)*) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "x",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Pointer(
                             Tuple(
@@ -38,7 +38,7 @@ func test(x: (felt, felt)*) { }
                 ),
                 body: [],
             },
-            0..31,
+            0..29,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/types::pointer_type.snap
+++ b/crates/compiler/parser/tests/snapshots/types::pointer_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(x: felt*) { }
+fn test(x: felt*) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(x: felt*) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "x",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Pointer(
                             Named(
@@ -31,7 +31,7 @@ func test(x: felt*) { }
                 ),
                 body: [],
             },
-            0..23,
+            0..21,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/types::single_element_tuple_type.snap
+++ b/crates/compiler/parser/tests/snapshots/types::single_element_tuple_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(x: (felt,)) { }
+fn test(x: (felt,)) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(x: (felt,)) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "x",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Named(
                             "felt",
@@ -29,7 +29,7 @@ func test(x: (felt,)) { }
                 ),
                 body: [],
             },
-            0..25,
+            0..23,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/types::tuple_of_pointers.snap
+++ b/crates/compiler/parser/tests/snapshots/types::tuple_of_pointers.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(x: (felt*, felt*)) { }
+fn test(x: (felt*, felt*)) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(x: (felt*, felt*)) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "x",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Tuple(
                             [
@@ -40,7 +40,7 @@ func test(x: (felt*, felt*)) { }
                 ),
                 body: [],
             },
-            0..32,
+            0..30,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/snapshots/types::tuple_type.snap
+++ b/crates/compiler/parser/tests/snapshots/types::tuple_type.snap
@@ -3,7 +3,7 @@ source: crates/compiler/parser/tests/common.rs
 expression: snapshot
 ---
 --- Code ---
-func test(x: (felt, felt)) { }
+fn test(x: (felt, felt)) { }
 --- AST ---
 [
     Function(
@@ -11,13 +11,13 @@ func test(x: (felt, felt)) { }
             FunctionDef {
                 name: Spanned(
                     "test",
-                    5..9,
+                    3..7,
                 ),
                 params: [
                     Parameter {
                         name: Spanned(
                             "x",
-                            10..11,
+                            8..9,
                         ),
                         type_expr: Tuple(
                             [
@@ -36,7 +36,7 @@ func test(x: (felt, felt)) { }
                 ),
                 body: [],
             },
-            0..30,
+            0..28,
         ),
     ),
 ]

--- a/crates/compiler/parser/tests/test_cases/control_flow/loop_with_breaks.cm
+++ b/crates/compiler/parser/tests/test_cases/control_flow/loop_with_breaks.cm
@@ -1,4 +1,4 @@
-func loop_control_flow() {
+fn loop_control_flow() {
     // Break in different contexts
     loop {
         break;

--- a/crates/compiler/parser/tests/test_cases/control_flow/nested_loops.cm
+++ b/crates/compiler/parser/tests/test_cases/control_flow/nested_loops.cm
@@ -1,4 +1,4 @@
-func nested_loops() {
+fn nested_loops() {
     // Nested while loops
     let i = 0;
     while (i != 5) {

--- a/crates/compiler/parser/tests/test_cases/control_flow/simple_loop.cm
+++ b/crates/compiler/parser/tests/test_cases/control_flow/simple_loop.cm
@@ -1,4 +1,4 @@
-func test_loops() {
+fn test_loops() {
     // Infinite loop
     loop {
         let x = 1;

--- a/crates/compiler/parser/tests/test_cases/tuple_destructuring.cm
+++ b/crates/compiler/parser/tests/test_cases/tuple_destructuring.cm
@@ -1,38 +1,38 @@
 // Test file for tuple destructuring patterns
 
-func test_basic_tuple_destructuring() -> felt {
+fn test_basic_tuple_destructuring() -> felt {
     // Basic tuple destructuring
     let (x, y) = (10, 20);
     return x + y;
 }
 
-func test_function_return_destructuring() -> (felt, felt) {
+fn test_function_return_destructuring() -> (felt, felt) {
     // Function that returns a tuple
-    func get_pair() -> (felt, felt) {
+    fn get_pair() -> (felt, felt) {
         return (100, 200);
     }
-    
+
     // Destructure function return value
     let (a, b) = get_pair();
     return (a, b);
 }
 
-func test_local_destructuring() {
+fn test_local_destructuring() {
     // Local tuple destructuring
     local (x, y) = (5, 15);
     let sum = x + y;
-    
+
     // Nested expressions
     let (a, b) = (x + 1, y - 1);
 }
 
-func test_three_element_tuple() -> felt {
+fn test_three_element_tuple() -> felt {
     // Three element tuple
     let (x, y, z) = (1, 2, 3);
     return x + y + z;
 }
 
-func test_with_type_annotation() {
+fn test_with_type_annotation() {
     // With type annotation
     let (x, y): (felt, felt) = (42, 84);
     local (a, b): (felt, felt) = (1, 2);

--- a/crates/compiler/semantic/src/semantic_index.rs
+++ b/crates/compiler/semantic/src/semantic_index.rs
@@ -1286,7 +1286,7 @@ mod tests {
 
     #[test]
     fn test_simple_function() {
-        let TestCase { db, source } = test_case("func test() { }");
+        let TestCase { db, source } = test_case("fn test() { }");
         let crate_id = single_file_crate(&db, source);
         let index = module_semantic_index(&db, crate_id, "main".to_string());
 
@@ -1316,7 +1316,7 @@ mod tests {
 
     #[test]
     fn test_function_with_parameters() {
-        let TestCase { db, source } = test_case("func add(a: felt, b: felt) { }");
+        let TestCase { db, source } = test_case("fn add(a: felt, b: felt) { }");
         let crate_id = single_file_crate(&db, source);
         let index = module_semantic_index(&db, crate_id, "main".to_string());
 
@@ -1341,8 +1341,7 @@ mod tests {
 
     #[test]
     fn test_variable_resolution() {
-        let TestCase { db, source } =
-            test_case("func test(param: felt) { let local_var = param; }");
+        let TestCase { db, source } = test_case("fn test(param: felt) { let local_var = param; }");
         let crate_id = single_file_crate(&db, source);
         let index = module_semantic_index(&db, crate_id, "main".to_string());
 
@@ -1373,14 +1372,14 @@ mod tests {
                 y: felt
             }
 
-            func distance(p1: Point, p2: Point) -> felt {
+            fn distance(p1: Point, p2: Point) -> felt {
                 let dx = p1.x - p2.x;
                 local dy: felt = p1.y - p2.y;
                 return dx * dx + dy * dy;
             }
 
             namespace Math {
-                func square(x: felt) -> felt {
+                fn square(x: felt) -> felt {
                     return x * x;
                 }
             }
@@ -1474,7 +1473,7 @@ mod tests {
 
     #[test]
     fn test_real_spans_are_used() {
-        let TestCase { db, source } = test_case("func test(x: felt) { let y = x; }");
+        let TestCase { db, source } = test_case("fn test(x: felt) { let y = x; }");
         let crate_id = single_file_crate(&db, source);
         let index = module_semantic_index(&db, crate_id, "main".to_string());
 
@@ -1529,7 +1528,7 @@ mod tests {
             r#"
             const Z = 314;
 
-            func test() -> felt {
+            fn test() -> felt {
                 let x = 42;
                 local y: felt = 100;
                 return x + y;

--- a/crates/compiler/semantic/src/type_resolution.rs
+++ b/crates/compiler/semantic/src/type_resolution.rs
@@ -713,7 +713,7 @@ mod tests {
     #[test]
     fn test_direct_ast_node_access() {
         let db = test_db();
-        let crate_id = crate_from_program(&db, "func test() { let x = 42; }");
+        let crate_id = crate_from_program(&db, "fn test() { let x = 42; }");
         let file = *crate_id.modules(&db).values().next().unwrap();
         let semantic_index = module_semantic_index(&db, crate_id, "main".to_string());
 
@@ -756,7 +756,7 @@ mod tests {
         // Simple test program that exercises all expression types
         let program = r#"
             struct Point { x: felt, y: felt }
-            func test() {
+            fn test() {
                 let p = Point { x: 1, y: 2 };
                 let sum = 1 + 2;
                 let coord = p.x;
@@ -844,7 +844,7 @@ mod tests {
             struct Point { x: felt, y: felt }
             struct Nested { point: Point, value: felt }
 
-            func test(p: Point, ptr: felt*, nested: Nested) -> felt {
+            fn test(p: Point, ptr: felt*, nested: Nested) -> felt {
                 let x1 = p.x;           // Direct struct field access
                 let n1 = nested.value;  // Nested struct field
                 let n2 = nested.point;  // Nested struct returns Point type
@@ -891,7 +891,7 @@ mod tests {
         let program = r#"
             struct Point { x: felt, y: felt }
 
-            func test(ptr: Point*) -> felt {
+            fn test(ptr: Point*) -> felt {
                 let x = ptr.x;  // Should automatically dereference
                 return x;
             }

--- a/crates/compiler/semantic/src/types/types_test.rs
+++ b/crates/compiler/semantic/src/types/types_test.rs
@@ -128,7 +128,7 @@ fn test_function_signature_resolution() {
     let db = test_db();
     let program = r#"
         struct Point { x: felt, y: felt }
-        func get_point(x: felt) -> Point {
+        fn get_point(x: felt) -> Point {
             return Point { x: x, y: 0 };
         }
     "#;
@@ -177,7 +177,7 @@ fn test_parameter_type_resolution() {
     let db = test_db();
     let program = r#"
         struct Vector { x: felt, y: felt }
-        func magnitude(v: Vector) -> felt {
+        fn magnitude(v: Vector) -> felt {
             return 0;
         }
     "#;
@@ -213,7 +213,7 @@ fn test_expression_type_inference() {
     let db = test_db();
     let program = r#"
         struct Point { x: felt, y: felt }
-        func test(p: Point) -> felt {
+        fn test(p: Point) -> felt {
             let a = 42;
             let b = a + 1;
             let c = p.x;
@@ -277,7 +277,7 @@ fn test_let_variable_type_inference() {
     let db = test_db();
     let program = r#"
         struct Point { x: felt, y: felt }
-        func test() {
+        fn test() {
             let a = 42;
             let b = 13;
             let p = Point { x: 1, y: 2 };
@@ -366,7 +366,7 @@ fn test_explicit_type_annotations_priority() {
     let db = test_db();
     let program = r#"
         struct Point { x: felt, y: felt }
-        func test() {
+        fn test() {
             let x: felt = 42;
             local y: Point = 13;
             let p: Point = Point { x: 1, y: 2 };
@@ -423,7 +423,7 @@ fn test_local_variable_inference_without_annotation() {
     let db = test_db();
     let program = r#"
         struct Point { x: felt, y: felt }
-        func test() {
+        fn test() {
             local x = 42;
             local y = Point { x: 1, y: 2 };
         }
@@ -469,7 +469,7 @@ fn test_mixed_variable_scenarios() {
     let db = test_db();
     let program = r#"
         struct Vector { x: felt, y: felt }
-        func complex_test() {
+        fn complex_test() {
             let a = 42;                    // infer from literal
             let b: felt = a + 1;           // explicit annotation, infer from expression
             local c = Vector { x: 1, y: 2 }; // infer from struct literal
@@ -528,7 +528,7 @@ fn test_multiple_return_type_signature() {
     let db = test_db();
     let program = r#"
         struct Point { x: felt, y: felt }
-        func my_func() -> (felt, Point) {
+        fn my_func() -> (felt, Point) {
             return (1, Point { x: 2, y: 3 });
         }
     "#;

--- a/crates/compiler/semantic/src/validation/tests/snapshots/cairo_m_compiler_semantic__validation__tests__fib_program_diagnostics.snap
+++ b/crates/compiler/semantic/src/validation/tests/snapshots/cairo_m_compiler_semantic__validation__tests__fib_program_diagnostics.snap
@@ -5,7 +5,7 @@ expression: snapshot_content
 Fixture: fib.cm
 ============================================================
 Source code:
-func fib(n: felt) -> felt {
+fn fib(n: felt) -> felt {
     if (n == 0) {
         return 0;
     }

--- a/crates/compiler/semantic/src/validation/tests/test_data/fib.cm
+++ b/crates/compiler/semantic/src/validation/tests/test_data/fib.cm
@@ -1,4 +1,4 @@
-func fib(n: felt) -> felt {
+fn fib(n: felt) -> felt {
     if (n == 0) {
         return 0;
     }

--- a/crates/compiler/semantic/src/validation/type_validator.rs
+++ b/crates/compiler/semantic/src/validation/type_validator.rs
@@ -1452,8 +1452,8 @@ mod tests {
         let db = test_db();
         let program = r#"
             struct Point { x: felt, y: felt }
-            func returns_felt() -> felt { return 0; }
-            func test() {
+            fn returns_felt() -> felt { return 0; }
+            fn test() {
                 let valid = 1 + 2;              // OK: felt + felt
                 let point = Point { x: 1, y: 2 };
                 let invalid_1 = point + 1;        // Error: struct + felt
@@ -1483,9 +1483,9 @@ mod tests {
     fn test_function_call_type_validation() {
         let db = test_db();
         let program = r#"
-            func add(x: felt, y: felt) -> felt { return x + y; }
+            fn add(x: felt, y: felt) -> felt { return x + y; }
             struct Point { x: felt, y: felt }
-            func test() {
+            fn test() {
                 let valid = add(1, 2);          // OK: correct types
                 let point = Point { x: 1, y: 2 };
                 let invalid = add(point, 1);    // Error: struct instead of felt
@@ -1515,7 +1515,7 @@ mod tests {
         let db = test_db();
         let program = r#"
             struct Point { x: felt, y: felt }
-            func test() {
+            fn test() {
                 let p = Point { x: 1, y: 2 };
                 let valid_access = p.x;         // OK: valid field
                 let invalid_access = p.z;      // Error: invalid field
@@ -1562,7 +1562,7 @@ mod tests {
         let db = test_db();
         let program = r#"
             struct Point { x: felt, y: felt }
-            func test() {
+            fn test() {
                 // Let statement tests
                 let a: felt = 1;              // OK: correct type
                 let b: Point = Point { x: 1, y: 2 }; // OK: correct type
@@ -1601,15 +1601,15 @@ mod tests {
             struct Point { x: felt, y: felt }
 
             // Valid return type functions
-            func valid_return_felt() -> felt {
+            fn valid_return_felt() -> felt {
                 return 42;                    // OK: correct return type
             }
 
-            func valid_return_point() -> Point {
+            fn valid_return_point() -> Point {
                 return Point { x: 1, y: 2 };  // OK: correct return type
             }
 
-            func valid_return_conditional() -> felt {
+            fn valid_return_conditional() -> felt {
                 if (1) {
                     return 1;                 // OK: correct return type
                 } else {
@@ -1618,15 +1618,15 @@ mod tests {
             }
 
             // Invalid return type functions
-            func invalid_return_felt() -> felt {
+            fn invalid_return_felt() -> felt {
                 return Point { x: 1, y: 2 };  // Error: wrong return type
             }
 
-            func invalid_return_point() -> Point {
+            fn invalid_return_point() -> Point {
                 return 42;                    // Error: wrong return type
             }
 
-            func invalid_return_conditional() -> felt {
+            fn invalid_return_conditional() -> felt {
                 if (1) {
                     return Point { x: 1, y: 2 }; // Error: wrong return type
                 } else {
@@ -1658,7 +1658,7 @@ mod tests {
         let db = test_db();
         let program = r#"
             struct Point { x: felt, y: felt }
-            func test() {
+            fn test() {
                 // Valid if statements
                 if (1) {                      // OK: felt condition
                     let a = 42;
@@ -1721,7 +1721,7 @@ mod tests {
         let db = test_db();
         let program = r#"
             struct Point { x: felt, y: felt }
-            func test() {
+            fn test() {
                 // Valid local statements
                 local a: felt = 1;            // OK: correct type
                 local b: Point = Point { x: 1, y: 2 }; // OK: correct type
@@ -1763,7 +1763,7 @@ mod tests {
         let db = test_db();
         let program = r#"
             struct Point { x: felt, y: felt }
-            func test() {
+            fn test() {
                 // Valid comparisons - all with felt operands
                 let a = 1 < 2;                // OK: felt < felt
                 let b = 3 > 1;                // OK: felt > felt
@@ -1829,7 +1829,7 @@ mod tests {
         let db = test_db();
         let program = r#"
             struct Point { x: felt, y: felt }
-            func test() {
+            fn test() {
                 let a = 5;
                 let b = 10;
 
@@ -1895,7 +1895,7 @@ mod tests {
     fn test_mixed_operators_with_comparisons() {
         let db = test_db();
         let program = r#"
-            func test() {
+            fn test() {
                 let a = 5;
                 let b = 10;
                 let c = 15;
@@ -1943,7 +1943,7 @@ mod tests {
         let db = test_db();
         let program = r#"
             struct Point { x: felt, y: felt }
-            func test() {
+            fn test() {
                 // Valid assignments
                 let a: felt = 1;
                 a = 2;                        // OK: same type

--- a/crates/compiler/semantic/tests/README.md
+++ b/crates/compiler/semantic/tests/README.md
@@ -100,7 +100,7 @@ fn test_unused_variable_error() {
 #[test]
 fn test_with_helper_function() {
     assert_semantic_ok!(&with_functions(
-        "func helper() -> felt { return 42; }",
+        "fn helper() -> felt { return 42; }",
         &in_function("let x = helper(); return x;")
     ));
 }

--- a/crates/compiler/semantic/tests/control_flow/break_continue.rs
+++ b/crates/compiler/semantic/tests/control_flow/break_continue.rs
@@ -5,7 +5,7 @@ fn test_nested_loops_with_break_continue() {
     // Break and continue in nested loops should be valid
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 loop {
                     if (1) {
@@ -29,7 +29,7 @@ fn test_break_continue_in_block() {
     // Break/continue in block inside loop should be valid
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 {
                     if (1) {
@@ -49,7 +49,7 @@ fn test_break_continue_in_block_outside_loop() {
     // Break/continue in block outside loop should error
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             {
                 break;
             }
@@ -64,7 +64,7 @@ fn test_multiple_break_continue_errors() {
     // Multiple break/continue outside loops should produce multiple errors
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             break;
             if (1) {
                 continue;
@@ -86,7 +86,7 @@ fn test_break_in_while_condition() {
     // If the parser doesn't support this, the test may need adjustment
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             while (1) {
                 break;
             }
@@ -101,16 +101,16 @@ fn test_break_continue_mix() {
     // Mix of valid and invalid break/continue
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             break;  // Error
-            
+
             loop {
                 break;  // OK
                 continue;  // OK (unreachable but syntactically valid)
             }
-            
+
             continue;  // Error
-            
+
             while (1) {
                 if (1) {
                     break;  // OK
@@ -118,7 +118,7 @@ fn test_break_continue_mix() {
                     continue;  // OK
                 }
             }
-            
+
             return;
         }
         "#

--- a/crates/compiler/semantic/tests/control_flow/control_flow_paths.rs
+++ b/crates/compiler/semantic/tests/control_flow/control_flow_paths.rs
@@ -6,7 +6,7 @@ use crate::*;
 fn test_all_paths_return() {
     assert_semantic_ok!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 1;
             } else {
@@ -21,7 +21,7 @@ fn test_all_paths_return() {
 fn test_not_all_paths_return() {
     assert_semantic_err!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 1;
             }
@@ -35,7 +35,7 @@ fn test_not_all_paths_return() {
 fn test_nested_control_flow_all_paths() {
     assert_semantic_ok!(
         r#"
-        func test(x: felt, y: felt) -> felt {
+        fn test(x: felt, y: felt) -> felt {
             if (x == 0) {
                 if (y == 0) {
                     return 1;
@@ -54,7 +54,7 @@ fn test_nested_control_flow_all_paths() {
 fn test_nested_control_flow_missing_path() {
     assert_semantic_err!(
         r#"
-        func test(x: felt, y: felt) -> felt {
+        fn test(x: felt, y: felt) -> felt {
             if (x == 0) {
                 if (y == 0) {
                     return 1;
@@ -72,7 +72,7 @@ fn test_nested_control_flow_missing_path() {
 fn test_early_return_valid() {
     assert_semantic_ok!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 0; // Early return
             }

--- a/crates/compiler/semantic/tests/control_flow/loop_scoping.rs
+++ b/crates/compiler/semantic/tests/control_flow/loop_scoping.rs
@@ -5,7 +5,7 @@ fn test_loop_body_creates_new_scope() {
     // Variables declared in loop body should not be visible outside
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 let x = 42;
                 break;
@@ -24,7 +24,7 @@ fn test_nested_loop_scopes() {
     // Each loop creates its own scope
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 let outer = 1;
                 loop {
@@ -46,7 +46,7 @@ fn test_while_loop_scoping() {
     // While loop body creates new scope
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let condition = 1;
             while (condition) {
                 let loop_var = 42;
@@ -64,7 +64,7 @@ fn test_loop_variable_shadowing() {
     // Variables in loop can shadow outer variables
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             let x = 1;
             loop {
                 let x = 2;  // Shadows outer x
@@ -88,7 +88,7 @@ fn test_loop_scope_with_blocks() {
     // Blocks inside loops create additional scopes
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 let loop_var = 1;
                 {

--- a/crates/compiler/semantic/tests/control_flow/loop_type_checking.rs
+++ b/crates/compiler/semantic/tests/control_flow/loop_type_checking.rs
@@ -5,7 +5,7 @@ fn test_while_loop_with_felt_condition() {
     // This should pass - felt is the correct type for conditions
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             let x: felt = 1;
             while (x) {
                 return;
@@ -25,7 +25,7 @@ fn test_while_loop_with_non_felt_condition() {
             y: felt,
         }
 
-        func test() {
+        fn test() {
             let p: Point = Point { x: 1, y: 2 };
             while (p) {
                 return;
@@ -39,7 +39,7 @@ fn test_while_loop_with_non_felt_condition() {
 fn test_while_loop_with_tuple_condition() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let t: (felt, felt) = (1, 2);
             while (t) {
                 return;
@@ -57,7 +57,7 @@ fn test_while_loop_with_complex_non_felt_expression() {
             enabled: felt,
         }
 
-        func test() {
+        fn test() {
             let config: Config = Config { enabled: 1 };
             // This should fail - accessing the struct itself, not the field
             while (config) {
@@ -73,7 +73,7 @@ fn test_while_loop_with_nested_conditions() {
     // This should pass - all conditions are felt
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             let a: felt = 1;
             let b: felt = 0;
 
@@ -94,7 +94,7 @@ fn test_while_loop_with_comparison_expression() {
     // This should pass - comparisons return felt
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             let x: felt = 10;
             while (x == 0) {
                 return;
@@ -110,7 +110,7 @@ fn test_while_loop_with_logical_expression() {
     // This should pass - logical operations return felt
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             let a: felt = 1;
             let b: felt = 0;
             while (a && b) {

--- a/crates/compiler/semantic/tests/control_flow/loop_unreachable.rs
+++ b/crates/compiler/semantic/tests/control_flow/loop_unreachable.rs
@@ -5,7 +5,7 @@ fn test_code_after_infinite_loop() {
     // Code after an infinite loop (without breaks) is unreachable
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 let x = 1;
             }
@@ -21,7 +21,7 @@ fn test_code_after_loop_with_break() {
     // Code after a loop with break is reachable
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 break;
             }
@@ -37,7 +37,7 @@ fn test_code_after_break() {
     // Code after break in loop is unreachable
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 break;
                 let x = 1;  // Unreachable
@@ -53,7 +53,7 @@ fn test_code_after_continue() {
     // Code after continue in loop is unreachable
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 continue;
                 let x = 1;  // Unreachable
@@ -69,7 +69,7 @@ fn test_conditional_break_unreachable() {
     // Conditional breaks don't make following code unreachable
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 if (1) {
                     break;
@@ -87,7 +87,7 @@ fn test_nested_loop_unreachable() {
     // Unreachable code in nested loops
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 loop {
                     break;
@@ -107,7 +107,7 @@ fn test_while_loop_unreachable() {
     // While loops don't make following code unreachable (might not execute)
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             while (0) {
                 let x = 1;
             }
@@ -125,7 +125,7 @@ fn test_loop_with_return() {
     // Return in loop makes code after it unreachable
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 return;
                 let x = 1;  // Unreachable

--- a/crates/compiler/semantic/tests/control_flow/loop_validation.rs
+++ b/crates/compiler/semantic/tests/control_flow/loop_validation.rs
@@ -5,7 +5,7 @@ fn test_break_in_loop() {
     // Break inside loop should be valid
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             let running = 1;
             loop {
                 if (running) {
@@ -23,7 +23,7 @@ fn test_break_outside_loop() {
     // Break outside loop should error
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             break;
             return;
         }
@@ -36,7 +36,7 @@ fn test_continue_in_loop() {
     // Continue inside loop should be valid
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             let x = 0;
             loop {
                 if (x) {
@@ -55,7 +55,7 @@ fn test_continue_outside_loop() {
     // Continue outside loop should error
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             continue;
             return;
         }
@@ -68,7 +68,7 @@ fn test_break_in_nested_loops() {
     // Break in nested loops should be valid
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 loop {
                     break;
@@ -86,7 +86,7 @@ fn test_break_in_if_inside_loop() {
     // Break inside if statement within loop should be valid
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             loop {
                 if (1) {
                     break;
@@ -103,7 +103,7 @@ fn test_break_in_if_outside_loop() {
     // Break inside if statement outside loop should error
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             if (1) {
                 break;
             }
@@ -118,7 +118,7 @@ fn test_while_loop_with_break() {
     // Break in while loop should be valid
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             while (1) {
                 break;
             }

--- a/crates/compiler/semantic/tests/control_flow/missing_returns.rs
+++ b/crates/compiler/semantic/tests/control_flow/missing_returns.rs
@@ -6,7 +6,7 @@ use crate::*;
 fn test_missing_return_simple() {
     assert_semantic_err!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 42;
             // Missing return statement
         }
@@ -18,7 +18,7 @@ fn test_missing_return_simple() {
 fn test_missing_return_with_if() {
     assert_semantic_err!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 1;
             }
@@ -32,7 +32,7 @@ fn test_missing_return_with_if() {
 fn test_missing_return_in_else() {
     assert_semantic_err!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 1;
             } else {
@@ -48,7 +48,7 @@ fn test_missing_return_in_else() {
 fn test_valid_return_all_paths() {
     assert_semantic_ok!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 1;
             } else {
@@ -63,7 +63,7 @@ fn test_valid_return_all_paths() {
 fn test_valid_return_simple() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 42;
             return x;
         }
@@ -75,7 +75,7 @@ fn test_valid_return_simple() {
 fn test_unit_return_type_ok() {
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             let x = 42;
             return ();
         }
@@ -88,7 +88,7 @@ fn test_unit_return_type_implicit() {
     // Functions with unit return type should still require explicit return
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let x = 42;
             // Missing return () for unit functions
         }
@@ -100,7 +100,7 @@ fn test_unit_return_type_implicit() {
 fn test_nested_missing_return() {
     assert_semantic_err!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 if (x == 10) {
                     return 1;
@@ -119,7 +119,7 @@ fn test_nested_missing_return() {
 fn test_complex_control_flow_valid() {
     assert_semantic_ok!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 if (x == 10) {
                     return 1;
@@ -138,7 +138,7 @@ fn test_complex_control_flow_valid() {
 fn test_return_in_nested_block() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             {
                 {
                     return 42;

--- a/crates/compiler/semantic/tests/control_flow/unreachable_code.rs
+++ b/crates/compiler/semantic/tests/control_flow/unreachable_code.rs
@@ -6,7 +6,7 @@ use crate::*;
 fn test_code_after_return() {
     assert_semantic_err!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             return 42;
             let unreachable = 1; // Error: unreachable code
         }
@@ -18,7 +18,7 @@ fn test_code_after_return() {
 fn test_code_after_return_in_block() {
     assert_semantic_err!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             {
                 return 42;
                 let unreachable = 1; // Error: unreachable code
@@ -32,7 +32,7 @@ fn test_code_after_return_in_block() {
 fn test_code_after_if_with_returns() {
     assert_semantic_err!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 1;
             } else {
@@ -49,7 +49,7 @@ fn test_reachable_code_after_partial_if() {
     // Code after if without else should be reachable
     assert_semantic_ok!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 1;
             }
@@ -64,7 +64,7 @@ fn test_reachable_code_after_partial_if() {
 fn test_multiple_returns_in_sequence() {
     assert_semantic_err!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             return 1;
             return 2; // Error: unreachable code
         }
@@ -76,7 +76,7 @@ fn test_multiple_returns_in_sequence() {
 fn test_unreachable_after_nested_return() {
     assert_semantic_err!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             {
                 {
                     return 42;
@@ -92,7 +92,7 @@ fn test_unreachable_after_nested_return() {
 fn test_reachable_code_in_function() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 1;
             let y = x + 2;
             return y;
@@ -105,7 +105,7 @@ fn test_reachable_code_in_function() {
 fn test_unreachable_in_complex_control_flow() {
     assert_semantic_err!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 if (x == 10) {
                     return 1;

--- a/crates/compiler/semantic/tests/expressions/type_errors.rs
+++ b/crates/compiler/semantic/tests/expressions/type_errors.rs
@@ -9,7 +9,7 @@ fn test_struct_in_arithmetic_operation() {
         r#"
         struct Point { x: felt, y: felt }
 
-        func test() {
+        fn test() {
             let p = Point { x: 10, y: 20 };
             let result = p + 5;  // Error: struct in arithmetic
         }
@@ -24,7 +24,7 @@ fn test_struct_with_numeric_field_suggestion() {
         r#"
         struct Counter { value: felt }
 
-        func test() {
+        fn test() {
             let c = Counter { value: 42 };
             let result = c * 2;  // Should suggest accessing 'value' field
         }
@@ -37,7 +37,7 @@ fn test_tuple_in_arithmetic_operation() {
     // Test tuple in arithmetic with suggestion
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let t = (42,);
             let result = t + 10;  // Should suggest accessing with [0]
         }
@@ -50,11 +50,11 @@ fn test_function_not_called_error() {
     // Test function used without parentheses
     assert_semantic_err!(
         r#"
-        func get_value() -> felt {
+        fn get_value() -> felt {
             return 42;
         }
 
-        func test() {
+        fn test() {
             let x = get_value + 5;  // Should suggest adding parentheses
         }
     "#
@@ -68,7 +68,7 @@ fn test_comparison_type_mismatch_with_context() {
         r#"
         struct Point { x: felt, y: felt }
 
-        func test() {
+        fn test() {
             let p = Point { x: 1, y: 2 };
             let num = 42;
             if (p == num) {  // Type mismatch with context
@@ -87,11 +87,11 @@ fn test_function_argument_type_mismatch_with_param_name() {
         r#"
         struct Point { x: felt, y: felt }
 
-        func distance(p1: Point, p2: Point) -> felt {
+        fn distance(p1: Point, p2: Point) -> felt {
             return 0;
         }
 
-        func test() {
+        fn test() {
             let p = Point { x: 1, y: 2 };
             let d = distance(p, 42);  // Should show parameter name 'p2'
         }
@@ -106,7 +106,7 @@ fn test_assignment_type_mismatch_with_context() {
         r#"
         struct Point { x: felt, y: felt }
 
-        func test() {
+        fn test() {
             let x: felt = 10;
             let p = Point { x: 1, y: 2 };
             x = p;  // Should show variable type context
@@ -123,7 +123,7 @@ fn test_return_type_mismatch_with_function_context() {
         r#"
         struct Point { x: felt, y: felt }
 
-        func get_coordinate() -> felt {
+        fn get_coordinate() -> felt {
             let p = Point { x: 10, y: 20 };
             return p;  // Should show function signature context
         }
@@ -138,7 +138,7 @@ fn test_if_condition_type_error() {
         r#"
         struct Point { x: felt, y: felt }
 
-        func test() {
+        fn test() {
             let p = Point { x: 1, y: 2 };
             if (p) {  // Non-felt condition
                 return ();
@@ -157,7 +157,7 @@ fn test_multiple_type_errors_with_suggestions() {
         struct Point { x: felt, y: felt }
         struct Counter { value: felt }
 
-        func test() -> felt {
+        fn test() -> felt {
             let p = Point { x: 1, y: 2 };
             let c = Counter { value: 10 };
             let result = p + c;  // Two type errors, both should have suggestions
@@ -174,7 +174,7 @@ fn test_unary_op_type_error() {
         r#"
         struct Point { x: felt, y: felt }
 
-        func test() -> felt {
+        fn test() -> felt {
             let p = Point { x: 1, y: 2 };
             let x = -p;  // Should show type error for negation on struct
             return x;

--- a/crates/compiler/semantic/tests/functions/function_calls.rs
+++ b/crates/compiler/semantic/tests/functions/function_calls.rs
@@ -6,11 +6,11 @@ use crate::*;
 fn test_valid_function_call() {
     assert_semantic_ok!(
         r#"
-        func helper(x: felt) -> felt {
+        fn helper(x: felt) -> felt {
             return x + 1;
         }
 
-        func test() -> felt {
+        fn test() -> felt {
             return helper(42);
         }
     "#
@@ -21,7 +21,7 @@ fn test_valid_function_call() {
 fn test_undeclared_function_call() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let result = undefined_function(42);
         }
     "#
@@ -32,11 +32,11 @@ fn test_undeclared_function_call() {
 fn test_function_call_with_undeclared_argument() {
     assert_semantic_err!(
         r#"
-        func helper(x: felt) -> felt {
+        fn helper(x: felt) -> felt {
             return x;
         }
 
-        func test() {
+        fn test() {
             let result = helper(undefined_var);
         }
     "#
@@ -47,15 +47,15 @@ fn test_function_call_with_undeclared_argument() {
 fn test_multiple_function_calls() {
     assert_semantic_ok!(
         r#"
-        func add(a: felt, b: felt) -> felt {
+        fn add(a: felt, b: felt) -> felt {
             return a + b;
         }
 
-        func multiply(a: felt, b: felt) -> felt {
+        fn multiply(a: felt, b: felt) -> felt {
             return a * b;
         }
 
-        func test() -> felt {
+        fn test() -> felt {
             let sum = add(1, 2);
             let product = multiply(sum, 3);
             return product;
@@ -68,15 +68,15 @@ fn test_multiple_function_calls() {
 fn test_nested_function_calls() {
     assert_semantic_ok!(
         r#"
-        func inner(x: felt) -> felt {
+        fn inner(x: felt) -> felt {
             return x * 2;
         }
 
-        func outer(x: felt) -> felt {
+        fn outer(x: felt) -> felt {
             return inner(x) + 1;
         }
 
-        func test() -> felt {
+        fn test() -> felt {
             return outer(inner(5));
         }
     "#
@@ -87,11 +87,11 @@ fn test_nested_function_calls() {
 fn test_function_call_in_expression() {
     assert_semantic_ok!(
         r#"
-        func get_value() -> felt {
+        fn get_value() -> felt {
             return 42;
         }
 
-        func test() -> felt {
+        fn test() -> felt {
             let result = get_value() + 10;
             return result;
         }
@@ -103,11 +103,11 @@ fn test_function_call_in_expression() {
 fn test_function_call_as_condition() {
     assert_semantic_ok!(
         r#"
-        func is_null(x: felt) -> felt {
+        fn is_null(x: felt) -> felt {
             return x == 0;
         }
 
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (is_null(x)) {
                 return 1;
             } else {
@@ -122,7 +122,7 @@ fn test_function_call_as_condition() {
 fn test_recursive_function_call() {
     assert_semantic_ok!(
         r#"
-        func factorial(n: felt) -> felt {
+        fn factorial(n: felt) -> felt {
             if (n == 1) {
                 return 1;
             } else {
@@ -130,7 +130,7 @@ fn test_recursive_function_call() {
             }
         }
 
-        func test() -> felt {
+        fn test() -> felt {
             return factorial(5);
         }
     "#

--- a/crates/compiler/semantic/tests/functions/parameter_validation.rs
+++ b/crates/compiler/semantic/tests/functions/parameter_validation.rs
@@ -6,7 +6,7 @@ use crate::*;
 fn test_function_with_single_parameter() {
     assert_semantic_ok!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             return x;
         }
     "#
@@ -17,7 +17,7 @@ fn test_function_with_single_parameter() {
 fn test_function_with_multiple_parameters() {
     assert_semantic_ok!(
         r#"
-        func test(x: felt, y: felt, z: felt) -> felt {
+        fn test(x: felt, y: felt, z: felt) -> felt {
             return x + y + z;
         }
     "#
@@ -28,7 +28,7 @@ fn test_function_with_multiple_parameters() {
 fn test_function_with_no_parameters() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             return 42;
         }
     "#
@@ -39,7 +39,7 @@ fn test_function_with_no_parameters() {
 fn test_duplicate_parameter_names() {
     assert_semantic_err!(
         r#"
-        func test(x: felt, x: felt) -> felt {
+        fn test(x: felt, x: felt) -> felt {
             return x;
         }
     "#
@@ -50,7 +50,7 @@ fn test_duplicate_parameter_names() {
 fn test_parameter_used_in_function_body() {
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             let var = param + 1;
             return var;
         }
@@ -62,7 +62,7 @@ fn test_parameter_used_in_function_body() {
 fn test_unused_parameter_warning() {
     assert_semantic_err!(
         r#"
-        func test(unused_param: felt) -> felt {
+        fn test(unused_param: felt) -> felt {
             return 42;
         }
     "#,
@@ -74,7 +74,7 @@ fn test_unused_parameter_warning() {
 fn test_parameter_used_in_nested_scope() {
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             {
                 let inner = param * 2;
                 return inner;
@@ -88,7 +88,7 @@ fn test_parameter_used_in_nested_scope() {
 fn test_parameter_used_in_if_statement() {
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             if (param == 0) {
                 return param;
             } else {
@@ -103,7 +103,7 @@ fn test_parameter_used_in_if_statement() {
 fn test_parameter_assignment() {
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             param = param + 1;
             return param;
         }
@@ -116,7 +116,7 @@ fn test_parameter_vs_local_variable_shadowing() {
     // Shadowing is now supported - local variables can shadow parameters
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             let param = 42; // OK: shadows parameter
             return param;
         }
@@ -129,7 +129,7 @@ fn test_parameter_shadowed_in_nested_scope() {
     // Parameter can be shadowed in nested scope
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             {
                 let param = 100; // OK: shadows parameter in nested scope
                 return param;
@@ -143,7 +143,7 @@ fn test_parameter_shadowed_in_nested_scope() {
 fn test_multiple_parameters_all_used() {
     assert_semantic_ok!(
         r#"
-        func test(a: felt, b: felt, c: felt) -> felt {
+        fn test(a: felt, b: felt, c: felt) -> felt {
             return a + b + c;
         }
     "#
@@ -154,7 +154,7 @@ fn test_multiple_parameters_all_used() {
 fn test_multiple_parameters_some_unused() {
     assert_semantic_err!(
         r#"
-        func test(used: felt, unused1: felt, unused2: felt) -> felt {
+        fn test(used: felt, unused1: felt, unused2: felt) -> felt {
             return used;
         }
     "#,
@@ -166,11 +166,11 @@ fn test_multiple_parameters_some_unused() {
 fn test_parameter_used_in_function_call() {
     assert_semantic_ok!(
         r#"
-        func helper(x: felt) -> felt {
+        fn helper(x: felt) -> felt {
             return x * 2;
         }
 
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             return helper(param);
         }
     "#
@@ -181,7 +181,7 @@ fn test_parameter_used_in_function_call() {
 fn test_parameter_used_in_complex_expression() {
     assert_semantic_ok!(
         r#"
-        func test(a: felt, b: felt, c: felt) -> felt {
+        fn test(a: felt, b: felt, c: felt) -> felt {
             return (a + b) * c - a / b;
         }
     "#
@@ -192,7 +192,7 @@ fn test_parameter_used_in_complex_expression() {
 fn test_parameter_type_annotation() {
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             return param;
         }
     "#
@@ -203,11 +203,11 @@ fn test_parameter_type_annotation() {
 fn test_function_call_with_correct_parameter_count() {
     assert_semantic_ok!(
         r#"
-        func helper(x: felt, y: felt) -> felt {
+        fn helper(x: felt, y: felt) -> felt {
             return x + y;
         }
 
-        func test() -> felt {
+        fn test() -> felt {
             return helper(10, 20);
         }
     "#
@@ -218,7 +218,7 @@ fn test_function_call_with_correct_parameter_count() {
 fn test_parameter_used_as_condition() {
     assert_semantic_ok!(
         r#"
-        func test(condition: felt) -> felt {
+        fn test(condition: felt) -> felt {
             if (condition == 0) {
                 return 1;
             } else {
@@ -233,7 +233,7 @@ fn test_parameter_used_as_condition() {
 fn test_parameter_used_in_return_statement() {
     assert_semantic_ok!(
         r#"
-        func test(value: felt) -> felt {
+        fn test(value: felt) -> felt {
             return value;
         }
     "#
@@ -244,7 +244,7 @@ fn test_parameter_used_in_return_statement() {
 fn test_recursive_function_with_parameter() {
     assert_semantic_ok!(
         r#"
-        func factorial(n: felt) -> felt {
+        fn factorial(n: felt) -> felt {
             if (n == 1) {
                 return 1;
             } else {

--- a/crates/compiler/semantic/tests/functions/return_types.rs
+++ b/crates/compiler/semantic/tests/functions/return_types.rs
@@ -6,7 +6,7 @@ use crate::*;
 fn test_function_with_felt_return_type() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             return 42;
         }
     "#
@@ -17,7 +17,7 @@ fn test_function_with_felt_return_type() {
 fn test_function_with_unit_return_type() {
     assert_semantic_ok!(
         r#"
-        func test() {
+        fn test() {
             return ();
         }
     "#
@@ -28,7 +28,7 @@ fn test_function_with_unit_return_type() {
 fn test_function_with_explicit_unit_return_type() {
     assert_semantic_ok!(
         r#"
-        func test() -> () {
+        fn test() -> () {
             return ();
         }
     "#
@@ -39,7 +39,7 @@ fn test_function_with_explicit_unit_return_type() {
 fn test_function_missing_return_statement() {
     assert_semantic_err!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 42;
             // Missing return statement
         }
@@ -52,7 +52,7 @@ fn test_function_unit_missing_return_statement() {
     // Unit functions should still require explicit return
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let x = 42;
             // Missing return () statement
         }
@@ -64,7 +64,7 @@ fn test_function_unit_missing_return_statement() {
 fn test_function_return_variable() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 42;
             return x;
         }
@@ -76,7 +76,7 @@ fn test_function_return_variable() {
 fn test_function_return_expression() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 10;
             let y = 20;
             return x + y;
@@ -89,11 +89,11 @@ fn test_function_return_expression() {
 fn test_function_return_function_call() {
     assert_semantic_ok!(
         r#"
-        func helper() -> felt {
+        fn helper() -> felt {
             return 42;
         }
 
-        func test() -> felt {
+        fn test() -> felt {
             return helper();
         }
     "#
@@ -104,7 +104,7 @@ fn test_function_return_function_call() {
 fn test_function_return_complex_expression() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let a = 10;
             let b = 5;
             let c = 2;
@@ -118,7 +118,7 @@ fn test_function_return_complex_expression() {
 fn test_function_return_in_if_statement() {
     assert_semantic_ok!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return x;
             } else {
@@ -133,7 +133,7 @@ fn test_function_return_in_if_statement() {
 fn test_function_return_missing_in_if_branch() {
     assert_semantic_err!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return x;
             }
@@ -147,7 +147,7 @@ fn test_function_return_missing_in_if_branch() {
 fn test_function_return_missing_in_else_branch() {
     assert_semantic_err!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return x;
             } else {
@@ -163,7 +163,7 @@ fn test_function_return_missing_in_else_branch() {
 fn test_function_return_in_nested_blocks() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             {
                 {
                     return 42;
@@ -178,7 +178,7 @@ fn test_function_return_in_nested_blocks() {
 fn test_function_return_parameter() {
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             return param;
         }
     "#
@@ -189,7 +189,7 @@ fn test_function_return_parameter() {
 fn test_function_return_modified_parameter() {
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             param = param + 1;
             return param;
         }
@@ -201,7 +201,7 @@ fn test_function_return_modified_parameter() {
 fn test_function_early_return() {
     assert_semantic_ok!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 0; // Early return
             }
@@ -217,7 +217,7 @@ fn test_function_early_return() {
 fn test_function_multiple_return_paths() {
     assert_semantic_ok!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 100) {
                 return 100;
             } else if (x == 0) {
@@ -234,7 +234,7 @@ fn test_function_multiple_return_paths() {
 fn test_function_return_undeclared_variable() {
     assert_semantic_err!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             return undefined_var;
         }
     "#
@@ -245,7 +245,7 @@ fn test_function_return_undeclared_variable() {
 fn test_recursive_function_return() {
     assert_semantic_ok!(
         r#"
-        func factorial(n: felt) -> felt {
+        fn factorial(n: felt) -> felt {
             if (n == 1) {
                 return 1;
             } else {
@@ -260,7 +260,7 @@ fn test_recursive_function_return() {
 fn test_function_return_literal() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             return 42;
         }
     "#
@@ -272,7 +272,7 @@ fn test_function_void_return_with_value() {
     // Unit functions should return () not values
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             return 42; // Error: should return ()
         }
     "#
@@ -283,7 +283,7 @@ fn test_function_void_return_with_value() {
 fn test_function_nested_control_flow_all_paths_return() {
     assert_semantic_ok!(
         r#"
-        func test(x: felt, y: felt) -> felt {
+        fn test(x: felt, y: felt) -> felt {
             if (x == 0) {
                 if (y == 0) {
                     return 1;

--- a/crates/compiler/semantic/tests/functions/tuple_destructuring.rs
+++ b/crates/compiler/semantic/tests/functions/tuple_destructuring.rs
@@ -6,7 +6,7 @@ use crate::*;
 fn test_basic_tuple_destructuring() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let (x, y) = (10, 20);
             return x + y;
         }
@@ -18,7 +18,7 @@ fn test_basic_tuple_destructuring() {
 fn test_tuple_destructuring_type_mismatch() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let (x, y) = 42; // Error: Cannot destructure non-tuple
         }
         "#
@@ -29,7 +29,7 @@ fn test_tuple_destructuring_type_mismatch() {
 fn test_tuple_destructuring_arity_mismatch() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let (x, y) = (1, 2, 3); // Error: Pattern has 2 elements but value has 3
         }
         "#
@@ -40,7 +40,7 @@ fn test_tuple_destructuring_arity_mismatch() {
 fn test_tuple_destructuring_wrong_type_annotation() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let (x, y): felt = (1, 2); // Error: Expected felt, found tuple
         }
         "#
@@ -51,7 +51,7 @@ fn test_tuple_destructuring_wrong_type_annotation() {
 fn test_local_tuple_destructuring() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             local (a, b): (felt, felt) = (100, 200);
             let sum = a + b;
             return sum;
@@ -64,11 +64,11 @@ fn test_local_tuple_destructuring() {
 fn test_tuple_destructuring_from_function() {
     assert_semantic_ok!(
         r#"
-        func returns_tuple() -> (felt, felt) {
+        fn returns_tuple() -> (felt, felt) {
             return (100, 200);
         }
-        
-        func test() -> felt {
+
+        fn test() -> felt {
             let (a, b) = returns_tuple();
             return a + b;
         }
@@ -80,7 +80,7 @@ fn test_tuple_destructuring_from_function() {
 fn test_tuple_destructuring_unused_variables() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let (x, y) = (1, 2); // y should be marked as unused
             let z = x + 1;
         }

--- a/crates/compiler/semantic/tests/integration/mod.rs
+++ b/crates/compiler/semantic/tests/integration/mod.rs
@@ -12,21 +12,21 @@ pub mod multi_file_test;
 fn test_complete_program_with_multiple_functions() {
     assert_semantic_ok!(
         r#"
-        func add(a: felt, b: felt) -> felt {
+        fn add(a: felt, b: felt) -> felt {
             return a + b;
         }
 
-        func multiply(a: felt, b: felt) -> felt {
+        fn multiply(a: felt, b: felt) -> felt {
             return a * b;
         }
 
-        func calculate(x: felt, y: felt) -> felt {
+        fn calculate(x: felt, y: felt) -> felt {
             let sum = add(x, y);
             let product = multiply(sum, 2);
             return product;
         }
 
-        func main() -> felt {
+        fn main() -> felt {
             let result = calculate(10, 20);
             return result;
         }
@@ -40,15 +40,15 @@ fn test_program_with_structs_and_functions() {
         "Point",
         "x: felt, y: felt",
         r#"
-        func create_point(x: felt, y: felt) -> Point {
+        fn create_point(x: felt, y: felt) -> Point {
             return Point { x: x, y: y };
         }
 
-        func distance_squared(p: Point) -> felt {
+        fn distance_squared(p: Point) -> felt {
             return p.x * p.x + p.y * p.y;
         }
 
-        func main() -> felt {
+        fn main() -> felt {
             let point = create_point(3, 4);
             return distance_squared(point);
         }
@@ -62,7 +62,7 @@ fn test_complex_control_flow_integration() {
     // TODO: fix this when support for arrays is added
     assert_semantic_ok!(
         r#"
-        func process_number(n: felt) -> felt {
+        fn process_number(n: felt) -> felt {
             if (n == 0) {
                 return n / 2;
             } else {
@@ -70,7 +70,7 @@ fn test_complex_control_flow_integration() {
             }
         }
 
-        func main() -> felt {
+        fn main() -> felt {
             let numbers: felt* = [1, 2, 3, 4, 5];
             let result = 0;
 
@@ -90,7 +90,7 @@ fn test_error_combination_undeclared_and_unused() {
     // This should catch both undeclared variable and unused variable errors
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let unused_var = 42;
             let result = undefined_var + 10;
         }
@@ -102,11 +102,11 @@ fn test_error_combination_undeclared_and_unused() {
 fn test_nested_scopes_with_function_calls() {
     assert_semantic_ok!(
         r#"
-        func helper(x: felt) -> felt {
+        fn helper(x: felt) -> felt {
             return x * 2;
         }
 
-        func complex_function(param: felt) -> felt {
+        fn complex_function(param: felt) -> felt {
             let outer = param;
             {
                 let middle = helper(outer);
@@ -121,7 +121,7 @@ fn test_nested_scopes_with_function_calls() {
             }
         }
 
-        func main() -> felt {
+        fn main() -> felt {
             return complex_function(10);
         }
     "#
@@ -133,12 +133,12 @@ fn test_comprehensive_error_detection() {
     // Test that multiple types of errors are detected in one program
     assert_semantic_err!(
         r#"
-        func helper(x: felt) -> felt {
+        fn helper(x: felt) -> felt {
             let unused = 42; // Unused variable
             return undefined_var; // Undeclared variable
         }
 
-        func test() -> felt {
+        fn test() -> felt {
             let shadowed = 1;
             let shadowed = 2;
 

--- a/crates/compiler/semantic/tests/integration/multi_file_test.rs
+++ b/crates/compiler/semantic/tests/integration/multi_file_test.rs
@@ -16,7 +16,7 @@ fn test_cross_module_function_call() {
 
     // Create utils module with a function
     let utils_source = r#"
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 "#;
@@ -25,7 +25,7 @@ func add(a: felt, b: felt) -> felt {
     let main_source = r#"
 use utils::add;
 
-func test() -> felt {
+fn test() -> felt {
     return add(1, 2);
 }
 "#;
@@ -62,7 +62,7 @@ fn test_undefined_import() {
     let main_source = r#"
 use utils::nonexistent;
 
-func test() {
+fn test() {
     nonexistent();
 }
 "#;
@@ -105,7 +105,7 @@ struct Point {
     let main_source = r#"
 use types::Point;
 
-func test() -> Point {
+fn test() -> Point {
     return Point { x: 1, y: 2 };
 }
 "#;
@@ -144,7 +144,7 @@ fn test_cyclic_imports() {
     let module_a_source = r#"
 use module_b::func_b;
 
-func func_a() {
+fn func_a() {
     func_b();
 }
 "#;
@@ -153,7 +153,7 @@ func func_a() {
     let module_b_source = r#"
 use module_a::func_a;
 
-func func_b() {
+fn func_b() {
     func_a();
 }
 "#;
@@ -197,22 +197,22 @@ fn test_multi_file_project_validation() {
 
     // Create a project with multiple independent modules
     let math_source = r#"
-func multiply(a: felt, b: felt) -> felt {
+fn multiply(a: felt, b: felt) -> felt {
     return a * b;
 }
 
-func divide(a: felt, b: felt) -> felt {
+fn divide(a: felt, b: felt) -> felt {
     return a / b;
 }
 "#;
 
     let utils_source = r#"
-func foo(a: felt, b: felt) -> felt {
+fn foo(a: felt, b: felt) -> felt {
     // Simplified max function for testing
     return a;
 }
 
-func square(x: felt) -> felt {
+fn square(x: felt) -> felt {
     return x * x;
 }
 "#;
@@ -221,7 +221,7 @@ func square(x: felt) -> felt {
 use math::multiply;
 use utils::foo;
 
-func main() -> felt {
+fn main() -> felt {
     let x = multiply(5, 6);
     let y = foo(x, 10);
     return y;
@@ -263,15 +263,15 @@ fn test_braced_imports() {
 
     // Create lib module with multiple functions
     let lib_source = r#"
-func a() -> felt {
+fn a() -> felt {
     return 1;
 }
 
-func b() -> felt {
+fn b() -> felt {
     return 2;
 }
 
-func c() -> felt {
+fn c() -> felt {
     return 3;
 }
 "#;
@@ -280,7 +280,7 @@ func c() -> felt {
     let main_source = r#"
 use lib::{a, b};
 
-func test() -> felt {
+fn test() -> felt {
     let x = a();
     let y = b();
     return x + y;
@@ -318,7 +318,7 @@ fn test_import_name_conflict_with_local() {
 
     // Create lib module with a function
     let lib_source = r#"
-func my_func() -> felt {
+fn my_func() -> felt {
     return 42;
 }
 "#;
@@ -327,7 +327,7 @@ func my_func() -> felt {
     let main_source = r#"
 use lib::my_func;
 
-func test() -> felt {
+fn test() -> felt {
     let my_func = 100;  // Local variable shadows the imported function
     return my_func;     // Should refer to the local variable (100), not imported function
 }
@@ -364,7 +364,7 @@ fn test_undefined_braced_import_item() {
 
     // Create lib module with only one function
     let lib_source = r#"
-func a() -> felt {
+fn a() -> felt {
     return 1;
 }
 "#;
@@ -373,7 +373,7 @@ func a() -> felt {
     let main_source = r#"
 use lib::{a, nonexistent_b};
 
-func test() -> felt {
+fn test() -> felt {
     let x = a();
     let y = nonexistent_b();  // This should cause an error
     return x + y;
@@ -425,13 +425,13 @@ fn test_multiple_import_conflicts() {
 
     // Create two modules with conflicting function names
     let math_source = r#"
-func calculate() -> felt {
+fn calculate() -> felt {
     return 42;
 }
 "#;
 
     let utils_source = r#"
-func calculate() -> felt {
+fn calculate() -> felt {
     return 100;
 }
 "#;
@@ -441,7 +441,7 @@ func calculate() -> felt {
 use math::calculate;
 use utils::calculate;  // This should cause a conflict
 
-func test() -> felt {
+fn test() -> felt {
     return calculate();
 }
 "#;
@@ -487,21 +487,21 @@ fn test_braced_import_conflicts() {
 
     // Create two modules with conflicting function names
     let math_source = r#"
-func calculate() -> felt {
+fn calculate() -> felt {
     return 42;
 }
 
-func add() -> felt {
+fn add() -> felt {
     return 1;
 }
 "#;
 
     let utils_source = r#"
-func calculate() -> felt {
+fn calculate() -> felt {
     return 100;
 }
 
-func subtract() -> felt {
+fn subtract() -> felt {
     return 2;
 }
 "#;
@@ -511,7 +511,7 @@ func subtract() -> felt {
 use math::{calculate, add};
 use utils::{calculate, subtract};  // calculate should cause a conflict
 
-func test() -> felt {
+fn test() -> felt {
     return calculate() + add() + subtract();
 }
 "#;
@@ -567,7 +567,7 @@ fn test_nested_module_imports() {
 
     // Create a chain of modules: main -> utils -> core
     let core_source = r#"
-func core_function() -> felt {
+fn core_function() -> felt {
     return 1;
 }
 "#;
@@ -575,7 +575,7 @@ func core_function() -> felt {
     let utils_source = r#"
 use core::core_function;
 
-func utils_function() -> felt {
+fn utils_function() -> felt {
     return core_function() + 1;
 }
 "#;
@@ -583,7 +583,7 @@ func utils_function() -> felt {
     let main_source = r#"
 use utils::utils_function;
 
-func test() -> felt {
+fn test() -> felt {
     return utils_function();
 }
 "#;
@@ -623,11 +623,11 @@ fn test_self_import_detected() {
     let main_source = r#"
 use main::foo;
 
-func foo() -> felt {
+fn foo() -> felt {
     return 42;
 }
 
-func test() -> felt {
+fn test() -> felt {
     return foo();
 }
 "#;
@@ -672,15 +672,15 @@ fn test_self_import_with_braced_syntax() {
     let utils_source = r#"
 use utils::{add, multiply};
 
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 
-func multiply(a: felt, b: felt) -> felt {
+fn multiply(a: felt, b: felt) -> felt {
     return a * b;
 }
 
-func test() -> felt {
+fn test() -> felt {
     return add(1, 2);
 }
 "#;
@@ -723,7 +723,7 @@ fn test_cross_module_type_checking_wrong_argument_types() {
 
     // Create math module with add function
     let math_source = r#"
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 "#;
@@ -741,7 +741,7 @@ struct Point {
 use math::add;
 use types::Point;
 
-func test() {
+fn test() {
     let p = Point { x: 1, y: 1 };
     add(1, p); // ERROR: second argument should be 'felt', not 'Point'
 }
@@ -798,7 +798,7 @@ fn test_cross_module_type_checking_wrong_argument_count() {
 
     // Create math module with add function that takes 2 parameters
     let math_source = r#"
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 "#;
@@ -807,7 +807,7 @@ func add(a: felt, b: felt) -> felt {
     let main_source = r#"
 use math::add;
 
-func test() {
+fn test() {
     add(1); // ERROR: Expected 2 arguments, got 1
 }
 "#;
@@ -875,7 +875,7 @@ struct Point {
     let main_source = r#"
 use types::Point;
 
-func test() {
+fn test() {
     // ERROR: wrong field name 'z' and missing field 'y'
     let p = Point { x: 1, z: 2 };
 }
@@ -932,7 +932,7 @@ fn test_duplicate_import_same_item() {
 
     // Create math module with add function
     let math_source = r#"
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 "#;
@@ -942,7 +942,7 @@ func add(a: felt, b: felt) -> felt {
 use math::add;
 use math::add; // ERROR: 'add' is already imported
 
-func test() {
+fn test() {
     add(1, 2);
 }
 "#;
@@ -997,7 +997,7 @@ fn test_import_conflict_with_top_level_definition() {
 
     // Create lib module with my_func
     let lib_source = r#"
-func my_func() -> felt {
+fn my_func() -> felt {
     return 1;
 }
 "#;
@@ -1007,11 +1007,11 @@ func my_func() -> felt {
 use lib::my_func;
 
 // ERROR: 'my_func' is defined multiple times
-func my_func() -> felt {
+fn my_func() -> felt {
     return 2;
 }
 
-func test() -> felt {
+fn test() -> felt {
     return my_func();
 }
 "#;
@@ -1065,7 +1065,7 @@ fn test_unused_imports() {
 
     // Create lib module with functions and struct
     let lib_source = r#"
-func my_func() {}
+fn my_func() {}
 
 struct Point {
     x: felt
@@ -1076,7 +1076,7 @@ struct Point {
     let main_source = r#"
 use lib::{my_func, Point}; // Both 'my_func' and 'Point' are unused
 
-func test() -> felt {
+fn test() -> felt {
     return 0;
 }
 "#;

--- a/crates/compiler/semantic/tests/mod.rs
+++ b/crates/compiler/semantic/tests/mod.rs
@@ -266,22 +266,22 @@ macro_rules! assert_semantic_err {
 
 /// Helper to wrap statement code inside a function, since most statements are not top-level.
 pub fn in_function(code: &str) -> String {
-    format!("func test() {{ {code} }}")
+    format!("fn test() {{ {code} }}")
 }
 
 /// Helper to wrap code in a function with a return type
 pub fn in_function_with_return(code: &str, return_type: &str) -> String {
-    format!("func test() -> {return_type} {{ {code} }}")
+    format!("fn test() -> {return_type} {{ {code} }}")
 }
 
 /// Helper to wrap code in a function with parameters
 pub fn in_function_with_params(code: &str, params: &str) -> String {
-    format!("func test({params}) {{ {code} }}")
+    format!("fn test({params}) {{ {code} }}")
 }
 
 /// Helper to wrap code in a function with both parameters and return type
 pub fn in_function_with_params_and_return(code: &str, params: &str, return_type: &str) -> String {
-    format!("func test({params}) -> {return_type} {{ {code} }}")
+    format!("fn test({params}) -> {return_type} {{ {code} }}")
 }
 
 /// Helper to create a struct definition with the given fields

--- a/crates/compiler/semantic/tests/scoping/duplicate_definitions.rs
+++ b/crates/compiler/semantic/tests/scoping/duplicate_definitions.rs
@@ -6,7 +6,7 @@ use crate::*;
 fn test_duplicate_in_same_scope() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let var = 10;
             let another = 20;
             let var = 30;
@@ -20,7 +20,7 @@ fn test_duplicate_in_same_scope() {
 fn test_duplicate_parameters() {
     assert_semantic_err!(
         r#"
-        func test(param: felt, param: felt) -> felt {
+        fn test(param: felt, param: felt) -> felt {
             return param;
         }
     "#
@@ -32,7 +32,7 @@ fn test_parameter_and_local_shadowing() {
     // Local variables can shadow parameters
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             let param = 42;
             return param;
         }
@@ -45,7 +45,7 @@ fn test_no_duplicate_across_scopes() {
     // This should be OK - different scopes can have same variable names
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 1;
             {
                 let x = 2; // OK: different scope
@@ -60,11 +60,11 @@ fn test_no_duplicate_across_scopes() {
 fn test_duplicate_function_names() {
     assert_semantic_err!(
         r#"
-        func duplicate_func() {
+        fn duplicate_func() {
             return ();
         }
 
-        func duplicate_func() {
+        fn duplicate_func() {
             return ();
         }
     "#
@@ -76,7 +76,7 @@ fn test_multiple_shadowing() {
     // Multiple variables can be shadowed
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 1;
             let y = 2;
             let x = 3;

--- a/crates/compiler/semantic/tests/scoping/nested_scopes.rs
+++ b/crates/compiler/semantic/tests/scoping/nested_scopes.rs
@@ -6,7 +6,7 @@ use crate::*;
 fn test_deeply_nested_scopes() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let level1 = 1;
             {
                 let level2 = level1 + 1;
@@ -27,7 +27,7 @@ fn test_deeply_nested_scopes() {
 fn test_nested_scope_variable_access() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let outer = 1;
             {
                 let middle = 2;
@@ -45,7 +45,7 @@ fn test_nested_scope_variable_access() {
 fn test_nested_if_scopes() {
     assert_semantic_ok!(
         r#"
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 let positive = x;
                 if (positive == 10) {
@@ -66,7 +66,7 @@ fn test_nested_if_scopes() {
 fn test_nested_scope_shadowing() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 1;
             {
                 let x = 2; // Shadows outer x
@@ -84,7 +84,7 @@ fn test_nested_scope_shadowing() {
 fn test_complex_scope_interaction() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let a = 1;
             {
                 let b = a + 1; // OK: a is visible
@@ -103,11 +103,11 @@ fn test_complex_scope_interaction() {
 fn test_nested_function_calls_with_scopes() {
     assert_semantic_ok!(
         r#"
-        func helper(x: felt) -> felt {
+        fn helper(x: felt) -> felt {
             return x * 2;
         }
 
-        func test() -> felt {
+        fn test() -> felt {
             let outer = 5;
             {
                 let middle = helper(outer);
@@ -125,7 +125,7 @@ fn test_nested_function_calls_with_scopes() {
 fn test_scope_boundaries_with_assignments() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let x = 1;
             {
                 let y = 2;
@@ -141,7 +141,7 @@ fn test_scope_boundaries_with_assignments() {
 fn test_multiple_nested_branches() {
     assert_semantic_ok!(
         r#"
-        func test(condition: felt) -> felt {
+        fn test(condition: felt) -> felt {
             let base = 10;
             if (condition == 0) {
                 let branch1 = base + 1;

--- a/crates/compiler/semantic/tests/scoping/scope_visibility.rs
+++ b/crates/compiler/semantic/tests/scoping/scope_visibility.rs
@@ -6,7 +6,7 @@ use crate::*;
 fn test_basic_scope_visibility() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let outer = 1;
             {
                 let inner = outer + 1; // OK: outer is visible
@@ -21,7 +21,7 @@ fn test_basic_scope_visibility() {
 fn test_inner_scope_not_visible_outside() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             {
                 let inner = 42;
             }
@@ -35,7 +35,7 @@ fn test_inner_scope_not_visible_outside() {
 fn test_nested_scope_access() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let level1 = 1;
             {
                 let level2 = level1 + 1; // OK: level1 visible
@@ -53,7 +53,7 @@ fn test_nested_scope_access() {
 fn test_sibling_scopes_not_visible() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             {
                 let first_scope = 1;
             }
@@ -69,7 +69,7 @@ fn test_sibling_scopes_not_visible() {
 fn test_parameter_visible_in_function() {
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             let var =  param + 1;
             return var;
         }
@@ -81,7 +81,7 @@ fn test_parameter_visible_in_function() {
 fn test_parameter_visible_in_nested_scopes() {
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             {
                 let inner = param + 1; // OK: param visible
                 {
@@ -99,7 +99,7 @@ fn test_parameter_visible_in_nested_scopes() {
 fn test_if_statement_scope() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             if (true) {
                 let if_var = 42;
             }
@@ -114,7 +114,7 @@ fn test_variable_shadowing_different_scopes() {
     // This should be OK - different scopes can have same variable names
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 1;
             {
                 let x = 2; // OK: different scope
@@ -129,7 +129,7 @@ fn test_variable_shadowing_different_scopes() {
 fn test_complex_nested_visibility() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let outer = 1;
             {
                 let middle = outer + 1; // OK

--- a/crates/compiler/semantic/tests/scoping/undeclared_variables.rs
+++ b/crates/compiler/semantic/tests/scoping/undeclared_variables.rs
@@ -6,7 +6,7 @@ use crate::*;
 fn test_simple_undeclared_variable() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let x = undefined_var;
         }
     "#
@@ -17,7 +17,7 @@ fn test_simple_undeclared_variable() {
 fn test_undeclared_in_expression() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let x = 5;
             let y = x + undefined_var;
         }
@@ -29,7 +29,7 @@ fn test_undeclared_in_expression() {
 fn test_undeclared_in_return() {
     assert_semantic_err!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             return undefined_var;
         }
     "#
@@ -40,11 +40,11 @@ fn test_undeclared_in_return() {
 fn test_undeclared_in_function_call() {
     assert_semantic_err!(
         r#"
-        func valid_func(x: felt) -> felt {
+        fn valid_func(x: felt) -> felt {
             return x;
         }
 
-        func test() {
+        fn test() {
             let result = valid_func(undefined_var);
         }
     "#
@@ -55,7 +55,7 @@ fn test_undeclared_in_function_call() {
 fn test_undeclared_function_call() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let result = undefined_function(42);
         }
     "#
@@ -66,7 +66,7 @@ fn test_undeclared_function_call() {
 fn test_multiple_undeclared_variables() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let x = first_undefined;
             let y = second_undefined;
             let z = x + y + third_undefined;
@@ -79,7 +79,7 @@ fn test_multiple_undeclared_variables() {
 fn test_undeclared_in_if_condition() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             if (undefined_condition) {
                 let x = 1;
             }
@@ -92,7 +92,7 @@ fn test_undeclared_in_if_condition() {
 fn test_undeclared_in_assignment() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let x = 5;
             x = undefined_var;
         }
@@ -104,7 +104,7 @@ fn test_undeclared_in_assignment() {
 fn test_declared_variable_ok() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 5;
             let y = x + 10;
             return y;
@@ -117,7 +117,7 @@ fn test_declared_variable_ok() {
 fn test_parameter_usage_ok() {
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             let variable = param + 1;
             return variable;
         }

--- a/crates/compiler/semantic/tests/scoping/unused_variables.rs
+++ b/crates/compiler/semantic/tests/scoping/unused_variables.rs
@@ -6,7 +6,7 @@ use crate::*;
 fn test_simple_unused_variable() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let unused = 42;
             return ();
         }
@@ -19,7 +19,7 @@ fn test_simple_unused_variable() {
 fn test_unused_parameter() {
     assert_semantic_err!(
         r#"
-        func test(unused_param: felt) {
+        fn test(unused_param: felt) {
             return ();
         }
     "#,
@@ -31,7 +31,7 @@ fn test_unused_parameter() {
 fn test_multiple_unused_variables() {
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let unused1 = 10;
             let unused2 = 20;
             let unused3 = 30;
@@ -46,7 +46,7 @@ fn test_multiple_unused_variables() {
 fn test_mixed_used_and_unused() {
     assert_semantic_err!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let used = 10;
             let unused = 20;
             return used;
@@ -60,7 +60,7 @@ fn test_mixed_used_and_unused() {
 fn test_unused_in_nested_scope() {
     assert_semantic_err!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let used = 10;
             {
                 let unused_inner = 20;
@@ -76,7 +76,7 @@ fn test_unused_in_nested_scope() {
 fn test_variable_used_in_expression() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 10;
             let y = 20;
             return x + y;
@@ -89,7 +89,7 @@ fn test_variable_used_in_expression() {
 fn test_variable_used_in_assignment() {
     assert_semantic_ok!(
         r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 10;
             let y = 20;
             y = x + 5;
@@ -103,7 +103,7 @@ fn test_variable_used_in_assignment() {
 fn test_parameter_used() {
     assert_semantic_ok!(
         r#"
-        func test(param: felt) -> felt {
+        fn test(param: felt) -> felt {
             return param + 1;
         }
     "#
@@ -117,7 +117,7 @@ fn test_unused_but_assigned() {
     // TODO: fix this one
     assert_semantic_err!(
         r#"
-        func test() {
+        fn test() {
             let unused = 10;
             unused = 20;
             return ();

--- a/crates/compiler/semantic/tests/semantic_model.rs
+++ b/crates/compiler/semantic/tests/semantic_model.rs
@@ -81,7 +81,7 @@ where
 #[test]
 fn test_use_def_resolution_simple() {
     let source = r#"
-        func main() {
+        fn main() {
             let x = 42; // Definition
             let y = x;  // Usage
         }
@@ -117,7 +117,7 @@ fn test_use_def_resolution_across_scopes() {
     let source = r#"
         const global_var = 100;
 
-        func test() {
+        fn test() {
             let local_var = global_var; // Usage of global_var
             return local_var;           // Usage of local_var
         }
@@ -171,7 +171,7 @@ fn test_use_def_resolution_across_scopes() {
 fn test_scope_hierarchy_correctness() {
     let source = r#"
         namespace Math {
-            func square(x: felt) -> felt {
+            fn square(x: felt) -> felt {
                 let result = x * x;
                 return result;
             }
@@ -222,7 +222,7 @@ fn test_scope_hierarchy_correctness() {
 #[test]
 fn test_symbol_table_flags() {
     let source = r#"
-        func test(param: felt) {
+        fn test(param: felt) {
             let used_var = 1;
             let unused_var = 2;
             return used_var + param;
@@ -265,7 +265,7 @@ fn test_symbol_table_flags() {
 
 #[test]
 fn test_span_to_scope_mapping() {
-    let source = r#"func test() { let x = 1; }"#;
+    let source = r#"fn test() { let x = 1; }"#;
 
     with_semantic_index(source, |_db, _file, index| {
         // The exact spans depend on the parser, but we can verify the mapping exists
@@ -298,7 +298,7 @@ fn test_span_to_scope_mapping() {
 #[test]
 fn test_expression_tracking() {
     let source = r#"
-        func test() {
+        fn test() {
             let a = 42;
             let b = a + 1;
             return b;
@@ -345,7 +345,7 @@ fn test_definition_completeness() {
             y: felt,
         }
 
-        func distance(p1: Point, p2: Point) -> felt {
+        fn distance(p1: Point, p2: Point) -> felt {
             let dx = p1.x - p2.x;
             return dx;
         }
@@ -397,7 +397,7 @@ fn test_definition_completeness() {
 #[test]
 fn test_unresolved_identifier_tracking() {
     let source = r#"
-        func test() {
+        fn test() {
             let x = undefined_variable; // This should be tracked as unresolved
         }
     "#;
@@ -433,7 +433,7 @@ fn test_nested_scope_name_resolution() {
     let source = r#"
         const outer = 1;
 
-        func test() {
+        fn test() {
             let inner = 2;
             let combined = outer + inner; // Uses both outer and inner
         }
@@ -483,7 +483,7 @@ fn test_nested_scope_name_resolution() {
 fn test_variable_shadowing_resolution() {
     let source = r#"
         const x = 1; // Outer x
-        func test() {
+        fn test() {
             let x = 2; // Inner x, shadows outer
             let y = x; // This should resolve to the inner x
         }
@@ -577,7 +577,7 @@ fn test_variable_shadowing_resolution() {
 #[test]
 fn test_same_scope_shadowing_resolution() {
     let source = r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x = 10;     // First definition
             let y = x;      // Uses first x (10)
             let x = 20;     // Shadows x in same scope

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::break_continue::test_break_continue_in_block_outside_loop.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::break_continue::test_break_continue_in_block_outside_loop.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::break_continue::test_break_continue_in_bl
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             {
                 break;
             }

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::break_continue::test_break_continue_mix.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::break_continue::test_break_continue_mix.snap
@@ -6,16 +6,16 @@ Fixture: semantic_tests::control_flow::break_continue::test_break_continue_mix
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             break;  // Error
-            
+
             loop {
                 break;  // OK
                 continue;  // OK (unreachable but syntactically valid)
             }
-            
+
             continue;  // Error
-            
+
             while (1) {
                 if (1) {
                     break;  // OK
@@ -23,7 +23,7 @@ Source code:
                     continue;  // OK
                 }
             }
-            
+
             return;
         }
         

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::break_continue::test_multiple_break_continue_errors.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::break_continue::test_multiple_break_continue_errors.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::break_continue::test_multiple_break_conti
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             break;
             if (1) {
                 continue;

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::control_flow_paths::test_nested_control_flow_missing_path.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::control_flow_paths::test_nested_control_flow_missing_path.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::control_flow_paths::test_nested_control_f
 ============================================================
 Source code:
 
-        func test(x: felt, y: felt) -> felt {
+        fn test(x: felt, y: felt) -> felt {
             if (x == 0) {
                 if (y == 0) {
                     return 1;
@@ -22,9 +22,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::control_flow::control_flow_paths::test_nested_control_flow_missing_path:2:14 ]
+   ╭─[ semantic_tests::control_flow::control_flow_paths::test_nested_control_flow_missing_path:2:12 ]
    │
- 2 │         func test(x: felt, y: felt) -> felt {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test(x: felt, y: felt) -> felt {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::control_flow_paths::test_not_all_paths_return.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::control_flow_paths::test_not_all_paths_return.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::control_flow_paths::test_not_all_paths_re
 ============================================================
 Source code:
 
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 1;
             }
@@ -18,9 +18,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::control_flow::control_flow_paths::test_not_all_paths_return:2:14 ]
+   ╭─[ semantic_tests::control_flow::control_flow_paths::test_not_all_paths_return:2:12 ]
    │
- 2 │         func test(x: felt) -> felt {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test(x: felt) -> felt {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_scoping::test_loop_body_creates_new_scope.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_scoping::test_loop_body_creates_new_scope.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_scoping::test_loop_body_creates_new_
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             loop {
                 let x = 42;
                 break;

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_scoping::test_loop_scope_with_blocks.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_scoping::test_loop_scope_with_blocks.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_scoping::test_loop_scope_with_blocks
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             loop {
                 let loop_var = 1;
                 {

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_scoping::test_nested_loop_scopes.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_scoping::test_nested_loop_scopes.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_scoping::test_nested_loop_scopes
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             loop {
                 let outer = 1;
                 loop {

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_scoping::test_while_loop_scoping.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_scoping::test_while_loop_scoping.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_scoping::test_while_loop_scoping
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let condition = 1;
             while (condition) {
                 let loop_var = 42;

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_type_checking::test_while_loop_with_complex_non_felt_expression.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_type_checking::test_while_loop_with_complex_non_felt_expression.snap
@@ -10,7 +10,7 @@ Source code:
             enabled: felt,
         }
 
-        func test() {
+        fn test() {
             let config: Config = Config { enabled: 1 };
             // This should fail - accessing the struct itself, not the field
             while (config) {
@@ -32,9 +32,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::control_flow::loop_type_checking::test_while_loop_with_complex_non_felt_expression:6:14 ]
+   ╭─[ semantic_tests::control_flow::loop_type_checking::test_while_loop_with_complex_non_felt_expression:6:12 ]
    │
- 6 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 6 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_type_checking::test_while_loop_with_function_returning_non_felt.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_type_checking::test_while_loop_with_function_returning_non_felt.snap
@@ -9,17 +9,17 @@ Source code:
         struct Data {
             value: felt,
         }
-        
-        func get_data() -> Data {
+
+        fn get_data() -> Data {
             return Data { value: 42 };
         }
-        
-        func test() {
+
+        fn test() {
             while (get_data()) {
                 return;
             }
         }
-        
+
 ============================================================
 Found 2 diagnostic(s):
 
@@ -28,7 +28,7 @@ Found 2 diagnostic(s):
     ╭─[ semantic_tests::control_flow::loop_type_checking::test_while_loop_with_function_returning_non_felt:11:20 ]
     │
  11 │             while (get_data()) {
-    │                    ─────┬────  
+    │                    ─────┬────
     │                         ╰────── While loop condition must be of type felt, found 'Data'
 ────╯
 
@@ -36,7 +36,7 @@ Found 2 diagnostic(s):
 [3002] Error: Function 'test' doesn't return on all paths
     ╭─[ semantic_tests::control_flow::loop_type_checking::test_while_loop_with_function_returning_non_felt:10:14 ]
     │
- 10 │         func test() {
-    │              ──┬─  
+ 10 │         fn test() {
+    │              ──┬─
     │                ╰─── Function 'test' doesn't return on all paths
 ────╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_type_checking::test_while_loop_with_non_felt_condition.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_type_checking::test_while_loop_with_non_felt_condition.snap
@@ -11,7 +11,7 @@ Source code:
             y: felt,
         }
 
-        func test() {
+        fn test() {
             let p: Point = Point { x: 1, y: 2 };
             while (p) {
                 return;
@@ -32,9 +32,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::control_flow::loop_type_checking::test_while_loop_with_non_felt_condition:7:14 ]
+   ╭─[ semantic_tests::control_flow::loop_type_checking::test_while_loop_with_non_felt_condition:7:12 ]
    │
- 7 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 7 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_type_checking::test_while_loop_with_tuple_condition.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_type_checking::test_while_loop_with_tuple_condition.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_type_checking::test_while_loop_with_
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let t: (felt, felt) = (1, 2);
             while (t) {
                 return;
@@ -27,9 +27,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::control_flow::loop_type_checking::test_while_loop_with_tuple_condition:2:14 ]
+   ╭─[ semantic_tests::control_flow::loop_type_checking::test_while_loop_with_tuple_condition:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_unreachable::test_code_after_break.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_unreachable::test_code_after_break.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_unreachable::test_code_after_break
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             loop {
                 break;
                 let x = 1;  // Unreachable

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_unreachable::test_code_after_continue.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_unreachable::test_code_after_continue.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_unreachable::test_code_after_continu
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             loop {
                 continue;
                 let x = 1;  // Unreachable

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_unreachable::test_code_after_infinite_loop.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_unreachable::test_code_after_infinite_loop.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_unreachable::test_code_after_infinit
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             loop {
                 let x = 1;
             }

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_unreachable::test_loop_with_return.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_unreachable::test_loop_with_return.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_unreachable::test_loop_with_return
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             loop {
                 return;
                 let x = 1;  // Unreachable

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_unreachable::test_nested_loop_unreachable.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_unreachable::test_nested_loop_unreachable.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_unreachable::test_nested_loop_unreac
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             loop {
                 loop {
                     break;

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_validation::test_break_in_if_outside_loop.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_validation::test_break_in_if_outside_loop.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_validation::test_break_in_if_outside
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             if (1) {
                 break;
             }

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_validation::test_break_outside_loop.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_validation::test_break_outside_loop.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_validation::test_break_outside_loop
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             break;
             return;
         }

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_validation::test_continue_outside_loop.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::loop_validation::test_continue_outside_loop.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::loop_validation::test_continue_outside_lo
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             continue;
             return;
         }

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::missing_returns::test_missing_return_in_else.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::missing_returns::test_missing_return_in_else.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::missing_returns::test_missing_return_in_e
 ============================================================
 Source code:
 
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 1;
             } else {
@@ -20,9 +20,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::control_flow::missing_returns::test_missing_return_in_else:2:14 ]
+   ╭─[ semantic_tests::control_flow::missing_returns::test_missing_return_in_else:2:12 ]
    │
- 2 │         func test(x: felt) -> felt {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test(x: felt) -> felt {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::missing_returns::test_missing_return_simple.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::missing_returns::test_missing_return_simple.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::missing_returns::test_missing_return_simp
 ============================================================
 Source code:
 
-        func test() -> felt {
+        fn test() -> felt {
             let x = 42;
             // Missing return statement
         }
@@ -16,9 +16,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::control_flow::missing_returns::test_missing_return_simple:2:14 ]
+   ╭─[ semantic_tests::control_flow::missing_returns::test_missing_return_simple:2:12 ]
    │
- 2 │         func test() -> felt {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() -> felt {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::missing_returns::test_missing_return_with_if.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::missing_returns::test_missing_return_with_if.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::missing_returns::test_missing_return_with
 ============================================================
 Source code:
 
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 1;
             }
@@ -18,9 +18,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::control_flow::missing_returns::test_missing_return_with_if:2:14 ]
+   ╭─[ semantic_tests::control_flow::missing_returns::test_missing_return_with_if:2:12 ]
    │
- 2 │         func test(x: felt) -> felt {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test(x: felt) -> felt {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::missing_returns::test_nested_missing_return.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::missing_returns::test_nested_missing_return.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::missing_returns::test_nested_missing_retu
 ============================================================
 Source code:
 
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 if (x == 10) {
                     return 1;
@@ -23,9 +23,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::control_flow::missing_returns::test_nested_missing_return:2:14 ]
+   ╭─[ semantic_tests::control_flow::missing_returns::test_nested_missing_return:2:12 ]
    │
- 2 │         func test(x: felt) -> felt {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test(x: felt) -> felt {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::missing_returns::test_unit_return_type_implicit.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::missing_returns::test_unit_return_type_implicit.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::missing_returns::test_unit_return_type_im
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let x = 42;
             // Missing return () for unit functions
         }
@@ -16,9 +16,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::control_flow::missing_returns::test_unit_return_type_implicit:2:14 ]
+   ╭─[ semantic_tests::control_flow::missing_returns::test_unit_return_type_implicit:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::unreachable_code::test_code_after_if_with_returns.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::unreachable_code::test_code_after_if_with_returns.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::unreachable_code::test_code_after_if_with
 ============================================================
 Source code:
 
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return 1;
             } else {

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::unreachable_code::test_code_after_return.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::unreachable_code::test_code_after_return.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::unreachable_code::test_code_after_return
 ============================================================
 Source code:
 
-        func test() -> felt {
+        fn test() -> felt {
             return 42;
             let unreachable = 1; // Error: unreachable code
         }

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::unreachable_code::test_code_after_return_in_block.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::unreachable_code::test_code_after_return_in_block.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::unreachable_code::test_code_after_return_
 ============================================================
 Source code:
 
-        func test() -> felt {
+        fn test() -> felt {
             {
                 return 42;
                 let unreachable = 1; // Error: unreachable code

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::unreachable_code::test_multiple_returns_in_sequence.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::unreachable_code::test_multiple_returns_in_sequence.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::unreachable_code::test_multiple_returns_i
 ============================================================
 Source code:
 
-        func test() -> felt {
+        fn test() -> felt {
             return 1;
             return 2; // Error: unreachable code
         }

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::unreachable_code::test_unreachable_after_nested_return.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::unreachable_code::test_unreachable_after_nested_return.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::unreachable_code::test_unreachable_after_
 ============================================================
 Source code:
 
-        func test() -> felt {
+        fn test() -> felt {
             {
                 {
                     return 42;

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::unreachable_code::test_unreachable_in_complex_control_flow.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__control_flow::unreachable_code::test_unreachable_in_complex_control_flow.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::control_flow::unreachable_code::test_unreachable_in_com
 ============================================================
 Source code:
 
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 if (x == 10) {
                     return 1;

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_assignment_type_mismatch_with_context.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_assignment_type_mismatch_with_context.snap
@@ -8,7 +8,7 @@ Source code:
 
         struct Point { x: felt, y: felt }
 
-        func test() {
+        fn test() {
             let x: felt = 10;
             let p = Point { x: 1, y: 2 };
             x = p;  // Should show variable type context

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_comparison_type_mismatch_with_context.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_comparison_type_mismatch_with_context.snap
@@ -8,7 +8,7 @@ Source code:
 
         struct Point { x: felt, y: felt }
 
-        func test() {
+        fn test() {
             let p = Point { x: 1, y: 2 };
             let num = 42;
             if (p == num) {  // Type mismatch with context

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_function_argument_type_mismatch_with_param_name.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_function_argument_type_mismatch_with_param_name.snap
@@ -8,11 +8,11 @@ Source code:
 
         struct Point { x: felt, y: felt }
 
-        func distance(p1: Point, p2: Point) -> felt {
+        fn distance(p1: Point, p2: Point) -> felt {
             return 0;
         }
 
-        func test() {
+        fn test() {
             let p = Point { x: 1, y: 2 };
             let d = distance(p, 42);  // Should show parameter name 'p2'
         }
@@ -31,9 +31,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::expressions::type_errors::test_function_argument_type_mismatch_with_param_name:8:14 ]
+   ╭─[ semantic_tests::expressions::type_errors::test_function_argument_type_mismatch_with_param_name:8:12 ]
    │
- 8 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 8 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_function_not_called_error.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_function_not_called_error.snap
@@ -6,11 +6,11 @@ Fixture: semantic_tests::expressions::type_errors::test_function_not_called_erro
 ============================================================
 Source code:
 
-        func get_value() -> felt {
+        fn get_value() -> felt {
             return 42;
         }
 
-        func test() {
+        fn test() {
             let x = get_value + 5;  // Should suggest adding parentheses
         }
     
@@ -30,9 +30,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::expressions::type_errors::test_function_not_called_error:6:14 ]
+   ╭─[ semantic_tests::expressions::type_errors::test_function_not_called_error:6:12 ]
    │
- 6 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 6 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_if_condition_type_error.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_if_condition_type_error.snap
@@ -8,7 +8,7 @@ Source code:
 
         struct Point { x: felt, y: felt }
 
-        func test() {
+        fn test() {
             let p = Point { x: 1, y: 2 };
             if (p) {  // Non-felt condition
                 return ();

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_multiple_type_errors_with_suggestions.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_multiple_type_errors_with_suggestions.snap
@@ -9,7 +9,7 @@ Source code:
         struct Point { x: felt, y: felt }
         struct Counter { value: felt }
 
-        func test() -> felt {
+        fn test() -> felt {
             let p = Point { x: 1, y: 2 };
             let c = Counter { value: 10 };
             let result = p + c;  // Two type errors, both should have suggestions

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_return_type_mismatch_with_function_context.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_return_type_mismatch_with_function_context.snap
@@ -8,7 +8,7 @@ Source code:
 
         struct Point { x: felt, y: felt }
 
-        func get_coordinate() -> felt {
+        fn get_coordinate() -> felt {
             let p = Point { x: 10, y: 20 };
             return p;  // Should show function signature context
         }
@@ -20,9 +20,9 @@ Found 1 diagnostic(s):
 [2001] Error: Type mismatch in return statement. Function expects 'felt', but returning 'Point'
    ╭─[ semantic_tests::expressions::type_errors::test_return_type_mismatch_with_function_context:6:13 ]
    │
- 4 │         func get_coordinate() -> felt {
-   │              ───────┬──────  
-   │                     ╰──────── Function 'get_coordinate' declared here with return type 'felt'
+ 4 │         fn get_coordinate() -> felt {
+   │            ───────┬──────  
+   │                   ╰──────── Function 'get_coordinate' declared here with return type 'felt'
    │ 
  6 │             return p;  // Should show function signature context
    │             ────┬──┬─  

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_struct_in_arithmetic_operation.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_struct_in_arithmetic_operation.snap
@@ -8,7 +8,7 @@ Source code:
 
         struct Point { x: felt, y: felt }
 
-        func test() {
+        fn test() {
             let p = Point { x: 10, y: 20 };
             let result = p + 5;  // Error: struct in arithmetic
         }
@@ -29,9 +29,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::expressions::type_errors::test_struct_in_arithmetic_operation:4:14 ]
+   ╭─[ semantic_tests::expressions::type_errors::test_struct_in_arithmetic_operation:4:12 ]
    │
- 4 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 4 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_struct_with_numeric_field_suggestion.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_struct_with_numeric_field_suggestion.snap
@@ -8,7 +8,7 @@ Source code:
 
         struct Counter { value: felt }
 
-        func test() {
+        fn test() {
             let c = Counter { value: 42 };
             let result = c * 2;  // Should suggest accessing 'value' field
         }
@@ -29,9 +29,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::expressions::type_errors::test_struct_with_numeric_field_suggestion:4:14 ]
+   ╭─[ semantic_tests::expressions::type_errors::test_struct_with_numeric_field_suggestion:4:12 ]
    │
- 4 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 4 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_tuple_in_arithmetic_operation.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_tuple_in_arithmetic_operation.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::expressions::type_errors::test_tuple_in_arithmetic_oper
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let t = (42,);
             let result = t + 10;  // Should suggest accessing with [0]
         }
@@ -16,9 +16,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::expressions::type_errors::test_tuple_in_arithmetic_operation:2:14 ]
+   ╭─[ semantic_tests::expressions::type_errors::test_tuple_in_arithmetic_operation:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_unary_op_type_error.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__expressions::type_errors::test_unary_op_type_error.snap
@@ -8,7 +8,7 @@ Source code:
 
         struct Point { x: felt, y: felt }
 
-        func test() -> felt {
+        fn test() -> felt {
             let p = Point { x: 1, y: 2 };
             let x = -p;  // Should show type error for negation on struct
             return x;

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::function_calls::test_function_call_with_undeclared_argument.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::function_calls::test_function_call_with_undeclared_argument.snap
@@ -6,11 +6,11 @@ Fixture: semantic_tests::functions::function_calls::test_function_call_with_unde
 ============================================================
 Source code:
 
-        func helper(x: felt) -> felt {
+        fn helper(x: felt) -> felt {
             return x;
         }
 
-        func test() {
+        fn test() {
             let result = helper(undefined_var);
         }
     
@@ -28,9 +28,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::functions::function_calls::test_function_call_with_undeclared_argument:6:14 ]
+   ╭─[ semantic_tests::functions::function_calls::test_function_call_with_undeclared_argument:6:12 ]
    │
- 6 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 6 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::function_calls::test_undeclared_function_call.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::function_calls::test_undeclared_function_call.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::function_calls::test_undeclared_function_cal
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let result = undefined_function(42);
         }
     
@@ -24,9 +24,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::functions::function_calls::test_undeclared_function_call:2:14 ]
+   ╭─[ semantic_tests::functions::function_calls::test_undeclared_function_call:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::parameter_validation::test_duplicate_parameter_names.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::parameter_validation::test_duplicate_parameter_names.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::parameter_validation::test_duplicate_paramet
 ============================================================
 Source code:
 
-        func test(x: felt, x: felt) -> felt {
+        fn test(x: felt, x: felt) -> felt {
             return x;
         }
     
@@ -15,9 +15,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [1003] Error: Duplicate definition of 'x'
-   ╭─[ semantic_tests::functions::parameter_validation::test_duplicate_parameter_names:2:28 ]
+   ╭─[ semantic_tests::functions::parameter_validation::test_duplicate_parameter_names:2:26 ]
    │
- 2 │         func test(x: felt, x: felt) -> felt {
-   │                            ┬  
-   │                            ╰── Duplicate definition of 'x'
+ 2 │         fn test(x: felt, x: felt) -> felt {
+   │                          ┬  
+   │                          ╰── Duplicate definition of 'x'
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::parameter_validation::test_multiple_parameters_some_unused.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::parameter_validation::test_multiple_parameters_some_unused.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::parameter_validation::test_multiple_paramete
 ============================================================
 Source code:
 
-        func test(used: felt, unused1: felt, unused2: felt) -> felt {
+        fn test(used: felt, unused1: felt, unused2: felt) -> felt {
             return used;
         }
     
@@ -15,18 +15,18 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 1 ---
 [1002] Warning: Unused variable 'unused1'
-   ╭─[ semantic_tests::functions::parameter_validation::test_multiple_parameters_some_unused:2:31 ]
+   ╭─[ semantic_tests::functions::parameter_validation::test_multiple_parameters_some_unused:2:29 ]
    │
- 2 │         func test(used: felt, unused1: felt, unused2: felt) -> felt {
-   │                               ───┬───  
-   │                                  ╰───── Unused variable 'unused1'
+ 2 │         fn test(used: felt, unused1: felt, unused2: felt) -> felt {
+   │                             ───┬───  
+   │                                ╰───── Unused variable 'unused1'
 ───╯
 
 --- Diagnostic 2 ---
 [1002] Warning: Unused variable 'unused2'
-   ╭─[ semantic_tests::functions::parameter_validation::test_multiple_parameters_some_unused:2:46 ]
+   ╭─[ semantic_tests::functions::parameter_validation::test_multiple_parameters_some_unused:2:44 ]
    │
- 2 │         func test(used: felt, unused1: felt, unused2: felt) -> felt {
-   │                                              ───┬───  
-   │                                                 ╰───── Unused variable 'unused2'
+ 2 │         fn test(used: felt, unused1: felt, unused2: felt) -> felt {
+   │                                            ───┬───  
+   │                                               ╰───── Unused variable 'unused2'
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::parameter_validation::test_unused_parameter_warning.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::parameter_validation::test_unused_parameter_warning.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::parameter_validation::test_unused_parameter_
 ============================================================
 Source code:
 
-        func test(unused_param: felt) -> felt {
+        fn test(unused_param: felt) -> felt {
             return 42;
         }
     
@@ -15,9 +15,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [1002] Warning: Unused variable 'unused_param'
-   ╭─[ semantic_tests::functions::parameter_validation::test_unused_parameter_warning:2:19 ]
+   ╭─[ semantic_tests::functions::parameter_validation::test_unused_parameter_warning:2:17 ]
    │
- 2 │         func test(unused_param: felt) -> felt {
-   │                   ──────┬─────  
-   │                         ╰─────── Unused variable 'unused_param'
+ 2 │         fn test(unused_param: felt) -> felt {
+   │                 ──────┬─────  
+   │                       ╰─────── Unused variable 'unused_param'
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::return_types::test_function_missing_return_statement.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::return_types::test_function_missing_return_statement.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::return_types::test_function_missing_return_s
 ============================================================
 Source code:
 
-        func test() -> felt {
+        fn test() -> felt {
             let x = 42;
             // Missing return statement
         }
@@ -16,9 +16,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::functions::return_types::test_function_missing_return_statement:2:14 ]
+   ╭─[ semantic_tests::functions::return_types::test_function_missing_return_statement:2:12 ]
    │
- 2 │         func test() -> felt {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() -> felt {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::return_types::test_function_return_missing_in_else_branch.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::return_types::test_function_return_missing_in_else_branch.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::return_types::test_function_return_missing_i
 ============================================================
 Source code:
 
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return x;
             } else {
@@ -20,9 +20,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::functions::return_types::test_function_return_missing_in_else_branch:2:14 ]
+   ╭─[ semantic_tests::functions::return_types::test_function_return_missing_in_else_branch:2:12 ]
    │
- 2 │         func test(x: felt) -> felt {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test(x: felt) -> felt {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::return_types::test_function_return_missing_in_if_branch.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::return_types::test_function_return_missing_in_if_branch.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::return_types::test_function_return_missing_i
 ============================================================
 Source code:
 
-        func test(x: felt) -> felt {
+        fn test(x: felt) -> felt {
             if (x == 0) {
                 return x;
             }
@@ -18,9 +18,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::functions::return_types::test_function_return_missing_in_if_branch:2:14 ]
+   ╭─[ semantic_tests::functions::return_types::test_function_return_missing_in_if_branch:2:12 ]
    │
- 2 │         func test(x: felt) -> felt {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test(x: felt) -> felt {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::return_types::test_function_return_undeclared_variable.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::return_types::test_function_return_undeclared_variable.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::return_types::test_function_return_undeclare
 ============================================================
 Source code:
 
-        func test() -> felt {
+        fn test() -> felt {
             return undefined_var;
         }
     

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::return_types::test_function_unit_missing_return_statement.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::return_types::test_function_unit_missing_return_statement.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::return_types::test_function_unit_missing_ret
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let x = 42;
             // Missing return () statement
         }
@@ -16,9 +16,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::functions::return_types::test_function_unit_missing_return_statement:2:14 ]
+   ╭─[ semantic_tests::functions::return_types::test_function_unit_missing_return_statement:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::return_types::test_function_void_return_with_value.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::return_types::test_function_void_return_with_value.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::return_types::test_function_void_return_with
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             return 42; // Error: should return ()
         }
     
@@ -17,9 +17,9 @@ Found 1 diagnostic(s):
 [2001] Error: Function 'test' returns no value (unit type), but found return statement with type 'felt'
    ╭─[ semantic_tests::functions::return_types::test_function_void_return_with_value:3:13 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' declared here without explicit return type (implicitly returns unit)
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' declared here without explicit return type (implicitly returns unit)
  3 │             return 42; // Error: should return ()
    │             ─────┬────  
    │                  ╰────── Function 'test' returns no value (unit type), but found return statement with type 'felt'

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::tuple_destructuring::test_tuple_destructuring_arity_mismatch.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::tuple_destructuring::test_tuple_destructuring_arity_mismatch.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::tuple_destructuring::test_tuple_destructurin
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let (x, y) = (1, 2, 3); // Error: Pattern has 2 elements but value has 3
         }
         
@@ -24,9 +24,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::functions::tuple_destructuring::test_tuple_destructuring_arity_mismatch:2:14 ]
+   ╭─[ semantic_tests::functions::tuple_destructuring::test_tuple_destructuring_arity_mismatch:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::tuple_destructuring::test_tuple_destructuring_type_mismatch.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::tuple_destructuring::test_tuple_destructuring_type_mismatch.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::tuple_destructuring::test_tuple_destructurin
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let (x, y) = 42; // Error: Cannot destructure non-tuple
         }
         
@@ -24,9 +24,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::functions::tuple_destructuring::test_tuple_destructuring_type_mismatch:2:14 ]
+   ╭─[ semantic_tests::functions::tuple_destructuring::test_tuple_destructuring_type_mismatch:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::tuple_destructuring::test_tuple_destructuring_unused_variables.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::tuple_destructuring::test_tuple_destructuring_unused_variables.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::tuple_destructuring::test_tuple_destructurin
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let (x, y) = (1, 2); // y should be marked as unused
             let z = x + 1;
         }
@@ -16,9 +16,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::functions::tuple_destructuring::test_tuple_destructuring_unused_variables:2:14 ]
+   ╭─[ semantic_tests::functions::tuple_destructuring::test_tuple_destructuring_unused_variables:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__functions::tuple_destructuring::test_tuple_destructuring_wrong_type_annotation.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__functions::tuple_destructuring::test_tuple_destructuring_wrong_type_annotation.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::functions::tuple_destructuring::test_tuple_destructurin
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let (x, y): felt = (1, 2); // Error: Expected felt, found tuple
         }
         
@@ -24,9 +24,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::functions::tuple_destructuring::test_tuple_destructuring_wrong_type_annotation:2:14 ]
+   ╭─[ semantic_tests::functions::tuple_destructuring::test_tuple_destructuring_wrong_type_annotation:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__integration::test_comprehensive_error_detection.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__integration::test_comprehensive_error_detection.snap
@@ -6,12 +6,12 @@ Fixture: semantic_tests::integration::test_comprehensive_error_detection
 ============================================================
 Source code:
 
-        func helper(x: felt) -> felt {
+        fn helper(x: felt) -> felt {
             let unused = 42; // Unused variable
             return undefined_var; // Undeclared variable
         }
 
-        func test() -> felt {
+        fn test() -> felt {
             let shadowed = 1;
             let shadowed = 2;
 

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__integration::test_error_combination_undeclared_and_unused.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__integration::test_error_combination_undeclared_and_unused.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::integration::test_error_combination_undeclared_and_unus
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let unused_var = 42;
             let result = undefined_var + 10;
         }
@@ -25,9 +25,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::integration::test_error_combination_undeclared_and_unused:2:14 ]
+   ╭─[ semantic_tests::integration::test_error_combination_undeclared_and_unused:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::duplicate_definitions::test_duplicate_function_names.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::duplicate_definitions::test_duplicate_function_names.snap
@@ -6,11 +6,11 @@ Fixture: semantic_tests::scoping::duplicate_definitions::test_duplicate_function
 ============================================================
 Source code:
 
-        func duplicate_func() {
+        fn duplicate_func() {
             return ();
         }
 
-        func duplicate_func() {
+        fn duplicate_func() {
             return ();
         }
     
@@ -19,9 +19,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [1003] Error: Duplicate definition of 'duplicate_func'
-   ╭─[ semantic_tests::scoping::duplicate_definitions::test_duplicate_function_names:6:14 ]
+   ╭─[ semantic_tests::scoping::duplicate_definitions::test_duplicate_function_names:6:12 ]
    │
- 6 │         func duplicate_func() {
-   │              ───────┬──────  
-   │                     ╰──────── Duplicate definition of 'duplicate_func'
+ 6 │         fn duplicate_func() {
+   │            ───────┬──────  
+   │                   ╰──────── Duplicate definition of 'duplicate_func'
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::duplicate_definitions::test_duplicate_parameters.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::duplicate_definitions::test_duplicate_parameters.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::duplicate_definitions::test_duplicate_paramete
 ============================================================
 Source code:
 
-        func test(param: felt, param: felt) -> felt {
+        fn test(param: felt, param: felt) -> felt {
             return param;
         }
     
@@ -15,9 +15,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [1003] Error: Duplicate definition of 'param'
-   ╭─[ semantic_tests::scoping::duplicate_definitions::test_duplicate_parameters:2:32 ]
+   ╭─[ semantic_tests::scoping::duplicate_definitions::test_duplicate_parameters:2:30 ]
    │
- 2 │         func test(param: felt, param: felt) -> felt {
-   │                                ──┬──  
-   │                                  ╰──── Duplicate definition of 'param'
+ 2 │         fn test(param: felt, param: felt) -> felt {
+   │                              ──┬──  
+   │                                ╰──── Duplicate definition of 'param'
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::nested_scopes::test_complex_scope_interaction.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::nested_scopes::test_complex_scope_interaction.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::nested_scopes::test_complex_scope_interaction
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let a = 1;
             {
                 let b = a + 1; // OK: a is visible
@@ -41,9 +41,9 @@ Found 3 diagnostic(s):
 
 --- Diagnostic 3 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::nested_scopes::test_complex_scope_interaction:2:14 ]
+   ╭─[ semantic_tests::scoping::nested_scopes::test_complex_scope_interaction:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::nested_scopes::test_nested_scope_variable_access.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::nested_scopes::test_nested_scope_variable_access.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::nested_scopes::test_nested_scope_variable_acce
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let outer = 1;
             {
                 let middle = 2;
@@ -31,9 +31,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::nested_scopes::test_nested_scope_variable_access:2:14 ]
+   ╭─[ semantic_tests::scoping::nested_scopes::test_nested_scope_variable_access:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::nested_scopes::test_scope_boundaries_with_assignments.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::nested_scopes::test_scope_boundaries_with_assignments.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::nested_scopes::test_scope_boundaries_with_assi
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let x = 1;
             {
                 let y = 2;
@@ -29,9 +29,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::nested_scopes::test_scope_boundaries_with_assignments:2:14 ]
+   ╭─[ semantic_tests::scoping::nested_scopes::test_scope_boundaries_with_assignments:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::scope_visibility::test_complex_nested_visibility.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::scope_visibility::test_complex_nested_visibility.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::scope_visibility::test_complex_nested_visibili
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let outer = 1;
             {
                 let middle = outer + 1; // OK
@@ -31,9 +31,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::scope_visibility::test_complex_nested_visibility:2:14 ]
+   ╭─[ semantic_tests::scoping::scope_visibility::test_complex_nested_visibility:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::scope_visibility::test_if_statement_scope.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::scope_visibility::test_if_statement_scope.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::scope_visibility::test_if_statement_scope
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             if (true) {
                 let if_var = 42;
             }
@@ -27,9 +27,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::scope_visibility::test_if_statement_scope:2:14 ]
+   ╭─[ semantic_tests::scoping::scope_visibility::test_if_statement_scope:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::scope_visibility::test_inner_scope_not_visible_outside.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::scope_visibility::test_inner_scope_not_visible_outside.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::scope_visibility::test_inner_scope_not_visible
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             {
                 let inner = 42;
             }
@@ -27,9 +27,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::scope_visibility::test_inner_scope_not_visible_outside:2:14 ]
+   ╭─[ semantic_tests::scoping::scope_visibility::test_inner_scope_not_visible_outside:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::scope_visibility::test_sibling_scopes_not_visible.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::scope_visibility::test_sibling_scopes_not_visible.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::scope_visibility::test_sibling_scopes_not_visi
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             {
                 let first_scope = 1;
             }
@@ -29,9 +29,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::scope_visibility::test_sibling_scopes_not_visible:2:14 ]
+   ╭─[ semantic_tests::scoping::scope_visibility::test_sibling_scopes_not_visible:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_multiple_undeclared_variables.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_multiple_undeclared_variables.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::undeclared_variables::test_multiple_undeclared
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let x = first_undefined;
             let y = second_undefined;
             let z = x + y + third_undefined;
@@ -44,9 +44,9 @@ Found 4 diagnostic(s):
 
 --- Diagnostic 4 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::undeclared_variables::test_multiple_undeclared_variables:2:14 ]
+   ╭─[ semantic_tests::scoping::undeclared_variables::test_multiple_undeclared_variables:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_simple_undeclared_variable.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_simple_undeclared_variable.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::undeclared_variables::test_simple_undeclared_v
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let x = undefined_var;
         }
     
@@ -24,9 +24,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::undeclared_variables::test_simple_undeclared_variable:2:14 ]
+   ╭─[ semantic_tests::scoping::undeclared_variables::test_simple_undeclared_variable:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_undeclared_function_call.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_undeclared_function_call.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::undeclared_variables::test_undeclared_function
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let result = undefined_function(42);
         }
     
@@ -24,9 +24,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::undeclared_variables::test_undeclared_function_call:2:14 ]
+   ╭─[ semantic_tests::scoping::undeclared_variables::test_undeclared_function_call:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_undeclared_in_assignment.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_undeclared_in_assignment.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::undeclared_variables::test_undeclared_in_assig
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let x = 5;
             x = undefined_var;
         }
@@ -25,9 +25,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::undeclared_variables::test_undeclared_in_assignment:2:14 ]
+   ╭─[ semantic_tests::scoping::undeclared_variables::test_undeclared_in_assignment:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_undeclared_in_expression.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_undeclared_in_expression.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::undeclared_variables::test_undeclared_in_expre
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let x = 5;
             let y = x + undefined_var;
         }
@@ -25,9 +25,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::undeclared_variables::test_undeclared_in_expression:2:14 ]
+   ╭─[ semantic_tests::scoping::undeclared_variables::test_undeclared_in_expression:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_undeclared_in_function_call.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_undeclared_in_function_call.snap
@@ -6,11 +6,11 @@ Fixture: semantic_tests::scoping::undeclared_variables::test_undeclared_in_funct
 ============================================================
 Source code:
 
-        func valid_func(x: felt) -> felt {
+        fn valid_func(x: felt) -> felt {
             return x;
         }
 
-        func test() {
+        fn test() {
             let result = valid_func(undefined_var);
         }
     
@@ -28,9 +28,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::undeclared_variables::test_undeclared_in_function_call:6:14 ]
+   ╭─[ semantic_tests::scoping::undeclared_variables::test_undeclared_in_function_call:6:12 ]
    │
- 6 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 6 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_undeclared_in_if_condition.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_undeclared_in_if_condition.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::undeclared_variables::test_undeclared_in_if_co
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             if (undefined_condition) {
                 let x = 1;
             }
@@ -26,9 +26,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::scoping::undeclared_variables::test_undeclared_in_if_condition:2:14 ]
+   ╭─[ semantic_tests::scoping::undeclared_variables::test_undeclared_in_if_condition:2:12 ]
    │
- 2 │         func test() {
-   │              ──┬─  
-   │                ╰─── Function 'test' doesn't return on all paths
+ 2 │         fn test() {
+   │            ──┬─  
+   │              ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_undeclared_in_return.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::undeclared_variables::test_undeclared_in_return.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::undeclared_variables::test_undeclared_in_retur
 ============================================================
 Source code:
 
-        func test() -> felt {
+        fn test() -> felt {
             return undefined_var;
         }
     

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_mixed_used_and_unused.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_mixed_used_and_unused.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::unused_variables::test_mixed_used_and_unused
 ============================================================
 Source code:
 
-        func test() -> felt {
+        fn test() -> felt {
             let used = 10;
             let unused = 20;
             return used;

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_multiple_unused_variables.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_multiple_unused_variables.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::unused_variables::test_multiple_unused_variabl
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let unused1 = 10;
             let unused2 = 20;
             let unused3 = 30;

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_simple_unused_variable.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_simple_unused_variable.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::unused_variables::test_simple_unused_variable
 ============================================================
 Source code:
 
-        func test() {
+        fn test() {
             let unused = 42;
             return ();
         }

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_unused_in_nested_scope.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_unused_in_nested_scope.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::unused_variables::test_unused_in_nested_scope
 ============================================================
 Source code:
 
-        func test() -> felt {
+        fn test() -> felt {
             let used = 10;
             {
                 let unused_inner = 20;

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_unused_parameter.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_unused_parameter.snap
@@ -6,7 +6,7 @@ Fixture: semantic_tests::scoping::unused_variables::test_unused_parameter
 ============================================================
 Source code:
 
-        func test(unused_param: felt) {
+        fn test(unused_param: felt) {
             return ();
         }
     
@@ -15,9 +15,9 @@ Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [1002] Warning: Unused variable 'unused_param'
-   ╭─[ semantic_tests::scoping::unused_variables::test_unused_parameter:2:19 ]
+   ╭─[ semantic_tests::scoping::unused_variables::test_unused_parameter:2:17 ]
    │
- 2 │         func test(unused_param: felt) {
-   │                   ──────┬─────  
-   │                         ╰─────── Unused variable 'unused_param'
+ 2 │         fn test(unused_param: felt) {
+   │                 ──────┬─────  
+   │                       ╰─────── Unused variable 'unused_param'
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__statements::assignments::test_assignment_to_undeclared_variable.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__statements::assignments::test_assignment_to_undeclared_variable.snap
@@ -5,7 +5,7 @@ description: "Inline semantic validation error test: statements::assignments::te
 Fixture: semantic_tests::statements::assignments::test_assignment_to_undeclared_variable
 ============================================================
 Source code:
-func test() { 
+fn test() { 
         x = 42; // Error: undeclared variable
      }
 ============================================================
@@ -22,9 +22,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::statements::assignments::test_assignment_to_undeclared_variable:1:6 ]
+   ╭─[ semantic_tests::statements::assignments::test_assignment_to_undeclared_variable:1:4 ]
    │
- 1 │ func test() {
-   │      ──┬─  
-   │        ╰─── Function 'test' doesn't return on all paths
+ 1 │ fn test() {
+   │    ──┬─  
+   │      ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__statements::assignments::test_assignment_to_variable_not_in_scope.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__statements::assignments::test_assignment_to_variable_not_in_scope.snap
@@ -5,7 +5,7 @@ description: "Inline semantic validation error test: statements::assignments::te
 Fixture: semantic_tests::statements::assignments::test_assignment_to_variable_not_in_scope
 ============================================================
 Source code:
-func test() { 
+fn test() { 
         {
             let inner = 42;
         }
@@ -25,9 +25,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::statements::assignments::test_assignment_to_variable_not_in_scope:1:6 ]
+   ╭─[ semantic_tests::statements::assignments::test_assignment_to_variable_not_in_scope:1:4 ]
    │
- 1 │ func test() {
-   │      ──┬─  
-   │        ╰─── Function 'test' doesn't return on all paths
+ 1 │ fn test() {
+   │    ──┬─  
+   │      ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__statements::assignments::test_assignment_with_undeclared_in_rhs.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__statements::assignments::test_assignment_with_undeclared_in_rhs.snap
@@ -5,7 +5,7 @@ description: "Inline semantic validation error test: statements::assignments::te
 Fixture: semantic_tests::statements::assignments::test_assignment_with_undeclared_in_rhs
 ============================================================
 Source code:
-func test() { 
+fn test() { 
         let x = 10;
         x = undefined_var + 5; // Error: undeclared variable in RHS
      }
@@ -23,9 +23,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::statements::assignments::test_assignment_with_undeclared_in_rhs:1:6 ]
+   ╭─[ semantic_tests::statements::assignments::test_assignment_with_undeclared_in_rhs:1:4 ]
    │
- 1 │ func test() {
-   │      ──┬─  
-   │        ╰─── Function 'test' doesn't return on all paths
+ 1 │ fn test() {
+   │    ──┬─  
+   │      ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__statements::expression_statements::test_function_call_statement_undeclared.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__statements::expression_statements::test_function_call_statement_undeclared.snap
@@ -5,7 +5,7 @@ description: "Inline semantic validation error test: statements::expression_stat
 Fixture: semantic_tests::statements::expression_statements::test_function_call_statement_undeclared
 ============================================================
 Source code:
-func test() { 
+fn test() { 
         undefined_function(); // Error: undeclared function
      }
 ============================================================
@@ -22,9 +22,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::statements::expression_statements::test_function_call_statement_undeclared:1:6 ]
+   ╭─[ semantic_tests::statements::expression_statements::test_function_call_statement_undeclared:1:4 ]
    │
- 1 │ func test() {
-   │      ──┬─  
-   │        ╰─── Function 'test' doesn't return on all paths
+ 1 │ fn test() {
+   │    ──┬─  
+   │      ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__statements::expression_statements::test_function_call_statement_with_undeclared_args.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__statements::expression_statements::test_function_call_statement_with_undeclared_args.snap
@@ -5,9 +5,9 @@ description: "Inline semantic validation error test: statements::expression_stat
 Fixture: semantic_tests::statements::expression_statements::test_function_call_statement_with_undeclared_args
 ============================================================
 Source code:
-func process(x: felt) { return (); }
+fn process(x: felt) { return (); }
 
-func test() { 
+fn test() { 
             process(undefined_var); // Error: undeclared variable in argument
          }
 ============================================================
@@ -24,9 +24,9 @@ Found 2 diagnostic(s):
 
 --- Diagnostic 2 ---
 [3002] Error: Function 'test' doesn't return on all paths
-   ╭─[ semantic_tests::statements::expression_statements::test_function_call_statement_with_undeclared_args:3:6 ]
+   ╭─[ semantic_tests::statements::expression_statements::test_function_call_statement_with_undeclared_args:3:4 ]
    │
- 3 │ func test() {
-   │      ──┬─  
-   │        ╰─── Function 'test' doesn't return on all paths
+ 3 │ fn test() {
+   │    ──┬─  
+   │      ╰─── Function 'test' doesn't return on all paths
 ───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__statements::let_local_statements::test_let_with_undeclared_variable.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__statements::let_local_statements::test_let_with_undeclared_variable.snap
@@ -5,15 +5,15 @@ description: "Inline semantic validation error test: statements::let_local_state
 Fixture: semantic_tests::statements::let_local_statements::test_let_with_undeclared_variable
 ============================================================
 Source code:
-func test() { let x = undefined_var; return(); }
+fn test() { let x = undefined_var; return(); }
 ============================================================
 Found 1 diagnostic(s):
 
 --- Diagnostic 1 ---
 [1001] Error: Undeclared variable 'undefined_var'
-   ╭─[ semantic_tests::statements::let_local_statements::test_let_with_undeclared_variable:1:23 ]
+   ╭─[ semantic_tests::statements::let_local_statements::test_let_with_undeclared_variable:1:21 ]
    │
- 1 │ func test() { let x = undefined_var; return(); }
-   │                       ──────┬──────  
-   │                             ╰──────── Undeclared variable 'undefined_var'
+ 1 │ fn test() { let x = undefined_var; return(); }
+   │                     ──────┬──────  
+   │                           ╰──────── Undeclared variable 'undefined_var'
 ───╯

--- a/crates/compiler/semantic/tests/statements/assignments.rs
+++ b/crates/compiler/semantic/tests/statements/assignments.rs
@@ -97,7 +97,7 @@ fn test_assignment_to_variable_not_in_scope() {
 #[test]
 fn test_assignment_with_function_call() {
     assert_semantic_ok!(&with_functions(
-        "func get_value() -> felt { return 42; }",
+        "fn get_value() -> felt { return 42; }",
         &in_function(
             "
             let x = 10;

--- a/crates/compiler/semantic/tests/statements/expression_statements.rs
+++ b/crates/compiler/semantic/tests/statements/expression_statements.rs
@@ -5,7 +5,7 @@ use crate::*;
 #[test]
 fn test_function_call_statement() {
     assert_semantic_ok!(&with_functions(
-        "func side_effect() { return (); }",
+        "fn side_effect() { return (); }",
         &in_function(
             "
             side_effect(); // Function call as statement
@@ -27,7 +27,7 @@ fn test_function_call_statement_undeclared() {
 #[test]
 fn test_function_call_statement_with_args() {
     assert_semantic_ok!(&with_functions(
-        "func process(x: felt) { return (); }",
+        "fn process(x: felt) { return (); }",
         &in_function(
             "
             process(42); // Function call with arguments
@@ -40,7 +40,7 @@ fn test_function_call_statement_with_args() {
 #[test]
 fn test_function_call_statement_with_undeclared_args() {
     assert_semantic_err!(&with_functions(
-        "func process(x: felt) { return (); }",
+        "fn process(x: felt) { return (); }",
         &in_function(
             "
             process(undefined_var); // Error: undeclared variable in argument
@@ -52,7 +52,7 @@ fn test_function_call_statement_with_undeclared_args() {
 #[test]
 fn test_function_call_statement_with_variable_args() {
     assert_semantic_ok!(&with_functions(
-        "func process(x: felt, y: felt) { return (); }",
+        "fn process(x: felt, y: felt) { return (); }",
         &in_function(
             "
             let a = 10;
@@ -68,9 +68,9 @@ fn test_function_call_statement_with_variable_args() {
 fn test_nested_function_call_statements() {
     assert_semantic_ok!(&with_functions(
         r#"
-        func helper1() { return (); }
-        func helper2() { return (); }
-        func helper3() { return (); }
+        fn helper1() { return (); }
+        fn helper2() { return (); }
+        fn helper3() { return (); }
         "#,
         &in_function(
             "
@@ -86,7 +86,7 @@ fn test_nested_function_call_statements() {
 #[test]
 fn test_function_call_statement_in_block() {
     assert_semantic_ok!(&with_functions(
-        "func helper() { return (); }",
+        "fn helper() { return (); }",
         &in_function(
             "
             {
@@ -101,7 +101,7 @@ fn test_function_call_statement_in_block() {
 #[test]
 fn test_function_call_statement_in_if() {
     assert_semantic_ok!(&with_functions(
-        "func helper() { return (); }",
+        "fn helper() { return (); }",
         &in_function(
             "
             if (true) {
@@ -118,7 +118,7 @@ fn test_function_call_statement_in_if() {
 #[test]
 fn test_function_call_statement_with_complex_args() {
     assert_semantic_ok!(&with_functions(
-        "func process(x: felt) { return (); }",
+        "fn process(x: felt) { return (); }",
         &in_function(
             "
             let a = 10;
@@ -134,9 +134,9 @@ fn test_function_call_statement_with_complex_args() {
 fn test_multiple_function_call_statements() {
     assert_semantic_ok!(&with_functions(
         r#"
-        func step1() { return (); }
-        func step2(x: felt) { return (); }
-        func step3() { return (); }
+        fn step1() { return (); }
+        fn step2(x: felt) { return (); }
+        fn step3() { return (); }
         "#,
         &in_function(
             "
@@ -153,7 +153,7 @@ fn test_multiple_function_call_statements() {
 fn test_function_call_statement_return_value_ignored() {
     // Function calls that return values can be used as statements (return value ignored)
     assert_semantic_ok!(&with_functions(
-        "func get_value() -> felt { return 42; }",
+        "fn get_value() -> felt { return 42; }",
         &in_function(
             "
             get_value(); // Return value ignored
@@ -167,7 +167,7 @@ fn test_function_call_statement_return_value_ignored() {
 fn test_function_call_statement_with_side_effects() {
     // Test that function calls in statements properly validate their arguments
     assert_semantic_ok!(&with_functions(
-        "func modify(x: felt) { return (); }",
+        "fn modify(x: felt) { return (); }",
         &in_function(
             "
             let value = 100;
@@ -182,14 +182,14 @@ fn test_function_call_statement_with_side_effects() {
 fn test_recursive_function_call_statement() {
     assert_semantic_ok!(
         r#"
-        func recursive_helper(n: felt) {
+        fn recursive_helper(n: felt) {
             if (n == 0) {
                 recursive_helper(n - 1); // Recursive call as statement
             }
             return ();
         }
 
-        func test() {
+        fn test() {
             recursive_helper(5);
             return ();
         }
@@ -202,8 +202,8 @@ fn test_chained_function_calls_as_statements() {
     // While we can't chain calls directly, we can have sequential calls
     assert_semantic_ok!(&with_functions(
         r#"
-        func first() -> felt { return 1; }
-        func second(x: felt) { return (); }
+        fn first() -> felt { return 1; }
+        fn second(x: felt) { return (); }
         "#,
         &in_function(
             "

--- a/crates/compiler/semantic/tests/statements/let_local_statements.rs
+++ b/crates/compiler/semantic/tests/statements/let_local_statements.rs
@@ -54,7 +54,7 @@ fn test_multiple_let_statements() {
 #[test]
 fn test_let_statement_with_function_call() {
     assert_semantic_ok!(&with_functions(
-        "func helper() -> felt { return 42; }",
+        "fn helper() -> felt { return 42; }",
         &in_function(
             "
             let x = helper();

--- a/crates/compiler/semantic/tests/test_cases/functions/tuple_destructuring.cm
+++ b/crates/compiler/semantic/tests/test_cases/functions/tuple_destructuring.cm
@@ -1,25 +1,25 @@
 // Test tuple destructuring in let and local statements
 
-func test_basic_tuple_destructuring() -> felt {
+fn test_basic_tuple_destructuring() -> felt {
     let (x, y) = (10, 20);
     return x + y;
 }
 
-func test_tuple_destructuring_with_type() {
+fn test_tuple_destructuring_with_type() {
     let (a, b): (felt, felt) = (1, 2);
     local (c, d): (felt, felt) = (3, 4);
 }
 
-func returns_tuple() -> (felt, felt) {
+fn returns_tuple() -> (felt, felt) {
     return (100, 200);
 }
 
-func test_function_return_destructuring() -> felt {
+fn test_function_return_destructuring() -> felt {
     let (a, b) = returns_tuple();
     return a + b;
 }
 
-func test_nested_scopes() {
+fn test_nested_scopes() {
     let (x, y) = (1, 2);
     {
         let (x, y) = (10, 20); // Shadow outer x, y
@@ -29,16 +29,16 @@ func test_nested_scopes() {
 }
 
 // Test type mismatch error
-func test_type_mismatch() {
+fn test_type_mismatch() {
     let (x, y) = 42; // Error: Cannot destructure non-tuple
 }
 
 // Test arity mismatch
-func test_arity_mismatch() {
+fn test_arity_mismatch() {
     let (x, y) = (1, 2, 3); // Error: Pattern has 2 elements but value has 3
 }
 
 // Test with explicit wrong type
-func test_wrong_type_annotation() {
+fn test_wrong_type_annotation() {
     let (x, y): felt = (1, 2); // Error: Expected felt, found tuple
 }

--- a/crates/compiler/semantic/tests/types/definition_type_tests.rs
+++ b/crates/compiler/semantic/tests/types/definition_type_tests.rs
@@ -19,7 +19,7 @@ fn get_main_semantic_index(db: &dyn SemanticDb, crate_id: Crate) -> SemanticInde
 fn test_let_variable_type_inference() {
     let db = test_db();
     let program = r#"
-        func test() {
+        fn test() {
             let x = 42;        // Should infer felt
             let y: felt = 100; // Explicit felt type
         }
@@ -58,7 +58,7 @@ fn test_parameter_type_resolution() {
     let db = test_db();
     let program = r#"
         struct Vector { x: felt, y: felt }
-        func magnitude(v: Vector, scale: felt) -> felt {
+        fn magnitude(v: Vector, scale: felt) -> felt {
             return 0;
         }
     "#;
@@ -101,7 +101,7 @@ fn test_function_type_resolution() {
     let db = test_db();
     let program = r#"
         struct Point { x: felt, y: felt }
-        func get_point(x: felt) -> Point {
+        fn get_point(x: felt) -> Point {
             return Point { x: x, y: 0 };
         }
     "#;
@@ -203,7 +203,7 @@ fn test_pointer_variable_types() {
     // For now we have no support for casts, so, this should not even compile (type checks).
     // TODO: Add typechecks for literal -> pointers.
     let program = r#"
-        func test() {
+        fn test() {
             let ptr: felt* = 0;
             let double_ptr: felt** = 0;
         }

--- a/crates/compiler/semantic/tests/types/expression_type_tests.rs
+++ b/crates/compiler/semantic/tests/types/expression_type_tests.rs
@@ -12,7 +12,7 @@ use crate::{crate_from_program, get_main_semantic_index};
 fn test_literal_expression_types() {
     let db = test_db();
     let program = r#"
-        func test() {
+        fn test() {
             let a = 42;
             let b = 0;
         }
@@ -50,7 +50,7 @@ fn test_identifier_expression_types() {
     let db = test_db();
     let program = r#"
         struct Point { x: felt, y: felt }
-        func test(p: Point) -> felt {
+        fn test(p: Point) -> felt {
             let a = 42;
             let b = a;  // b should have type felt (same as a)
             let c = p;  // c should have type Point (same as p)
@@ -82,7 +82,7 @@ fn test_identifier_expression_types() {
 fn test_binary_expression_types() {
     let db = test_db();
     let program = r#"
-        func test() {
+        fn test() {
             let a = 10;
             let b = 20;
             let sum = a + b;      // Should be felt
@@ -119,7 +119,7 @@ fn test_member_access_expression_types() {
     let db = test_db();
     let program = r#"
         struct Point { x: felt, y: felt }
-        func test(p: Point) -> felt {
+        fn test(p: Point) -> felt {
             let x_val = p.x;  // Should be felt
             let y_val = p.y;  // Should be felt
             return x_val;
@@ -155,11 +155,11 @@ fn test_function_call_expression_types() {
     let program = r#"
         struct Point { x: felt, y: felt }
 
-        func make_point(x: felt, y: felt) -> Point {
+        fn make_point(x: felt, y: felt) -> Point {
             return Point { x: x, y: y };
         }
 
-        func test() -> Point {
+        fn test() -> Point {
             let p = make_point(1, 2);  // Should be Point
             return p;
         }
@@ -197,7 +197,7 @@ fn test_struct_literal_expression_types() {
     let db = test_db();
     let program = r#"
         struct Point { x: felt, y: felt }
-        func test() -> Point {
+        fn test() -> Point {
             let p = Point { x: 1, y: 2 };  // Should be Point
             return p;
         }
@@ -239,7 +239,7 @@ fn test_complex_expression_type_inference() {
     let program = r#"
         struct Point { x: felt, y: felt }
 
-        func distance_squared(p1: Point, p2: Point) -> felt {
+        fn distance_squared(p1: Point, p2: Point) -> felt {
             let dx = p1.x - p2.x;
             let dy = p1.y - p2.y;
             let result = dx * dx + dy * dy;  // Complex expression
@@ -276,7 +276,7 @@ fn test_complex_expression_type_inference() {
 fn test_unary_expression_types() {
     let db = test_db();
     let program = r#"
-        func test() {
+        fn test() {
             let a = 10;
             let neg_a = -a;       // Should be felt
             let not_a = !a;       // Should be felt
@@ -313,7 +313,7 @@ fn test_unary_operation_type_errors() {
     let db = test_db();
     let program = r#"
         struct Point { x: felt, y: felt }
-        func test() {
+        fn test() {
             let p = Point { x: 1, y: 2 };
             let invalid_neg = -p;     // Error: negation on struct
             let invalid_not = !p;     // Error: logical not on struct

--- a/crates/compiler/semantic/tests/types/function_signature_tests.rs
+++ b/crates/compiler/semantic/tests/types/function_signature_tests.rs
@@ -12,7 +12,7 @@ use crate::{crate_from_program, get_main_semantic_index};
 fn test_simple_function_signature() {
     let db = test_db();
     let program = r#"
-        func add(a: felt, b: felt) -> felt {
+        fn add(a: felt, b: felt) -> felt {
             return a + b;
         }
     "#;
@@ -46,7 +46,7 @@ fn test_function_with_struct_parameters() {
         struct Point { x: felt, y: felt }
         struct Vector { dx: felt, dy: felt }
 
-        func translate(point: Point, offset: Vector) -> Point {
+        fn translate(point: Point, offset: Vector) -> Point {
             return Point {
                 x: point.x + offset.dx,
                 y: point.y + offset.dy
@@ -101,7 +101,7 @@ fn test_function_with_struct_parameters() {
 fn test_function_with_pointer_parameters() {
     let db = test_db();
     let program = r#"
-        func modify_value(ptr: felt*, new_value: felt) {
+        fn modify_value(ptr: felt*, new_value: felt) {
             // Function body would modify the value
         }
     "#;
@@ -152,7 +152,7 @@ fn test_function_with_pointer_parameters() {
 fn test_function_with_no_parameters() {
     let db = test_db();
     let program = r#"
-        func get_constant() -> felt {
+        fn get_constant() -> felt {
             return 42;
         }
     "#;
@@ -182,7 +182,7 @@ fn test_function_signature_consistency() {
     let db = test_db();
     let program = r#"
         struct Point { x: felt, y: felt }
-        func create_point(x: felt, y: felt) -> Point {
+        fn create_point(x: felt, y: felt) -> Point {
             return Point { x: x, y: y };
         }
     "#;
@@ -219,11 +219,11 @@ fn test_nested_function_signatures() {
     let db = test_db();
     let program = r#"
         namespace Math {
-            func square(x: felt) -> felt {
+            fn square(x: felt) -> felt {
                 return x * x;
             }
 
-            func cube(x: felt) -> felt {
+            fn cube(x: felt) -> felt {
                 return x * square(x);
             }
         }

--- a/crates/compiler/semantic/tests/types/recursive_and_error_types_tests.rs
+++ b/crates/compiler/semantic/tests/types/recursive_and_error_types_tests.rs
@@ -60,7 +60,7 @@ fn test_recursive_struct_with_pointers() {
 #[test]
 fn test_error_type_propagation() {
     let source = r#"
-        func test() {
+        fn test() {
             let x: BadType = 1; // BadType doesn't exist
             let y = x;          // y should get error type
             let z = y + 1;      // z should also get error type
@@ -149,7 +149,7 @@ fn test_deeply_nested_error_recovery() {
             field: felt,
         }
 
-        func test() {
+        fn test() {
             let good: Valid = Valid { field: 42 };
             let bad: InvalidType = good;  // Type error
             let nested = bad.nonexistent_field; // Should not crash
@@ -184,7 +184,7 @@ fn test_deeply_nested_error_recovery() {
 #[test]
 fn test_type_error_in_expression_context() {
     let source = r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x: UnknownType = 42;
             let y: felt = 10;
             return x + y; // Should handle mixed error/valid types
@@ -254,7 +254,7 @@ fn test_recursive_type_alias() {
 #[test]
 fn test_error_type_compatibility() {
     let source = r#"
-        func test() {
+        fn test() {
             let x: BadType1 = 1;
             let y: BadType2 = 2;
             let z = x + y; // Two error types in operation
@@ -318,7 +318,7 @@ fn test_complex_recursive_scenario() {
             parent: TreeNode*,
         }
 
-        func traverse(node: TreeNode*) -> felt {
+        fn traverse(node: TreeNode*) -> felt {
             if (node == null) {
                 return 0;
             }

--- a/crates/compiler/semantic/tests/types/type_compatibility_tests.rs
+++ b/crates/compiler/semantic/tests/types/type_compatibility_tests.rs
@@ -9,7 +9,7 @@ use crate::{crate_from_program, get_maybe_main_semantic_index, test_db};
 #[test]
 fn test_basic_type_compatibility() {
     let source = r#"
-        func test() {
+        fn test() {
             let a: felt = 42;
             let b: felt = a; // felt should be compatible with felt
         }
@@ -39,7 +39,7 @@ fn test_struct_type_compatibility() {
             y: felt,
         }
 
-        func test() {
+        fn test() {
             let p: Point = Point { x: 1, y: 2 };
             let v: Vector = Vector { x: 3, y: 4 };
         }
@@ -70,7 +70,7 @@ fn test_struct_type_compatibility() {
 #[test]
 fn test_error_type_handling() {
     let source = r#"
-        func test() {
+        fn test() {
             let x: BadType = 1; // BadType doesn't exist
             let y = x;          // y should get error type
             let z = y + 1;      // z should also get error type
@@ -110,15 +110,15 @@ fn test_error_type_handling() {
 #[test]
 fn test_function_type_handling() {
     let source = r#"
-        func add(a: felt, b: felt) -> felt {
+        fn add(a: felt, b: felt) -> felt {
             return a + b;
         }
 
-        func multiply(x: felt, y: felt) -> felt {
+        fn multiply(x: felt, y: felt) -> felt {
             return x * y;
         }
 
-        func single_param(x: felt) -> felt {
+        fn single_param(x: felt) -> felt {
             return x;
         }
     "#;
@@ -163,7 +163,7 @@ fn test_nested_type_handling() {
             inner: Container,
         }
 
-        func test() {
+        fn test() {
             let c: Container = Container { value: 42 };
             let w: Wrapper = Wrapper { inner: c };
         }
@@ -203,7 +203,7 @@ fn test_type_error_recovery() {
             field: felt,
         }
 
-        func test() {
+        fn test() {
             let good: Valid = Valid { field: 42 };
             let bad: InvalidType = good;  // Type error
             let nested = bad.nonexistent_field; // Should not crash
@@ -237,7 +237,7 @@ fn test_type_error_recovery() {
 #[test]
 fn test_mixed_valid_and_error_types() {
     let source = r#"
-        func test() -> felt {
+        fn test() -> felt {
             let x: UnknownType = 42;
             let y: felt = 10;
             return x + y; // Should handle mixed error/valid types
@@ -266,7 +266,7 @@ fn test_mixed_valid_and_error_types() {
 #[test]
 fn test_type_compatibility_reflexivity() {
     let source = r#"
-        func test() {
+        fn test() {
             let a: felt = 42;
             let b: felt = a; // Same type should be compatible
         }
@@ -291,13 +291,13 @@ fn test_complex_type_scenario() {
             y: felt,
         }
 
-        func distance(p1: Point, p2: Point) -> felt {
+        fn distance(p1: Point, p2: Point) -> felt {
             let dx = p1.x - p2.x;
             let dy = p1.y - p2.y;
             return dx * dx + dy * dy;
         }
 
-        func test() {
+        fn test() {
             let origin: Point = Point { x: 0, y: 0 };
             let point: Point = Point { x: 3, y: 4 };
             let dist = distance(origin, point);

--- a/crates/compiler/semantic/tests/types/type_resolution_tests.rs
+++ b/crates/compiler/semantic/tests/types/type_resolution_tests.rs
@@ -205,7 +205,7 @@ fn test_resolve_types_in_nested_scopes() {
                 y: felt,
             }
 
-            func test() -> LocalStruct {
+            fn test() -> LocalStruct {
                 return LocalStruct { y: 0 };
             }
         }

--- a/crates/compiler/src/project_discovery.rs
+++ b/crates/compiler/src/project_discovery.rs
@@ -172,8 +172,8 @@ mod tests {
         let src_dir = temp_dir.path().join("src");
         fs::create_dir_all(&src_dir).unwrap();
 
-        fs::write(src_dir.join("main.cm"), "func main() {}").unwrap();
-        fs::write(src_dir.join("math.cm"), "func add() {}").unwrap();
+        fs::write(src_dir.join("main.cm"), "fn main() {}").unwrap();
+        fs::write(src_dir.join("math.cm"), "fn add() {}").unwrap();
         fs::write(src_dir.join("README.md"), "# Test").unwrap(); // Should be ignored
 
         let config = ProjectDiscoveryConfig::default();

--- a/crates/prover/tests/test_data/all_opcodes.cm
+++ b/crates/prover/tests/test_data/all_opcodes.cm
@@ -1,7 +1,7 @@
 // Cairo-M combination test file demonstrating all compilable opcodes
 // This program exercises all implemented opcodes for comprehensive testing
 
-func main() -> felt {
+fn main() -> felt {
     // Initialize some values for arithmetic operations
     let a = 10;
     let b = 5;
@@ -71,6 +71,6 @@ func main() -> felt {
     return result;
 }
 
-func helper() -> felt {
+fn helper() -> felt {
     return 5;
 }

--- a/crates/prover/tests/test_data/fibonacci.cm
+++ b/crates/prover/tests/test_data/fibonacci.cm
@@ -1,4 +1,4 @@
-func fib(n: felt) -> felt {
+fn fib(n: felt) -> felt {
     let a = 0;
     let b = 1;
     let i = 0;

--- a/crates/prover/tests/test_data/recursive_fibonacci.cm
+++ b/crates/prover/tests/test_data/recursive_fibonacci.cm
@@ -1,4 +1,4 @@
-func fib(n: felt) -> felt {
+fn fib(n: felt) -> felt {
     if (n == 0) {
         return 0;
     }

--- a/crates/runner/benches/fibonacci_loop.cm
+++ b/crates/runner/benches/fibonacci_loop.cm
@@ -1,4 +1,4 @@
-func fibonacci_loop(n: felt) -> felt {
+fn fibonacci_loop(n: felt) -> felt {
     let a = 0;
     let b = 1;
     let i = 0;

--- a/crates/runner/src/vm/instructions/jump_tests.rs
+++ b/crates/runner/src/vm/instructions/jump_tests.rs
@@ -11,14 +11,14 @@ const JMP_REL_INITIAL_STATE: State = State {
 
 /// Macro for absolute jump tests with empty memory
 macro_rules! test_jmp_abs_no_memory {
-    ($test_name:ident, $opcode:expr, $func:ident, $operands:expr, $expected_pc:expr) => {
+    ($test_name:ident, $opcode:expr, $fn:ident, $operands:expr, $expected_pc:expr) => {
         #[test]
         fn $test_name() -> Result<(), MemoryError> {
             let mut memory = Memory::default();
             let state = State::default();
             let instruction = Instruction::new($opcode, $operands);
 
-            let new_state = $func(&mut memory, state, &instruction)?;
+            let new_state = $fn(&mut memory, state, &instruction)?;
 
             let expected_state = State {
                 pc: M31($expected_pc),
@@ -33,13 +33,13 @@ macro_rules! test_jmp_abs_no_memory {
 
 /// Macro for relative jump tests with empty memory
 macro_rules! test_jmp_rel_no_memory {
-    ($test_name:ident, $opcode:expr, $func:ident, $operands:expr, $expected_pc:expr) => {
+    ($test_name:ident, $opcode:expr, $fn:ident, $operands:expr, $expected_pc:expr) => {
         #[test]
         fn $test_name() -> Result<(), MemoryError> {
             let mut memory = Memory::default();
             let instruction = Instruction::new($opcode, $operands);
 
-            let new_state = $func(&mut memory, JMP_REL_INITIAL_STATE, &instruction)?;
+            let new_state = $fn(&mut memory, JMP_REL_INITIAL_STATE, &instruction)?;
 
             let expected_state = State {
                 pc: M31($expected_pc),

--- a/crates/runner/src/vm/vm_tests.rs
+++ b/crates/runner/src/vm/vm_tests.rs
@@ -365,13 +365,13 @@ fn test_run_from_entrypoint_exponential_recursive_fibonacci() {
 /// Runs a Fibonacci program on the VM and asserts the result against the reference implementation.
 ///
 /// ```cairo-m
-/// func main() -> felt {
+/// fn main() -> felt {
 ///   let n = 10;
 ///   let result = fib(n);
 ///   return result;
 /// }
 ///
-/// func fib(n: felt) -> felt {
+/// fn fib(n: felt) -> felt {
 ///   if n == 0 {
 ///     return 0;
 ///   }

--- a/crates/runner/tests/test_data/ackermann.cm
+++ b/crates/runner/tests/test_data/ackermann.cm
@@ -1,11 +1,11 @@
-func main() -> felt {
+fn main() -> felt {
     let m = 2;
     let n = 2;
     let result = ackermann(m, n);
     return result;
 }
 
-func ackermann(m: felt, n: felt) -> felt {
+fn ackermann(m: felt, n: felt) -> felt {
     if (m == 0) {
         return n + 1;
     }

--- a/crates/runner/tests/test_data/combination.cm
+++ b/crates/runner/tests/test_data/combination.cm
@@ -1,4 +1,4 @@
-func main() -> felt {
+fn main() -> felt {
     let x = 3;
     let y = 13;
     let even_number = 16;
@@ -19,10 +19,10 @@ func main() -> felt {
     return mut_val + eq2 + a + bar() + b + compound1 + compound2;
 }
 
-func foo() -> (felt, felt) {
+fn foo() -> (felt, felt) {
     return (32, 62);
 }
 
-func bar() -> felt {
+fn bar() -> felt {
     return 123;
 }

--- a/crates/runner/tests/test_data/double_factorial.cm
+++ b/crates/runner/tests/test_data/double_factorial.cm
@@ -1,10 +1,10 @@
-func main() -> felt {
+fn main() -> felt {
     let n = 9;
     let result = double_factorial(n);
     return result;
 }
 
-func double_factorial(n: felt) -> felt {
+fn double_factorial(n: felt) -> felt {
     if (n == 0) {
         return 1;
     }

--- a/crates/runner/tests/test_data/factorial.cm
+++ b/crates/runner/tests/test_data/factorial.cm
@@ -1,10 +1,10 @@
-func main() -> felt {
+fn main() -> felt {
     let n = 10;
     let result = factorial(n);
     return result;
 }
 
-func factorial(n: felt) -> felt {
+fn factorial(n: felt) -> felt {
     if (n == 0) {
         return 1;
     }

--- a/crates/runner/tests/test_data/fibonacci.cm
+++ b/crates/runner/tests/test_data/fibonacci.cm
@@ -1,4 +1,4 @@
-func fib(n: felt) -> felt {
+fn fib(n: felt) -> felt {
     if (n == 0) {
         return 0;
     }

--- a/crates/runner/tests/test_data/fibonacci_loop.cm
+++ b/crates/runner/tests/test_data/fibonacci_loop.cm
@@ -1,4 +1,4 @@
-func fibonacci_loop(n: felt) -> felt {
+fn fibonacci_loop(n: felt) -> felt {
     let a = 0;
     let b = 1;
     let i = 0;

--- a/crates/runner/tests/test_data/loops_with_break_continue.cm
+++ b/crates/runner/tests/test_data/loops_with_break_continue.cm
@@ -1,4 +1,4 @@
-func loops_with_break_continue() -> felt {
+fn loops_with_break_continue() -> felt {
     let counter = 0;
     let i = 0;
     loop {

--- a/crates/runner/tests/test_data/mutual_recursion.cm
+++ b/crates/runner/tests/test_data/mutual_recursion.cm
@@ -1,18 +1,18 @@
-func main() -> felt {
+fn main() -> felt {
     let n = 42;
     let even_result = is_even(n);
     let odd_result = is_odd(n);
     return even_result * 100 + odd_result;
 }
 
-func is_even(n: felt) -> felt {
+fn is_even(n: felt) -> felt {
     if (n == 0) {
         return 1;
     }
     return is_odd(n - 1);
 }
 
-func is_odd(n: felt) -> felt {
+fn is_odd(n: felt) -> felt {
     if (n == 0) {
         return 0;
     }

--- a/crates/runner/tests/test_data/nested_calls.cm
+++ b/crates/runner/tests/test_data/nested_calls.cm
@@ -1,17 +1,17 @@
-func main() -> felt {
+fn main() -> felt {
     let x = 7;
     let result = compute(x);
     return result;
 }
 
-func compute(x: felt) -> felt {
+fn compute(x: felt) -> felt {
     return add(mul(x, 3), mul(x, 5));
 }
 
-func add(a: felt, b: felt) -> felt {
+fn add(a: felt, b: felt) -> felt {
     return a + b;
 }
 
-func mul(a: felt, b: felt) -> felt {
+fn mul(a: felt, b: felt) -> felt {
     return a * b;
 }

--- a/crates/runner/tests/test_data/nested_while_loops.cm
+++ b/crates/runner/tests/test_data/nested_while_loops.cm
@@ -1,4 +1,4 @@
-func nested_while_loops() -> felt {
+fn nested_while_loops() -> felt {
     let i = 0;
     let j = 0;
     while (i != 10) {

--- a/crates/runner/tests/test_data/power.cm
+++ b/crates/runner/tests/test_data/power.cm
@@ -1,4 +1,4 @@
-func power(base: felt, exp: felt) -> felt {
+fn power(base: felt, exp: felt) -> felt {
     if (exp == 0) {
         return 1;
     }

--- a/crates/runner/tests/test_data/sum_n.cm
+++ b/crates/runner/tests/test_data/sum_n.cm
@@ -1,10 +1,10 @@
-func main() -> felt {
+fn main() -> felt {
     let n = 10;
     let result = sum_n(n);
     return result;
 }
 
-func sum_n(n: felt) -> felt {
+fn sum_n(n: felt) -> felt {
     if (n == 0) {
         return 0;
     }

--- a/crates/runner/tests/test_data/triangular.cm
+++ b/crates/runner/tests/test_data/triangular.cm
@@ -1,10 +1,10 @@
-func main() -> felt {
+fn main() -> felt {
     let n = 100;
     let result = triangular(n);
     return result;
 }
 
-func triangular(n: felt) -> felt {
+fn triangular(n: felt) -> felt {
     if (n == 0) {
         return 0;
     }

--- a/docs/lang/project-structure.md
+++ b/docs/lang/project-structure.md
@@ -63,7 +63,7 @@ To import the `add` function from the `math` module:
 // In src/main.cm
 use math::add;
 
-func main() -> felt {
+fn main() -> felt {
     return add(1, 2);
 }
 ```
@@ -74,7 +74,7 @@ To import multiple items from the same module, use curly braces `{}`:
 // In src/main.cm
 use math::{add, sub};
 
-func main() -> felt {
+fn main() -> felt {
     let a = add(5, 3);
     return sub(a, 1);
 }
@@ -114,11 +114,11 @@ Follow these steps to create a new project.
     **`src/math.cm`**:
 
     ```cairo
-    func add(a: felt, b: felt) -> felt {
+    fn add(a: felt, b: felt) -> felt {
         return a + b;
     }
 
-    func sub(a: felt, b: felt) -> felt {
+    fn sub(a: felt, b: felt) -> felt {
         return a - b;
     }
     ```
@@ -128,7 +128,7 @@ Follow these steps to create a new project.
     ```cairo
     use math::{add, sub};
 
-    func main() -> felt {
+    fn main() -> felt {
         let x = add(10, 5);
         let y = sub(x, 3);
         return y;

--- a/test_diagnostics.cm
+++ b/test_diagnostics.cm
@@ -1,7 +1,0 @@
-func test_unused() {
-    let x = 3;
-    let x = 4;
-    let x = 5;
-    faoskhd();
-    return ();
-}

--- a/vscode-cairo-m/syntaxes/cairo-m.tmLanguage.json
+++ b/vscode-cairo-m/syntaxes/cairo-m.tmLanguage.json
@@ -96,7 +96,7 @@
         },
         {
           "name": "keyword.other.cairo-m",
-          "match": "\\b(func|let|local|const|struct|namespace|use|as)\\b"
+          "match": "\\b(fn|let|local|const|struct|namespace|use|as)\\b"
         },
         {
           "name": "constant.language.boolean.cairo-m",
@@ -165,7 +165,7 @@
     "functions": {
       "patterns": [
         {
-          "match": "(func)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(",
+          "match": "(fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(",
           "captures": {
             "1": {
               "name": "keyword.other.cairo-m"


### PR DESCRIPTION
refactors the keyword for functions from `func` to `fn`. 

Rationale is that it's way easier for LLM codegen and I observed mis-generations using `fn` for `func`. At the era of AI, it makes more sense.