### PR TITLE
feat(compiler): context‑aware numeric literal inference

### DIFF
--- a/crates/cairo-m-ls/src/backend.rs
+++ b/crates/cairo-m-ls/src/backend.rs
@@ -759,7 +759,7 @@ impl LanguageServer for Backend {
                 .map(|s| s.to_string())?;
 
             // Run semantic analysis query. Salsa will compute it incrementally.
-            let index = module_semantic_index(db.upcast(), crate_id, module_name);
+            let index = module_semantic_index(db.upcast(), crate_id, module_name).ok()?;
 
             // First, check if we're clicking on an identifier usage
             let identifier_usage = index
@@ -899,7 +899,7 @@ impl LanguageServer for Backend {
                 .map(|s| s.to_string())?;
 
             // Run semantic analysis query incrementally.
-            let index = module_semantic_index(db.upcast(), crate_id, module_name);
+            let index = module_semantic_index(db.upcast(), crate_id, module_name).ok()?;
 
             let identifier_usage = index
                 .identifier_usages()
@@ -982,7 +982,7 @@ impl LanguageServer for Backend {
                 .and_then(|stem| stem.to_str())
                 .map(|s| s.to_string())?;
 
-            let index = module_semantic_index(db.upcast(), crate_id, module_name);
+            let index = module_semantic_index(db.upcast(), crate_id, module_name).ok()?;
 
             // Find the scope at the cursor position.
             // TODO: This is inefficient. A better approach would be to have a query

--- a/crates/cairo-m-ls/tests/e2e/hover/snapshots/e2e__hover__cross_file_hover__hover_on_imported_constant.snap
+++ b/crates/cairo-m-ls/tests/e2e/hover/snapshots/e2e__hover__cross_file_hover__hover_on_imported_constant.snap
@@ -5,3 +5,5 @@ expression: result
 ```cairo-m
 MAX_VALUE: felt
 ```
+
+*From module: constants*

--- a/crates/cairo-m-ls/tests/e2e/hover/snapshots/e2e__hover__cross_file_hover__hover_on_imported_function.snap
+++ b/crates/cairo-m-ls/tests/e2e/hover/snapshots/e2e__hover__cross_file_hover__hover_on_imported_function.snap
@@ -5,3 +5,5 @@ expression: result
 ```cairo-m
 helper_foo: function
 ```
+
+*From module: utils*

--- a/crates/compiler/mir/src/ir_generation.rs
+++ b/crates/compiler/mir/src/ir_generation.rs
@@ -30,7 +30,7 @@ use cairo_m_compiler_parser::parse_file;
 use cairo_m_compiler_parser::parser::{
     Expression, FunctionDef, Pattern, Spanned, Statement, TopLevelItem,
 };
-use cairo_m_compiler_semantic::db::{Crate, project_semantic_index};
+use cairo_m_compiler_semantic::db::Crate;
 use cairo_m_compiler_semantic::definition::{Definition, DefinitionKind};
 use cairo_m_compiler_semantic::semantic_index::{DefinitionId, SemanticIndex};
 use cairo_m_compiler_semantic::type_resolution::{
@@ -521,7 +521,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
 
                     // 4. Check that the function call returns a tuple of the correct arity.
                     let func_call_semantic_type =
-                        expression_semantic_type(self.db, self.crate_id, self.file, expr_id);
+                        expression_semantic_type(self.db, self.crate_id, self.file, expr_id, None);
                     let TypeData::Tuple(element_types) = func_call_semantic_type.data(self.db)
                     else {
                         return Ok(false); // Does not return a tuple.
@@ -744,7 +744,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                 // Tuple destructuring pattern for non-literal tuples
                 // (literal tuples are handled by the optimization above)
                 let rhs_semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id);
+                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id, None);
 
                 match rhs_semantic_type.data(self.db) {
                     TypeData::Tuple(element_types) => {
@@ -892,7 +892,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                         )
                     })?;
                 let expr_semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id);
+                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id, None);
 
                 // Check if it's a tuple type
                 if let cairo_m_compiler_semantic::types::TypeData::Tuple(element_types) =
@@ -978,7 +978,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
 
                 // Query semantic type system for result type
                 let semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, rhs_expr_id);
+                    expression_semantic_type(self.db, self.crate_id, self.file, rhs_expr_id, None);
                 let result_type = MirType::from_semantic_type(self.db, semantic_type);
 
                 // Try to get the LHS ValueId directly if it's a simple identifier
@@ -1106,8 +1106,13 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                         }
 
                         // Check the function's return type
-                        let func_expr_semantic_type =
-                            expression_semantic_type(self.db, self.crate_id, self.file, expr_id);
+                        let func_expr_semantic_type = expression_semantic_type(
+                            self.db,
+                            self.crate_id,
+                            self.file,
+                            expr_id,
+                            None,
+                        );
 
                         if let cairo_m_compiler_semantic::types::TypeData::Tuple(element_types) =
                             func_expr_semantic_type.data(self.db)
@@ -1449,8 +1454,13 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                             object.span()
                         )
                     })?;
-                let object_semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, object_expr_id);
+                let object_semantic_type = expression_semantic_type(
+                    self.db,
+                    self.crate_id,
+                    self.file,
+                    object_expr_id,
+                    None,
+                );
                 let object_mir_type = MirType::from_semantic_type(self.db, object_semantic_type);
 
                 // Calculate the actual field offset from the type information
@@ -1466,7 +1476,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
 
                 // Query semantic type system for field type from the member access expression
                 let field_semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id);
+                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id, None);
                 let field_type = MirType::from_semantic_type(self.db, field_semantic_type);
                 let dest = self
                     .mir_function
@@ -1491,7 +1501,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
 
                 // Query semantic type system for array element type from the index access expression
                 let element_semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id);
+                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id, None);
                 let element_type = MirType::from_semantic_type(self.db, element_semantic_type);
                 let dest = self
                     .mir_function
@@ -1562,7 +1572,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
 
                 // Query semantic type system for result type based on this expression
                 let semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id);
