### PR TITLE
refactor(prover): optimize array filling in Enabler::packed_at

### DIFF
--- a/crates/prover/src/utils/enabler.rs
+++ b/crates/prover/src/utils/enabler.rs
@@ -25,9 +25,7 @@ impl Enabler {
 
         // The row is partially enabled.
         let mut res = [M31::zero(); N_LANES];
-        for v in res.iter_mut().take(self.padding_offset - row_offset) {
-            *v = M31::one();
-        }
+        res[..self.padding_offset - row_offset].fill(M31::one());
         PackedM31::from_array(res)
     }
 }


### PR DESCRIPTION
Replace manual iteration with the more efficient `fill` method when populating the enabler array. This improves code readability and potentially performance by using Rust's optimized array filling operation instead of manual iteration with mutable references

rebase: https://github.com/kkrt-labs/cairo-m/pull/151