### PR TITLE
fix(compiler): better handling of unused variables

### DIFF
--- a/crates/compiler/mir/src/ir_generation.rs
+++ b/crates/compiler/mir/src/ir_generation.rs
@@ -392,14 +392,14 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                         let def_id = DefinitionId::new(self.db, self.file, def_idx);
                         let mir_def_id = self.convert_definition_id(def_id);
 
-                        // Check if this variable is used
+                        // Check if this variable is used (read)
                         let is_used =
                             if let Some(definition) = self.semantic_index.definition(def_idx) {
                                 if let Some(place_table) =
                                     self.semantic_index.place_table(definition.scope_id)
                                 {
                                     if let Some(place) = place_table.place(definition.place_id) {
-                                        place.is_used()
+                                        place.is_read()
                                     } else {
                                         true
                                     }
@@ -564,7 +564,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                                     .place_table(def.scope_id)
                                     .and_then(|pt| pt.place(def.place_id))
                             })
-                            .map(|p| p.is_used())
+                            .map(|p| p.is_read())
                             .unwrap_or(true); // Conservatively assume used
 
                         let elem_type = element_types[i];
@@ -611,7 +611,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                             self.semantic_index.place_table(definition.scope_id)
                         {
                             if let Some(place) = place_table.place(definition.place_id) {
-                                place.is_used()
+                                place.is_read()
                             } else {
                                 true
                             }
@@ -696,7 +696,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                                 {
                                     // Check if the place is marked as used
                                     if let Some(place) = place_table.place(definition.place_id) {
-                                        place.is_used()
+                                        place.is_read()
                                     } else {
                                         true // Conservative: assume used if we can't find the place
                                     }
@@ -779,7 +779,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                                             if let Some(place) =
                                                 place_table.place(definition.place_id)
                                             {
-                                                place.is_used()
+                                                place.is_read()
                                             } else {
                                                 true
                                             }

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__aggregates_struct_literal.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__aggregates_struct_literal.snap
@@ -18,9 +18,9 @@ struct Point {
     y: felt,
 }
 
-fn test() -> felt {
+fn test() -> Point {
     let p = Point { x: 10, y: 20 };
-    return 0;
+    return p;
 }
 
 ============================================================
@@ -39,7 +39,7 @@ module {
       // Get address of field 'y'
 %2 = getelementptr %0, 1
       store %2, 20
-      return 0
+      return %0
 
   }
 

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__optimizations_unused_variable_elimination.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__optimizations_unused_variable_elimination.snap
@@ -9,16 +9,35 @@ expression: mir_output
 Fixture: unused_variable_elimination.cm
 ============================================================
 Source code:
-//!ASSERT FUNCTION_COUNT: 1
-//!ASSERT NOT_CONTAINS: %5 = stackalloc
-//!ASSERT NOT_CONTAINS: store %5
-
 // Test that unused variables don't generate allocations
 fn test_unused(a: felt, b: felt) -> felt {
     let c = a + b;  // Used - should allocate
     let d = a * b;  // Unused - should NOT allocate
     let e = a == b; // Unused - should NOT allocate
     return c;
+}
+
+struct TestStruct {
+    a: felt,
+    b: felt,
+}
+
+fn test_unused_struct(a: felt, b: felt) -> felt {
+    let s = TestStruct { a: a, b: b }; // Unused - should NOT allocate
+    let s2 = TestStruct { a: a, b: b }; // Used - should allocate TODO: propagate unused variables so that this is also ignored
+    let c = s2.a; // Unused - should NOT allocate
+    return 0;
+}
+
+
+fn foo() -> felt {
+    return 0;
+}
+
+fn test_unused_side_effect() -> felt {
+    let y = 1 + 2; // Unused - should NOT allocate
+    let x = foo() + 42; // Unused - should NOT allocate but should call foo
+    return 0;
 }
 
 ============================================================
@@ -33,6 +52,43 @@ module {
       %2 = stackalloc 1
       %2 = %0 Add %1
       return %2
+
+  }
+
+  // Function 1
+  fn test_unused_struct {
+    parameters: [0, 1]
+    entry: 0
+
+    0:
+      // Allocate struct
+%3 = stackalloc 2
+      // Get address of field 'a'
+%4 = getelementptr %3, 0
+      store %4, %0
+      // Get address of field 'b'
+%5 = getelementptr %3, 1
+      store %5, %1
+      return 0
+
+  }
+
+  // Function 2
+  fn foo {
+    entry: 0
+
+    0:
+      return 0
+
+  }
+
+  // Function 3
+  fn test_unused_side_effect {
+    entry: 0
+
+    0:
+      %1 = call 2()
+      return 0
 
   }
 

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__optimizations_unused_variable_elimination.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__optimizations_unused_variable_elimination.snap
@@ -29,6 +29,11 @@ fn test_unused_struct(a: felt, b: felt) -> felt {
     return 0;
 }
 
+fn test_unused_tuple(a: felt, b: felt) -> felt {
+    let t = (a, b); // Unused - should NOT allocate
+    return 0;
+}
+
 
 fn foo() -> felt {
     return 0;
@@ -74,7 +79,8 @@ module {
   }
 
   // Function 2
-  fn foo {
+  fn test_unused_tuple {
+    parameters: [0, 1]
     entry: 0
 
     0:
@@ -83,11 +89,20 @@ module {
   }
 
   // Function 3
+  fn foo {
+    entry: 0
+
+    0:
+      return 0
+
+  }
+
+  // Function 4
   fn test_unused_side_effect {
     entry: 0
 
     0:
-      %1 = call 2()
+      %1 = call 3()
       return 0
 
   }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/aggregates/struct_literal.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/aggregates/struct_literal.cm
@@ -7,7 +7,7 @@ struct Point {
     y: felt,
 }
 
-fn test() -> felt {
+fn test() -> Point {
     let p = Point { x: 10, y: 20 };
-    return 0;
+    return p;
 }

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/optimizations/unused_variable_elimination.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/optimizations/unused_variable_elimination.cm
@@ -18,6 +18,11 @@ fn test_unused_struct(a: felt, b: felt) -> felt {
     return 0;
 }
 
+fn test_unused_tuple(a: felt, b: felt) -> felt {
+    let t = (a, b); // Unused - should NOT allocate
+    return 0;
+}
+
 
 fn foo() -> felt {
     return 0;

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/optimizations/unused_variable_elimination.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/optimizations/unused_variable_elimination.cm
@@ -1,11 +1,30 @@
-//!ASSERT FUNCTION_COUNT: 1
-//!ASSERT NOT_CONTAINS: %5 = stackalloc
-//!ASSERT NOT_CONTAINS: store %5
-
 // Test that unused variables don't generate allocations
 fn test_unused(a: felt, b: felt) -> felt {
     let c = a + b;  // Used - should allocate
     let d = a * b;  // Unused - should NOT allocate
     let e = a == b; // Unused - should NOT allocate
     return c;
+}
+
+struct TestStruct {
+    a: felt,
+    b: felt,
+}
+
+fn test_unused_struct(a: felt, b: felt) -> felt {
+    let s = TestStruct { a: a, b: b }; // Unused - should NOT allocate
+    let s2 = TestStruct { a: a, b: b }; // Used - should allocate TODO: propagate unused variables so that this is also ignored
+    let c = s2.a; // Unused - should NOT allocate
+    return 0;
+}
+
+
+fn foo() -> felt {
+    return 0;
+}
+
+fn test_unused_side_effect() -> felt {
+    let y = 1 + 2; // Unused - should NOT allocate
+    let x = foo() + 42; // Unused - should NOT allocate but should call foo
+    return 0;
 }

--- a/crates/compiler/semantic/src/validation/scope_check.rs
+++ b/crates/compiler/semantic/src/validation/scope_check.rs
@@ -175,10 +175,8 @@ impl ScopeValidator {
 
     /// Check for unused variables (warnings for local variables)
     ///
-    /// TODO: Improve unused variable detection:
-    /// - Different handling for different variable types (params vs locals)
-    /// - Allow-list for common unused patterns (e.g., _unused prefix)
-    /// - Consider usage in different contexts (read vs write)
+    /// A variable is considered unused if it is defined but never read.
+    /// Variables that are only written to (assigned) but never read are still unused.
     fn check_unused_variables(
         &self,
         scope_id: crate::FileScopeId,
@@ -194,7 +192,8 @@ impl ScopeValidator {
             let is_local_or_param = !place.flags.contains(PlaceFlags::FUNCTION)
                 && !place.flags.contains(PlaceFlags::STRUCT);
 
-            if is_local_or_param && place.flags.contains(PlaceFlags::DEFINED) && !place.is_used() {
+            // A variable is unused if it's defined but never read
+            if is_local_or_param && place.flags.contains(PlaceFlags::DEFINED) && !place.is_read() {
                 // Get the proper span from the definition
                 let span =
                     if let Some((_, definition)) = index.definition_for_place(scope_id, place_id) {

--- a/crates/compiler/semantic/tests/scoping/unused_variables.rs
+++ b/crates/compiler/semantic/tests/scoping/unused_variables.rs
@@ -125,3 +125,21 @@ fn test_unused_but_assigned() {
         show_unused
     );
 }
+
+#[test]
+fn test_unused_struct_literal() {
+    assert_semantic_err!(
+        r#"
+        struct TestStruct {
+            a: felt,
+            b: felt,
+        }
+
+        fn test() -> felt {
+            let s = TestStruct { a: 1, b: 2};
+            return 0;
+        }
+    "#,
+        show_unused
+    );
+}

--- a/crates/compiler/semantic/tests/scoping/unused_variables.rs
+++ b/crates/compiler/semantic/tests/scoping/unused_variables.rs
@@ -111,7 +111,6 @@ fn test_parameter_used() {
 }
 
 #[test]
-#[ignore]
 fn test_unused_but_assigned() {
     // Variable is assigned but never read - should still be unused
     // TODO: fix this one

--- a/crates/compiler/semantic/tests/semantic_model.rs
+++ b/crates/compiler/semantic/tests/semantic_model.rs
@@ -243,7 +243,7 @@ fn test_symbol_table_flags() {
             .expect("Should find parameter");
         let param_place = func_table.place(param_place_id).unwrap();
         assert!(param_place.flags.contains(PlaceFlags::PARAMETER));
-        assert!(param_place.flags.contains(PlaceFlags::USED));
+        assert!(param_place.flags.contains(PlaceFlags::READ));
 
         // Check used variable flags
         let used_var_place_id = func_table
@@ -251,7 +251,7 @@ fn test_symbol_table_flags() {
             .expect("Should find used_var");
         let used_var_place = func_table.place(used_var_place_id).unwrap();
         assert!(used_var_place.flags.contains(PlaceFlags::DEFINED));
-        assert!(used_var_place.flags.contains(PlaceFlags::USED));
+        assert!(used_var_place.flags.contains(PlaceFlags::READ));
 
         // Check unused variable flags
         let unused_var_place_id = func_table
@@ -259,7 +259,7 @@ fn test_symbol_table_flags() {
             .expect("Should find unused_var");
         let unused_var_place = func_table.place(unused_var_place_id).unwrap();
         assert!(unused_var_place.flags.contains(PlaceFlags::DEFINED));
-        assert!(!unused_var_place.flags.contains(PlaceFlags::USED));
+        assert!(!unused_var_place.flags.contains(PlaceFlags::READ));
     });
 }
 

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_unused_but_assigned.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_unused_but_assigned.snap
@@ -1,0 +1,25 @@
+---
+source: crates/compiler/semantic/tests/mod.rs
+description: "Inline semantic validation error test: scoping::unused_variables::test_unused_but_assigned"
+---
+Fixture: semantic_tests::scoping::unused_variables::test_unused_but_assigned
+============================================================
+Source code:
+
+        fn test() {
+            let unused = 10;
+            unused = 20;
+            return ();
+        }
+    
+============================================================
+Found 1 diagnostic(s):
+
+--- Diagnostic 1 ---
+[1002] Warning: Unused variable 'unused'
+   ╭─[ semantic_tests::scoping::unused_variables::test_unused_but_assigned:3:17 ]
+   │
+ 3 │             let unused = 10;
+   │                 ───┬──  
+   │                    ╰──── Unused variable 'unused'
+───╯

--- a/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_unused_struct_literal.snap
+++ b/crates/compiler/semantic/tests/snapshots/diagnostics__scoping::unused_variables::test_unused_struct_literal.snap
@@ -1,0 +1,29 @@
+---
+source: crates/compiler/semantic/tests/mod.rs
+description: "Inline semantic validation error test: scoping::unused_variables::test_unused_struct_literal"
+---
+Fixture: semantic_tests::scoping::unused_variables::test_unused_struct_literal
+============================================================
+Source code:
+
+        struct TestStruct {
+            a: felt,
+            b: felt,
+        }
+
+        fn test() -> felt {
+            let s = TestStruct { a: 1, b: 2};
+            return 0;
+        }
+    
+============================================================
+Found 1 diagnostic(s):
+
+--- Diagnostic 1 ---
+[1002] Warning: Unused variable 's'
+   ╭─[ semantic_tests::scoping::unused_variables::test_unused_struct_literal:8:17 ]
+   │
+ 8 │             let s = TestStruct { a: 1, b: 2};
+   │                 ┬  
+   │                 ╰── Unused variable 's'
+───╯


### PR DESCRIPTION
- variables which are assigned to but never read are correctly flagged as unused (CORE-920)
- unused struct literals are not allocated anymore
- right hand side of unused assignements are evaluated only if they contain a function call