+                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id, None);
                 let result_type = MirType::from_semantic_type(self.db, semantic_type);
                 let dest = self.mir_function.new_typed_value_id(result_type);
                 self.add_instruction(Instruction::unary_op(*op, dest, expr_value));
@@ -1576,7 +1586,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
 
                 // Query semantic type system for result type based on this expression
                 let semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id);
+                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id, None);
                 let result_type = MirType::from_semantic_type(self.db, semantic_type);
                 let dest = self.mir_function.new_typed_value_id(result_type);
                 self.add_instruction(Instruction::binary_op(*op, dest, lhs_value, rhs_value));
@@ -1653,6 +1663,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                                 self.crate_id,
                                 self.file,
                                 expr_id,
+                                None,
                             );
 
                             // Check if the return type is a tuple
@@ -1743,8 +1754,13 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                             object.span()
                         )
                     })?;
-                let object_semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, object_expr_id);
+                let object_semantic_type = expression_semantic_type(
+                    self.db,
+                    self.crate_id,
+                    self.file,
+                    object_expr_id,
+                    None,
+                );
                 let object_mir_type = MirType::from_semantic_type(self.db, object_semantic_type);
 
                 // Calculate the actual field offset from the type information
@@ -1760,7 +1776,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
 
                 // Query semantic type system for the field type
                 let semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id);
+                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id, None);
                 let field_type = MirType::from_semantic_type(self.db, semantic_type);
 
                 // Calculate the address of the field
@@ -1790,7 +1806,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
 
                 // Query semantic type system for the element type
                 let semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id);
+                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id, None);
                 let element_type = MirType::from_semantic_type(self.db, semantic_type);
 
                 // Calculate the address of the array element
@@ -1817,7 +1833,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
 
                 // Query semantic type system for the struct type
                 let semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id);
+                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id, None);
                 let struct_type = MirType::from_semantic_type(self.db, semantic_type);
 
                 // Allocate space for the struct
@@ -1859,6 +1875,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                         self.crate_id,
                         self.file,
                         field_val_expr_id,
+                        None,
                     );
                     let field_type = MirType::from_semantic_type(self.db, field_semantic_type);
 
@@ -1892,7 +1909,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
 
                 // Query semantic type system for the tuple type
                 let semantic_type =
-                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id);
+                    expression_semantic_type(self.db, self.crate_id, self.file, expr_id, None);
                 let tuple_type = MirType::from_semantic_type(self.db, semantic_type);
 
                 // Allocate space for the tuple as consecutive values
@@ -1927,6 +1944,7 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
                         self.crate_id,
                         self.file,
                         element_expr_id,
+                        None,
                     );
                     let element_type = MirType::from_semantic_type(self.db, element_semantic_type);
 

--- a/crates/compiler/mir/src/ir_generation.rs
+++ b/crates/compiler/mir/src/ir_generation.rs
@@ -37,7 +37,7 @@ use cairo_m_compiler_semantic::type_resolution::{
     definition_semantic_type, expression_semantic_type,
 };
 use cairo_m_compiler_semantic::types::TypeData;
-use cairo_m_compiler_semantic::{File, SemanticDb};
+use cairo_m_compiler_semantic::{File, SemanticDb, module_semantic_index};
 use rustc_hash::FxHashMap;
 
 use crate::db::MirDb;
@@ -244,10 +244,8 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
         function_name: &str,
     ) -> Option<FunctionId> {
         // Get the crate's semantic index
-        let crate_index = project_semantic_index(self.db, self.crate_id).ok()?;
-
-        // Get imported module's semantic index
-        let imported_index = crate_index.modules().get(imported_module_name)?;
+        let imported_index =
+            module_semantic_index(self.db, self.crate_id, imported_module_name.to_string()).ok()?;
 
         // Get imported module's root scope
         let imported_root = imported_index.root_scope()?;

--- a/crates/compiler/semantic/src/semantic_index.rs
+++ b/crates/compiler/semantic/src/semantic_index.rs
@@ -438,7 +438,8 @@ impl SemanticIndex {
                     db,
                     crate_id,
                     use_def_ref.imported_module.value().clone(),
-                );
+                )
+                .expect("Failed to resolve index for imported module");
                 if let Some(imported_root) = imported_module_index.root_scope() {
                     if let Some((imported_def_idx, imported_def)) =
                         imported_module_index.resolve_name_to_definition(name, imported_root)
@@ -1520,7 +1521,7 @@ mod tests {
     fn test_empty_program() {
         let TestCase { db, source } = test_case("");
         let crate_id = single_file_crate(&db, source);
-        let index = module_semantic_index(&db, crate_id, "main".to_string());
+        let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
         let root = index.root_scope().expect("should have root scope");
         let scope = index.scope(root).unwrap();
@@ -1532,7 +1533,7 @@ mod tests {
     fn test_simple_function() {
         let TestCase { db, source } = test_case("fn test() { }");
         let crate_id = single_file_crate(&db, source);
-        let index = module_semantic_index(&db, crate_id, "main".to_string());
+        let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
         // Should have root scope and function scope
         let root = index.root_scope().unwrap();
@@ -1562,7 +1563,7 @@ mod tests {
     fn test_function_with_parameters() {
         let TestCase { db, source } = test_case("fn add(a: felt, b: felt) { }");
         let crate_id = single_file_crate(&db, source);
-        let index = module_semantic_index(&db, crate_id, "main".to_string());
+        let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
         let root = index.root_scope().unwrap();
         let child_scopes: Vec<_> = index.child_scopes(root).collect();
@@ -1587,7 +1588,7 @@ mod tests {
     fn test_variable_resolution() {
         let TestCase { db, source } = test_case("fn test(param: felt) { let local_var = param; }");
         let crate_id = single_file_crate(&db, source);
-        let index = module_semantic_index(&db, crate_id, "main".to_string());
+        let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
         let root = index.root_scope().unwrap();
         let child_scopes: Vec<_> = index.child_scopes(root).collect();
@@ -1631,7 +1632,7 @@ mod tests {
         );
 
         let crate_id = single_file_crate(&db, source);
-        let index = module_semantic_index(&db, crate_id, "main".to_string());
+        let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
         // Should have root scope plus function scope and namespace scope
         let root = index.root_scope().unwrap();
@@ -1719,7 +1720,7 @@ mod tests {
     fn test_real_spans_are_used() {
         let TestCase { db, source } = test_case("fn test(x: felt) { let y = x; }");
         let crate_id = single_file_crate(&db, source);
-        let index = module_semantic_index(&db, crate_id, "main".to_string());
+        let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
         // Get all identifier usages
         let usages = index.identifier_usages();
@@ -1780,7 +1781,7 @@ mod tests {
             "#,
         );
         let crate_id = single_file_crate(&db, source);
-        let index = module_semantic_index(&db, crate_id, "main".to_string());
+        let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
         // Find the let definition
         let let_definitions: Vec<_> = index

--- a/crates/compiler/semantic/src/validation/literal_validator.rs
+++ b/crates/compiler/semantic/src/validation/literal_validator.rs
@@ -159,7 +159,7 @@ mod tests {
         let negative_program = "fn test() { let x: u32 = -42; }";
         let crate_id = crate_from_program(&db, negative_program);
         let file = *crate_id.modules(&db).values().next().unwrap();
-        let index = module_semantic_index(&db, crate_id, "main".to_string());
+        let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
         let validator = LiteralValidator;
         let diagnostics = validator.validate(&db, crate_id, file, &index);
@@ -178,7 +178,7 @@ mod tests {
         let zero_program = "fn test() { let x: u32 = -0; }";
         let crate_id = crate_from_program(&db, zero_program);
         let file = *crate_id.modules(&db).values().next().unwrap();
-        let index = module_semantic_index(&db, crate_id, "main".to_string());
+        let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
         let diagnostics = validator.validate(&db, crate_id, file, &index);
         assert_eq!(

--- a/crates/compiler/semantic/src/validation/type_validator.rs
+++ b/crates/compiler/semantic/src/validation/type_validator.rs
@@ -1198,6 +1198,7 @@ mod tests {
 
     use super::*;
     use crate::db::tests::test_db;
+    use crate::module_semantic_index;
 
     // TODO For tests only - ideally not present there
     fn single_file_crate(db: &dyn SemanticDb, file: File) -> Crate {
@@ -1213,8 +1214,7 @@ mod tests {
     }
 
     fn get_main_semantic_index(db: &dyn SemanticDb, crate_id: Crate) -> SemanticIndex {
-        let semantic_index = crate::db::project_semantic_index(db, crate_id).unwrap();
-        semantic_index.modules().get("main").unwrap().clone()
+        module_semantic_index(db, crate_id, "main".to_string()).unwrap()
     }
 
     #[test]

--- a/crates/compiler/semantic/tests/common/mod.rs
+++ b/crates/compiler/semantic/tests/common/mod.rs
@@ -358,7 +358,7 @@ pub fn assert_semantic_parameterized_impl(
             for index in project_index.modules().values() {
                 for (expr_id, expr_info) in index.all_expressions() {
                     let expr_type =
-                        expression_semantic_type(&db, crate_id, expr_info.file, expr_id);
+                        expression_semantic_type(&db, crate_id, expr_info.file, expr_id, None);
                     if matches!(expr_type.data(&db), TypeData::Error) {
                         filtered_diagnostics.add(
                             Diagnostic::error(

--- a/crates/compiler/semantic/tests/common/snapshots/diagnostics__types::literal_type_inference_tests::test_mixed_type_operations_still_error.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/diagnostics__types::literal_type_inference_tests::test_mixed_type_operations_still_error.snap
@@ -1,0 +1,26 @@
+---
+source: crates/compiler/semantic/tests/common/mod.rs
+description: "Inline semantic validation error test: types::literal_type_inference_tests::test_mixed_type_operations_still_error"
+---
+Fixture: semantic_tests::types::literal_type_inference_tests::test_mixed_type_operations_still_error
+============================================================
+Source code:
+
+        fn test() {
+            let x: u32 = 10;
+            let y: felt = 20;
+            let z = x + y;           // Error: can't add u32 + felt
+            return;
+        }
+        
+============================================================
+Found 1 diagnostic(s):
+
+--- Diagnostic 1 ---
+[2001] Error: Invalid right operand for arithmetic operator `+`. Expected `u32`, found `felt`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::test_mixed_type_operations_still_error:5:25 ]
+   │
+ 5 │             let z = x + y;           // Error: can't add u32 + felt
+   │                         ┬  
+   │                         ╰── Invalid right operand for arithmetic operator `+`. Expected `u32`, found `felt`
+───╯

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__statements::let_local_statements::test_let_statements_with_type_annotation.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__statements::let_local_statements::test_let_statements_with_type_annotation.snap
@@ -5,6 +5,13 @@ expression: snapshot
 --- Input 1 (ERROR) ---
 fn test() { let x: felt = 32u32; return; }
 --- Diagnostics ---
+[2001] Error: Type mismatch for let statement `x`. Expected `felt`, found `u32`
+   ╭─[ semantic_tests::statements::let_local_statements::test_let_statements_with_type_annotation:1:27 ]
+   │
+ 1 │ fn test() { let x: felt = 32u32; return; }
+   │                           ──┬──  
+   │                             ╰──── Type mismatch for let statement `x`. Expected `felt`, found `u32`
+───╯
 [2001] Error: expected `felt`, got `u32`
    ╭─[ semantic_tests::statements::let_local_statements::test_let_statements_with_type_annotation:1:27 ]
    │
@@ -20,6 +27,13 @@ fn test() { let x: felt = 32u32; return; }
 --- Input 2 (ERROR) ---
 fn test() { let x: u32 = 32felt; return; }
 --- Diagnostics ---
+[2001] Error: Type mismatch for let statement `x`. Expected `u32`, found `felt`
+   ╭─[ semantic_tests::statements::let_local_statements::test_let_statements_with_type_annotation:1:26 ]
+   │
+ 1 │ fn test() { let x: u32 = 32felt; return; }
+   │                          ───┬──  
+   │                             ╰──── Type mismatch for let statement `x`. Expected `u32`, found `felt`
+───╯
 [2001] Error: expected `u32`, got `felt`
    ╭─[ semantic_tests::statements::let_local_statements::test_let_statements_with_type_annotation:1:26 ]
    │

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__structures::literals::test_struct_literals.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__structures::literals::test_struct_literals.snap
@@ -90,13 +90,6 @@ struct Point { fields: (felt, bool) } fn test() { let p = Point { fields: (10, 2
                 struct Foo { bar: (u32, (bool, felt)) }
                 fn test() { let f = Foo { bar: (10, (1, 20)) }; return; }
 --- Diagnostics ---
-[2001] Error: Type mismatch for field `bar`. Expected `(u32, (bool, felt))`, found `(u32, (felt, felt))`
-   ╭─[ semantic_tests::structures::literals::test_struct_literals:3:48 ]
-   │
- 3 │                 fn test() { let f = Foo { bar: (10, (1, 20)) }; return; }
-   │                                                ──────┬──────  
-   │                                                      ╰──────── Type mismatch for field `bar`. Expected `(u32, (bool, felt))`, found `(u32, (felt, felt))`
-───╯
 [2001] Error: expected `bool`, got `felt`
    ╭─[ semantic_tests::structures::literals::test_struct_literals:3:54 ]
    │

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__structures::literals::test_struct_literals.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__structures::literals::test_struct_literals.snap
@@ -112,6 +112,13 @@ struct Point { fields: (felt, bool) } fn test() { let p = Point { fields: (10, 2
 --- Input 7 (ERROR) ---
 struct Point { x: felt, y: felt } fn test() { let p = Point { x: 10, y: 20u32 }; return; }
 --- Diagnostics ---
+[2001] Error: Type mismatch for field `y`. Expected `felt`, found `u32`
+   ╭─[ semantic_tests::structures::literals::test_struct_literals:1:73 ]
+   │
+ 1 │ struct Point { x: felt, y: felt } fn test() { let p = Point { x: 10, y: 20u32 }; return; }
+   │                                                                         ──┬──  
+   │                                                                           ╰──── Type mismatch for field `y`. Expected `felt`, found `u32`
+───╯
 [2001] Error: expected `felt`, got `u32`
    ╭─[ semantic_tests::structures::literals::test_struct_literals:1:73 ]
    │

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__types::literal_type_inference_tests::literal_type_inference_suite.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__types::literal_type_inference_tests::literal_type_inference_suite.snap
@@ -1,0 +1,129 @@
+---
+source: crates/compiler/semantic/tests/common/mod.rs
+expression: snapshot
+---
+--- Input 1 (ERROR) ---
+fn test() { let x: u32 = 10; let y: felt = 20; let z = x + y; return; }
+--- Diagnostics ---
+[2001] Error: Invalid right operand for arithmetic operator `+`. Expected `u32`, found `felt`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::literal_type_inference_suite:1:60 ]
+   │
+ 1 │ fn test() { let x: u32 = 10; let y: felt = 20; let z = x + y; return; }
+   │                                                            ┬  
+   │                                                            ╰── Invalid right operand for arithmetic operator `+`. Expected `u32`, found `felt`
+───╯
+
+============================================================
+
+--- Input 2 (ERROR) ---
+fn test() { let x: u32 = 10; let y: felt = x; return; }
+--- Diagnostics ---
+[2001] Error: Type mismatch for let statement `y`. Expected `felt`, found `u32`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::literal_type_inference_suite:1:44 ]
+   │
+ 1 │ fn test() { let x: u32 = 10; let y: felt = x; return; }
+   │                                            ┬  
+   │                                            ╰── Type mismatch for let statement `y`. Expected `felt`, found `u32`
+───╯
+
+============================================================
+
+--- Input 3 (ERROR) ---
+fn test() { let b: bool = 42; return; }
+--- Diagnostics ---
+[2001] Error: expected `bool`, got `felt`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::literal_type_inference_suite:1:27 ]
+   │
+ 1 │ fn test() { let b: bool = 42; return; }
+   │                           ─┬  
+   │                            ╰── expected `bool`, got `felt`
+   │                            │  
+   │                            ╰── change the type of the numeric literal from `felt` to `bool`
+───╯
+
+============================================================
+
+--- Input 4 (ERROR) ---
+fn test() { let x: felt = 32u32; return; }
+--- Diagnostics ---
+[2001] Error: Type mismatch for let statement `x`. Expected `felt`, found `u32`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::literal_type_inference_suite:1:27 ]
+   │
+ 1 │ fn test() { let x: felt = 32u32; return; }
+   │                           ──┬──  
+   │                             ╰──── Type mismatch for let statement `x`. Expected `felt`, found `u32`
+───╯
+[2001] Error: expected `felt`, got `u32`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::literal_type_inference_suite:1:27 ]
+   │
+ 1 │ fn test() { let x: felt = 32u32; return; }
+   │                           ──┬──  
+   │                             ╰──── expected `felt`, got `u32`
+   │                             │    
+   │                             ╰──── change the type of the numeric literal from `u32` to `felt`
+───╯
+
+============================================================
+
+--- Input 5 (ERROR) ---
+fn test() { let x: u32 = -5; return; }
+--- Diagnostics ---
+[2001] Error: negative literal values are not allowed for type u32
+   ╭─[ semantic_tests::types::literal_type_inference_tests::literal_type_inference_suite:1:26 ]
+   │
+ 1 │ fn test() { let x: u32 = -5; return; }
+   │                          ─┬  
+   │                           ╰── negative literal values are not allowed for type u32
+   │                           │  
+   │                           ╰── u32 can only hold values from 0 to 4294967295
+───╯
+
+============================================================
+
+--- Input 6 (ERROR) ---
+struct P { x: felt, y: felt } fn test() { let _p = P { x: 10, y: 20u32 }; return; }
+--- Diagnostics ---
+[2001] Error: Type mismatch for field `y`. Expected `felt`, found `u32`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::literal_type_inference_suite:1:66 ]
+   │
+ 1 │ struct P { x: felt, y: felt } fn test() { let _p = P { x: 10, y: 20u32 }; return; }
+   │                                                                  ──┬──  
+   │                                                                    ╰──── Type mismatch for field `y`. Expected `felt`, found `u32`
+───╯
+[2001] Error: expected `felt`, got `u32`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::literal_type_inference_suite:1:66 ]
+   │
+ 1 │ struct P { x: felt, y: felt } fn test() { let _p = P { x: 10, y: 20u32 }; return; }
+   │                                                                  ──┬──  
+   │                                                                    ╰──── expected `felt`, got `u32`
+   │                                                                    │    
+   │                                                                    ╰──── change the type of the numeric literal from `u32` to `felt`
+───╯
+
+============================================================
+
+--- Input 7 (ERROR) ---
+struct S { f: (felt, bool) } fn test() { let _s = S { f: (10, 20) }; return; }
+--- Diagnostics ---
+[2001] Error: expected `bool`, got `felt`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::literal_type_inference_suite:1:63 ]
+   │
+ 1 │ struct S { f: (felt, bool) } fn test() { let _s = S { f: (10, 20) }; return; }
+   │                                                               ─┬  
+   │                                                                ╰── expected `bool`, got `felt`
+   │                                                                │  
+   │                                                                ╰── change the type of the numeric literal from `felt` to `bool`
+───╯
+
+============================================================
+
+--- Input 8 (ERROR) ---
+fn test() { let pair: (felt, u32) = (10, 20); let (x, y) = pair; let sum = x + y; return; }
+--- Diagnostics ---
+[2001] Error: Invalid right operand for arithmetic operator `+`. Expected `felt`, found `u32`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::literal_type_inference_suite:1:80 ]
+   │
+ 1 │ fn test() { let pair: (felt, u32) = (10, 20); let (x, y) = pair; let sum = x + y; return; }
+   │                                                                                ┬  
+   │                                                                                ╰── Invalid right operand for arithmetic operator `+`. Expected `felt`, found `u32`
+───╯

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__types::literal_type_inference_tests::test_parameterized_literal_inference.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__types::literal_type_inference_tests::test_parameterized_literal_inference.snap
@@ -1,0 +1,42 @@
+---
+source: crates/compiler/semantic/tests/common/mod.rs
+expression: snapshot
+---
+--- Input 1 (ERROR) ---
+fn test() { let x: u32 = 10; let y: felt = 20; let z = x + y; return; }
+--- Diagnostics ---
+[2001] Error: Invalid right operand for arithmetic operator `+`. Expected `u32`, found `felt`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::test_parameterized_literal_inference:1:60 ]
+   │
+ 1 │ fn test() { let x: u32 = 10; let y: felt = 20; let z = x + y; return; }
+   │                                                            ┬  
+   │                                                            ╰── Invalid right operand for arithmetic operator `+`. Expected `u32`, found `felt`
+───╯
+
+============================================================
+
+--- Input 2 (ERROR) ---
+fn test() { let x: u32 = 10; let y: felt = x; return; }
+--- Diagnostics ---
+[2001] Error: Type mismatch for let statement `y`. Expected `felt`, found `u32`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::test_parameterized_literal_inference:1:44 ]
+   │
+ 1 │ fn test() { let x: u32 = 10; let y: felt = x; return; }
+   │                                            ┬  
+   │                                            ╰── Type mismatch for let statement `y`. Expected `felt`, found `u32`
+───╯
+
+============================================================
+
+--- Input 3 (ERROR) ---
+fn test() { let x: bool = 42; return; }
+--- Diagnostics ---
+[2001] Error: expected `bool`, got `felt`
+   ╭─[ semantic_tests::types::literal_type_inference_tests::test_parameterized_literal_inference:1:27 ]
+   │
+ 1 │ fn test() { let x: bool = 42; return; }
+   │                           ─┬  
+   │                            ╰── expected `bool`, got `felt`
+   │                            │  
+   │                            ╰── change the type of the numeric literal from `felt` to `bool`
+───╯

--- a/crates/compiler/semantic/tests/semantic_model/mod.rs
+++ b/crates/compiler/semantic/tests/semantic_model/mod.rs
@@ -28,7 +28,7 @@ where
     let db = test_db();
     let crate_id = crate_from_program(&db, source);
     let file = *crate_id.modules(&db).values().next().unwrap();
-    let index = module_semantic_index(&db, crate_id, "main".to_string());
+    let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
     test_fn(&db, file, &index);
 }
 

--- a/crates/compiler/semantic/tests/types/definition_type_tests.rs
+++ b/crates/compiler/semantic/tests/types/definition_type_tests.rs
@@ -5,14 +5,13 @@
 
 use cairo_m_compiler_semantic::db::Crate;
 use cairo_m_compiler_semantic::semantic_index::DefinitionId;
-use cairo_m_compiler_semantic::{SemanticIndex, project_semantic_index};
+use cairo_m_compiler_semantic::{SemanticIndex, module_semantic_index};
 
 use super::*;
 use crate::crate_from_program;
 
 fn get_main_semantic_index(db: &dyn SemanticDb, crate_id: Crate) -> SemanticIndex {
-    let semantic_index = project_semantic_index(db, crate_id).unwrap();
-    semantic_index.modules().values().next().unwrap().clone()
+    module_semantic_index(db, crate_id, "main".to_string()).unwrap()
 }
 
 #[test]

--- a/crates/compiler/semantic/tests/types/expression_type_tests.rs
+++ b/crates/compiler/semantic/tests/types/expression_type_tests.rs
@@ -34,13 +34,13 @@ fn test_literal_expression_types() {
 
     // Test literal 42
     if let Some(expr_id) = find_expr_id("42") {
-        let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+        let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
         assert!(matches!(expr_type.data(&db), TypeData::Felt));
     }
 
     // Test literal 0
     if let Some(expr_id) = find_expr_id("0") {
-        let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+        let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
         assert!(matches!(expr_type.data(&db), TypeData::Felt));
     }
 }
@@ -70,7 +70,7 @@ fn test_identifier_expression_types() {
             let expr_info = semantic_index.expression(*expr_id).unwrap();
             // Check if this is an identifier expression (not a definition)
             if matches!(expr_info.ast_node, Expression::Identifier(_)) {
-                let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id);
+                let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id, None);
                 assert!(matches!(expr_type.data(&db), TypeData::Felt));
                 break;
             }
@@ -104,7 +104,7 @@ fn test_binary_expression_types() {
             expr_info.ast_node,
             cairo_m_compiler_parser::parser::Expression::BinaryOp { .. }
         ) {
-            let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id);
+            let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id, None);
             // Binary operations on felt should result in felt
             assert!(
                 matches!(expr_type.data(&db), TypeData::Felt),
@@ -139,7 +139,7 @@ fn test_member_access_expression_types() {
             expr_info.ast_node,
             cairo_m_compiler_parser::parser::Expression::MemberAccess { .. }
         ) {
-            let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id);
+            let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id, None);
             // Member access to felt fields should result in felt
             assert!(
                 matches!(expr_type.data(&db), TypeData::Felt),
@@ -180,7 +180,7 @@ fn test_function_call_expression_types() {
             cairo_m_compiler_parser::parser::Expression::FunctionCall { .. }
         ) && source_text.contains("make_point")
         {
-            let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id);
+            let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id, None);
             // Function call should return Point
             assert!(
                 matches!(expr_type.data(&db), TypeData::Struct(_)),
@@ -217,7 +217,7 @@ fn test_struct_literal_expression_types() {
             expr_info.ast_node,
             cairo_m_compiler_parser::parser::Expression::StructLiteral { .. }
         ) {
-            let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id);
+            let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id, None);
             // Struct literal should have the struct type
             match expr_type.data(&db) {
                 TypeData::Struct(struct_id) => {
@@ -260,7 +260,7 @@ fn test_complex_expression_type_inference() {
         if matches!(expr_info.ast_node, Expression::BinaryOp { .. })
             && source_text.contains("dx * dx + dy * dy")
         {
-            let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id);
+            let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id, None);
             // Complex arithmetic expression should result in felt
             assert!(
                 matches!(expr_type.data(&db), TypeData::Felt),
@@ -299,7 +299,7 @@ fn test_unary_expression_types() {
             expr_info.ast_node,
             cairo_m_compiler_parser::parser::Expression::UnaryOp { .. }
         ) {
-            let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id);
+            let expr_type = expression_semantic_type(&db, crate_id, file, *expr_id, None);
 
             // Check type based on the operation
             if source_text.starts_with('-') {

--- a/crates/compiler/semantic/tests/types/literal_type_inference_tests.rs
+++ b/crates/compiler/semantic/tests/types/literal_type_inference_tests.rs
@@ -1,0 +1,91 @@
+//! Parameterised tests for context‑aware numeric literal type inference.
+//!
+//! We group all scenarios into `ok` and `err` buckets so they run through the
+//! fast table‑driven macro, mirroring the style of other test modules.
+
+use crate::{assert_semantic_parameterized, in_function};
+
+#[test]
+fn literal_type_inference_suite() {
+    assert_semantic_parameterized! {
+        // ------------------------------------------------------------------
+        // Cases that must succeed
+        // ------------------------------------------------------------------
+        ok: [
+            // -------- Basic inference from explicit variable/annotation ----
+            in_function("let x: u32 = 3;"),
+            in_function("let y: felt = 42;"),
+            in_function("let x: u32 = 3; let y = x;"),
+
+            // -------- Binary operations ------------------------------------
+            in_function("let x: u32 = 3; let y = x + 1;"),
+            in_function("let x: u32 = 3; let y = 1 + x;"),
+            in_function("let a: u32 = 10; let b = (a + 5) * 2;"),
+            in_function("let a: u32 = 10; let c = a - 1 + 3;"),
+
+            // -------- Unary literal (negatives default to felt) ------------
+            in_function("let neg = -5;"),
+
+            // -------- Chained/complex expressions --------------------------
+            in_function("let a: u32 = 5; let b: u32 = 10; let c = a + (b + 15);"),
+            in_function("let a: u32 = 5; let b: u32 = 10; let d = a * 2 + b * 3;"),
+
+            // -------- Tuple destructuring -----------------------------------
+            in_function("let pair: (felt, u32) = (10, 20); let (x, y) = pair; let sum = x + 5;"),
+
+            // -------- Comparison operators ----------------------------------
+            in_function("let x: u32 = 10; let b = x < 100;"),
+            in_function("let x: u32 = 10; let b = x == 0;"),
+            in_function("let x: u32 = 10; let b = x >= 5 && x <= 15;"),
+
+            // -------- Struct literals ---------------------------------------
+            r#"
+                struct Config { port: u32, timeout: u32 }
+                fn test() { let _c = Config { port: 8080, timeout: 30 }; return; }
+            "#,
+
+            // Tuple‑typed field inference inside struct
+            "struct P { f: (felt, u32) } fn test() { let _p = P { f: (10, 20) }; return; }",
+
+            // Nested structs with mixed numeric kinds
+            r#"
+                struct Point { x: felt, y: felt }
+                struct Rect  { tl: Point, w: u32, h: u32 }
+                fn test() { let _r = Rect { tl: Point { x: 0, y: 0 }, w: 100, h: 200 }; return; }
+            "#,
+
+            // -------- Function call argument inference ----------------------
+            r#"
+                fn add_u32(a: u32, b: u32) -> u32 { return a + b; }
+                fn test() { let res = add_u32(20, 30); return; }
+            "#,
+
+            // Explicit literal suffix still compiles
+            in_function("let x: u32 = 10u32; let y: felt = 10felt;"),
+        ],
+
+        // ------------------------------------------------------------------
+        // Cases that must fail
+        // ------------------------------------------------------------------
+        err: [
+            // Mixed primitive kinds in arithmetic
+            in_function("let x: u32 = 10; let y: felt = 20; let z = x + y;"),
+            // Assigning u32 value to felt‑annotated variable
+            in_function("let x: u32 = 10; let y: felt = x;"),
+            // Wrong literal for explicit annotation
+            in_function("let b: bool = 42;"),
+            // Wrong suffix vs annotation
+            in_function("let x: felt = 32u32;"),
+            // Negative literal into unsigned variable
+            in_function("let x: u32 = -5;"),
+
+            // Struct field type mismatch from literal
+            "struct P { x: felt, y: felt } fn test() { let _p = P { x: 10, y: 20u32 }; return; }",
+            // Tuple field mismatch
+            "struct S { f: (felt, bool) } fn test() { let _s = S { f: (10, 20) }; return; }",
+
+            // Wrong addition of types
+            in_function("let pair: (felt, u32) = (10, 20); let (x, y) = pair; let sum = x + y;"),
+        ]
+    }
+}

--- a/crates/compiler/semantic/tests/types/mod.rs
+++ b/crates/compiler/semantic/tests/types/mod.rs
@@ -16,6 +16,7 @@
 mod definition_type_tests;
 mod expression_type_tests;
 mod function_signature_tests;
+mod literal_type_inference_tests;
 mod query_integration_tests;
 mod recursive_and_error_types_tests;
 mod struct_type_tests;

--- a/crates/compiler/semantic/tests/types/query_integration_tests.rs
+++ b/crates/compiler/semantic/tests/types/query_integration_tests.rs
@@ -12,18 +12,13 @@ use cairo_m_compiler_semantic::type_resolution::{
 };
 use cairo_m_compiler_semantic::types::{TypeData, TypeId};
 use cairo_m_compiler_semantic::validation::validator::Validator;
-use cairo_m_compiler_semantic::{
-    File, FileScopeId, SemanticDb, project_semantic_index, validation,
-};
+use cairo_m_compiler_semantic::{File, FileScopeId, SemanticDb, module_semantic_index, validation};
 
 use crate::common::*;
 use crate::{named_type, pointer_type};
 
 fn get_root_scope(db: &dyn SemanticDb, crate_id: Crate) -> FileScopeId {
-    let semantic_index = project_semantic_index(db, crate_id).unwrap();
-    semantic_index
-        .modules()
-        .get("main")
+    module_semantic_index(db, crate_id, "main".to_string())
         .unwrap()
         .root_scope()
         .unwrap()

--- a/crates/compiler/semantic/tests/types/query_integration_tests.rs
+++ b/crates/compiler/semantic/tests/types/query_integration_tests.rs
@@ -220,28 +220,28 @@ fn test_expression_type_inference() {
 
     // Test literal
     let expr_id = find_expr_id("42");
-    let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+    let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
     assert_eq!(expr_type, felt_type);
 
     // Test identifier `a` (inferred from literal)
     let a_expr_id = find_expr_id("a");
-    let a_expr_type = expression_semantic_type(&db, crate_id, file, a_expr_id);
+    let a_expr_type = expression_semantic_type(&db, crate_id, file, a_expr_id, None);
     assert_eq!(a_expr_type, felt_type);
 
     // Test binary operation
     let expr_id = find_expr_id("a + 1");
-    let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+    let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
     assert_eq!(expr_type, felt_type);
 
     // Test member access
     let expr_id = find_expr_id("p.x");
-    let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+    let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
     assert_eq!(expr_type, felt_type);
 
     // Test identifier `c` (inferred from member access)
     // Find the identifier 'c' in the return statement
     let c_expr_id = find_expr_id("c");
-    let c_expr_type = expression_semantic_type(&db, crate_id, file, c_expr_id);
+    let c_expr_type = expression_semantic_type(&db, crate_id, file, c_expr_id, None);
     assert_eq!(c_expr_type, felt_type);
 }
 
@@ -567,7 +567,7 @@ fn test_literal_inference_with_explicit_type() {
         for (span, expr_id) in &semantic_index.span_to_expression_id {
             let source_text = &program[span.start..span.end];
             if source_text == target_text {
-                return expression_semantic_type(&db, crate_id, file, *expr_id);
+                return expression_semantic_type(&db, crate_id, file, *expr_id, None);
             }
         }
         panic!(

--- a/crates/compiler/semantic/tests/types/u32_type_tests.rs
+++ b/crates/compiler/semantic/tests/types/u32_type_tests.rs
@@ -45,7 +45,7 @@ fn test_u32_explicit_declaration() {
     let program = "fn test() { let x: u32 = 42; let y = x; return;}"; // Use x so we get an identifier expression
     let crate_id = crate_from_program(&db, program);
     let file = *crate_id.modules(&db).values().next().unwrap();
-    let index = module_semantic_index(&db, crate_id, "main".to_string());
+    let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
     // Find the identifier 'x' and verify its type
     let mut found_u32_var = false;
@@ -77,7 +77,7 @@ fn test_u32_arithmetic_operations() {
     "#;
     let crate_id = crate_from_program(&db, program);
     let file = *crate_id.modules(&db).values().next().unwrap();
-    let index = module_semantic_index(&db, crate_id, "main".to_string());
+    let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
     // Count binary operations and verify they return u32
     let mut u32_operations = 0;
@@ -110,7 +110,7 @@ fn test_u32_comparison_operations() {
     "#;
     let crate_id = crate_from_program(&db, program);
     let file = *crate_id.modules(&db).values().next().unwrap();
-    let index = module_semantic_index(&db, crate_id, "main".to_string());
+    let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
     // Count comparison operations and verify they return bool
     let mut bool_operations = 0;
@@ -151,7 +151,7 @@ fn test_u32_unary_operations() {
 
     let crate_id = crate_from_program(&db, program);
     let file = *crate_id.modules(&db).values().next().unwrap();
-    let index = module_semantic_index(&db, crate_id, "main".to_string());
+    let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
     let mut found_neg_u32 = false;
 
@@ -193,7 +193,7 @@ fn test_u32_tuple_type() {
     "#;
     let crate_id = crate_from_program(&db, program);
     let file = *crate_id.modules(&db).values().next().unwrap();
-    let index = module_semantic_index(&db, crate_id, "main".to_string());
+    let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
     // Find the tuple variable and verify its type
     let mut found_u32_tuple = false;
@@ -230,7 +230,7 @@ fn test_u32_in_struct() {
     "#;
     let crate_id = crate_from_program(&db, program);
     let file = *crate_id.modules(&db).values().next().unwrap();
-    let index = module_semantic_index(&db, crate_id, "main".to_string());
+    let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
     // Find member access and verify it returns u32
     let mut found_u32_field = false;
@@ -263,7 +263,7 @@ fn test_u32_in_function_signature() {
     "#;
     let crate_id = crate_from_program(&db, program);
     let file = *crate_id.modules(&db).values().next().unwrap();
-    let index = module_semantic_index(&db, crate_id, "main".to_string());
+    let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
     // Find the function call and verify its return type
     let mut found_u32_call = false;
@@ -295,7 +295,7 @@ fn test_untyped_let_should_be_felt() {
     "#;
     let crate_id = crate_from_program(&db, program);
     let file = *crate_id.modules(&db).values().next().unwrap();
-    let index = module_semantic_index(&db, crate_id, "main".to_string());
+    let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
     // Find the identifier 'x' and verify its type
     for (expr_id, expr_info) in index.all_expressions() {
@@ -320,7 +320,7 @@ fn test_typed_let_should_be_u32() {
     "#;
     let crate_id = crate_from_program(&db, program);
     let file = *crate_id.modules(&db).values().next().unwrap();
-    let index = module_semantic_index(&db, crate_id, "main".to_string());
+    let index = module_semantic_index(&db, crate_id, "main".to_string()).unwrap();
 
     // Find the identifier 'x' and verify its type
     for (expr_id, expr_info) in index.all_expressions() {

--- a/crates/compiler/semantic/tests/types/u32_type_tests.rs
+++ b/crates/compiler/semantic/tests/types/u32_type_tests.rs
@@ -52,7 +52,7 @@ fn test_u32_explicit_declaration() {
     for (expr_id, expr_info) in index.all_expressions() {
         if let cairo_m_compiler_parser::parser::Expression::Identifier(name) = &expr_info.ast_node {
             if name.value() == "x" {
-                let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+                let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
                 assert!(matches!(expr_type.data(&db), TypeData::U32));
                 found_u32_var = true;
             }
@@ -83,7 +83,7 @@ fn test_u32_arithmetic_operations() {
     let mut u32_operations = 0;
     for (expr_id, expr_info) in index.all_expressions() {
         if let cairo_m_compiler_parser::parser::Expression::BinaryOp { .. } = &expr_info.ast_node {
-            let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+            let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
             if matches!(expr_type.data(&db), TypeData::U32) {
                 u32_operations += 1;
             }
@@ -126,7 +126,7 @@ fn test_u32_comparison_operations() {
             ..
         } = &expr_info.ast_node
         {
-            let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+            let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
             if matches!(expr_type.data(&db), TypeData::Bool) {
                 bool_operations += 1;
             }
@@ -158,7 +158,7 @@ fn test_u32_unary_operations() {
     for (expr_id, expr_info) in index.all_expressions() {
         if let cairo_m_compiler_parser::parser::Expression::UnaryOp { op, .. } = &expr_info.ast_node
         {
-            let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+            let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
             if matches!(op, UnaryOp::Neg) && matches!(expr_type.data(&db), TypeData::U32) {
                 found_neg_u32 = true;
             }
@@ -200,7 +200,7 @@ fn test_u32_tuple_type() {
     for (expr_id, expr_info) in index.all_expressions() {
         if let cairo_m_compiler_parser::parser::Expression::Identifier(name) = &expr_info.ast_node {
             if name.value() == "pair" {
-                let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+                let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
                 if let TypeData::Tuple(types) = expr_type.data(&db) {
                     assert_eq!(types.len(), 2);
                     assert!(matches!(types[0].data(&db), TypeData::U32));
@@ -239,7 +239,7 @@ fn test_u32_in_struct() {
             &expr_info.ast_node
         {
             if field.value() == "value" {
-                let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+                let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
                 assert!(matches!(expr_type.data(&db), TypeData::U32));
                 found_u32_field = true;
             }
@@ -271,7 +271,7 @@ fn test_u32_in_function_signature() {
         if let cairo_m_compiler_parser::parser::Expression::FunctionCall { .. } =
             &expr_info.ast_node
         {
-            let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+            let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
             if matches!(expr_type.data(&db), TypeData::U32) {
                 found_u32_call = true;
             }
@@ -301,7 +301,7 @@ fn test_untyped_let_should_be_felt() {
     for (expr_id, expr_info) in index.all_expressions() {
         if let cairo_m_compiler_parser::parser::Expression::Identifier(name) = &expr_info.ast_node {
             if name.value() == "x" {
-                let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+                let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
                 assert!(matches!(expr_type.data(&db), TypeData::Felt));
                 assert!(!matches!(expr_type.data(&db), TypeData::U32));
             }
@@ -326,7 +326,7 @@ fn test_typed_let_should_be_u32() {
     for (expr_id, expr_info) in index.all_expressions() {
         if let cairo_m_compiler_parser::parser::Expression::Identifier(name) = &expr_info.ast_node {
             if name.value() == "x" {
-                let expr_type = expression_semantic_type(&db, crate_id, file, expr_id);
+                let expr_type = expression_semantic_type(&db, crate_id, file, expr_id, None);
                 assert!(matches!(expr_type.data(&db), TypeData::U32));
             }
         }


### PR DESCRIPTION
This PR introduces a major improvement to the type system by implementing context-aware type inference for numeric literals. This allows the compiler to correctly deduce the type of a literal (e.g., as `u32` or `felt`) based on its surrounding context, such as a variable's type annotation, a function parameter, or another operand in an expression.

### Key Changes

-   **Context-Aware Literal Inference:** Developers can now write `let x: u32 = 10;` or `add_u32(x, 10)` without needing the explicit `10u32` suffix. The compiler infers the type from the context, improving code readability and ergonomics.
-   **Enhanced Semantic Analysis:** The semantic analysis pipeline has been refactored to propagate "expected type" hints downwards when resolving expression types.
-   **Improved Robustness:** The `module_semantic_index` query now returns a `Result` instead of panicking on failure. This makes the compiler and language server more resilient to semantic errors, allowing them to report issues gracefully without crashing and to aggregate diagnostics from multiple modules.
-   **LS Hover Enhancement:** Hovering over an imported item now displays the name of its source module.

This change significantly improves the developer experience by reducing verbosity and making the language more intuitive, backed by a more stable and reliable toolchain.