### PR TITLE
feat(compiler): add tuple indexing syntax support

### DIFF
--- a/crates/compiler/diagnostics/src/diagnostics.rs
+++ b/crates/compiler/diagnostics/src/diagnostics.rs
@@ -115,6 +115,8 @@ pub enum DiagnosticCode {
     InvalidTypeDefinition,
     InvalidAssignmentTarget,
     MissingReturnValue,
+    TupleIndexOutOfBounds,
+    InvalidTupleIndexAccess,
     // TODO: Add more type-related diagnostic codes:
     // - InvalidTypeAnnotation
     // - TypeArgumentMismatch
@@ -174,6 +176,8 @@ impl From<DiagnosticCode> for u32 {
             DiagnosticCode::ContinueOutsideLoop => 3004,
             DiagnosticCode::InvalidAssignmentTarget => 2010,
             DiagnosticCode::MissingReturnValue => 2011,
+            DiagnosticCode::TupleIndexOutOfBounds => 2012,
+            DiagnosticCode::InvalidTupleIndexAccess => 2013,
             DiagnosticCode::InternalError => 9001,
         }
     }

--- a/crates/compiler/formatter/src/rules/expressions.rs
+++ b/crates/compiler/formatter/src/rules/expressions.rs
@@ -74,6 +74,11 @@ impl Format for Expression {
                     braces(comma_separated(field_docs)),
                 ])
             }
+            Self::TupleIndex { tuple, index } => Doc::concat(vec![
+                tuple.value().format(ctx),
+                Doc::text("."),
+                Doc::text(index.to_string()),
+            ]),
         }
     }
 }

--- a/crates/compiler/mir/src/ir_generation/tests/mir_generation_tests.rs
+++ b/crates/compiler/mir/src/ir_generation/tests/mir_generation_tests.rs
@@ -80,6 +80,7 @@ mir_test!(comparison_ops, "expressions");
 mir_test!(compound_expr, "expressions");
 mir_test!(operator_precedence, "expressions");
 mir_test!(combination, "expressions");
+mir_test!(tuple_indexing, "expressions");
 
 // --- Control Flow ---
 mir_test!(if_else, "control_flow");

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_tuple_indexing.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_tuple_indexing.snap
@@ -32,12 +32,17 @@ fn test_nested_tuple_index() -> felt {
     return nested.0.1 + nested.1.0;
 }
 
+fn get_tuple() -> (felt, felt) {
+    return (42, 99);
+}
+
 fn test_function_return_tuple_index() -> felt {
     return get_tuple().1;
 }
 
-fn get_tuple() -> (felt, felt) {
-    return (42, 99);
+fn test_simple_function_call_index() -> felt {
+    let result = get_tuple().1;
+    return result;
 }
 
 fn test_chain_tuple_operations() -> felt {
@@ -148,15 +153,6 @@ module {
   }
 
   // Function 3
-  fn test_function_return_tuple_index {
-    entry: 0
-
-    0:
-      unreachable
-
-  }
-
-  // Function 4
   fn get_tuple {
     entry: 0
 
@@ -165,7 +161,29 @@ module {
 
   }
 
+  // Function 4
+  fn test_function_return_tuple_index {
+    entry: 0
+
+    0:
+      %0, %1 = call 3()
+      return %1
+
+  }
+
   // Function 5
+  fn test_simple_function_call_index {
+    entry: 0
+
+    0:
+      %0, %1 = call 3()
+      %2 = stackalloc 1
+      store %2, %1
+      return %2
+
+  }
+
+  // Function 6
   fn test_chain_tuple_operations {
     entry: 0
 

--- a/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_tuple_indexing.snap
+++ b/crates/compiler/mir/src/ir_generation/tests/snapshots/cairo_m_compiler_mir__ir_generation__tests__mir_generation_tests__expressions_tuple_indexing.snap
@@ -1,0 +1,206 @@
+---
+source: crates/compiler/mir/src/ir_generation/tests/mir_generation_tests.rs
+expression: snapshot_content
+---
+---
+source: crates/compiler/mir/src/ir_generation/tests/mir_generation_tests.rs
+expression: mir_output
+---
+Fixture: tuple_indexing.cm
+============================================================
+Source code:
+// Tests tuple indexing syntax (expr.N)
+fn test_basic_tuple_index() -> felt {
+    let tt = (10, 20, 30);
+    return tt.1;
+}
+
+// TODO: Add u32 test on accessing tuple index.
+// fn test_u32_tuple_index() -> u32 {
+//     let tt = (10u32, 20u32, 30u32);
+//     return tt.1;
+// }
+
+fn test_tuple_index_lvalue() -> felt {
+    let tt = (100, 200, 300);
+    tt.1 = 250;
+    return tt.1;
+}
+
+fn test_nested_tuple_index() -> felt {
+    let nested = ((1, 2), (3, 4));
+    return nested.0.1 + nested.1.0;
+}
+
+fn test_function_return_tuple_index() -> felt {
+    return get_tuple().1;
+}
+
+fn get_tuple() -> (felt, felt) {
+    return (42, 99);
+}
+
+fn test_chain_tuple_operations() -> felt {
+    let tt = (1, 2, 3);
+    let x = tt.0;
+    tt.2 = x + tt.1;
+    return tt.2;
+}
+
+============================================================
+Generated MIR:
+module {
+  // Function 0
+  fn test_basic_tuple_index {
+    entry: 0
+
+    0:
+      // Allocate tuple with 3 elements
+%0 = stackalloc 3
+      // Get address of tuple element 0
+%1 = getelementptr %0, 0
+      store %1, 10
+      // Get address of tuple element 1
+%2 = getelementptr %0, 1
+      store %2, 20
+      // Get address of tuple element 2
+%3 = getelementptr %0, 2
+      store %3, 30
+      // Get address of tuple element 1
+%4 = getelementptr %0, 1
+      // Load tuple element 1
+%5 = load %4
+      return %5
+
+  }
+
+  // Function 1
+  fn test_tuple_index_lvalue {
+    entry: 0
+
+    0:
+      // Allocate tuple with 3 elements
+%0 = stackalloc 3
+      // Get address of tuple element 0
+%1 = getelementptr %0, 0
+      store %1, 100
+      // Get address of tuple element 1
+%2 = getelementptr %0, 1
+      store %2, 200
+      // Get address of tuple element 2
+%3 = getelementptr %0, 2
+      store %3, 300
+      // Get address of tuple element 1 for assignment
+%4 = getelementptr %0, 1
+      store %4, 250
+      // Get address of tuple element 1
+%5 = getelementptr %0, 1
+      // Load tuple element 1
+%6 = load %5
+      return %6
+
+  }
+
+  // Function 2
+  fn test_nested_tuple_index {
+    entry: 0
+
+    0:
+      // Allocate tuple with 2 elements
+%0 = stackalloc 4
+      // Allocate tuple with 2 elements
+%1 = stackalloc 2
+      // Get address of tuple element 0
+%2 = getelementptr %1, 0
+      store %2, 1
+      // Get address of tuple element 1
+%3 = getelementptr %1, 1
+      store %3, 2
+      // Get address of tuple element 0
+%4 = getelementptr %0, 0
+      store %4, %1
+      // Allocate tuple with 2 elements
+%5 = stackalloc 2
+      // Get address of tuple element 0
+%6 = getelementptr %5, 0
+      store %6, 3
+      // Get address of tuple element 1
+%7 = getelementptr %5, 1
+      store %7, 4
+      // Get address of tuple element 1
+%8 = getelementptr %0, 1
+      store %8, %5
+      // Get address of tuple element 0 for assignment
+%9 = getelementptr %0, 0
+      // Get address of tuple element 1
+%10 = getelementptr %9, 1
+      // Load tuple element 1
+%11 = load %10
+      // Get address of tuple element 1 for assignment
+%12 = getelementptr %0, 2
+      // Get address of tuple element 0
+%13 = getelementptr %12, 0
+      // Load tuple element 0
+%14 = load %13
+      %15 = %11 Add %14
+      return %15
+
+  }
+
+  // Function 3
+  fn test_function_return_tuple_index {
+    entry: 0
+
+    0:
+      unreachable
+
+  }
+
+  // Function 4
+  fn get_tuple {
+    entry: 0
+
+    0:
+      return (42, 99)
+
+  }
+
+  // Function 5
+  fn test_chain_tuple_operations {
+    entry: 0
+
+    0:
+      // Allocate tuple with 3 elements
+%0 = stackalloc 3
+      // Get address of tuple element 0
+%1 = getelementptr %0, 0
+      store %1, 1
+      // Get address of tuple element 1
+%2 = getelementptr %0, 1
+      store %2, 2
+      // Get address of tuple element 2
+%3 = getelementptr %0, 2
+      store %3, 3
+      // Get address of tuple element 0
+%4 = getelementptr %0, 0
+      // Load tuple element 0
+%5 = load %4
+      %6 = stackalloc 1
+      store %6, %5
+      // Get address of tuple element 1
+%7 = getelementptr %0, 1
+      // Load tuple element 1
+%8 = load %7
+      %9 = %6 Add %8
+      // Get address of tuple element 2 for assignment
+%10 = getelementptr %0, 2
+      store %10, %9
+      // Get address of tuple element 2
+%11 = getelementptr %0, 2
+      // Load tuple element 2
+%12 = load %11
+      return %12
+
+  }
+
+}

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/tuple_indexing.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/tuple_indexing.cm
@@ -1,0 +1,37 @@
+// Tests tuple indexing syntax (expr.N)
+fn test_basic_tuple_index() -> felt {
+    let tt = (10, 20, 30);
+    return tt.1;
+}
+
+// TODO: Add u32 test on accessing tuple index.
+// fn test_u32_tuple_index() -> u32 {
+//     let tt = (10u32, 20u32, 30u32);
+//     return tt.1;
+// }
+
+fn test_tuple_index_lvalue() -> felt {
+    let tt = (100, 200, 300);
+    tt.1 = 250;
+    return tt.1;
+}
+
+fn test_nested_tuple_index() -> felt {
+    let nested = ((1, 2), (3, 4));
+    return nested.0.1 + nested.1.0;
+}
+
+fn test_function_return_tuple_index() -> felt {
+    return get_tuple().1;
+}
+
+fn get_tuple() -> (felt, felt) {
+    return (42, 99);
+}
+
+fn test_chain_tuple_operations() -> felt {
+    let tt = (1, 2, 3);
+    let x = tt.0;
+    tt.2 = x + tt.1;
+    return tt.2;
+}

--- a/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/tuple_indexing.cm
+++ b/crates/compiler/mir/src/ir_generation/tests/test_cases/expressions/tuple_indexing.cm
@@ -21,12 +21,17 @@ fn test_nested_tuple_index() -> felt {
     return nested.0.1 + nested.1.0;
 }
 
+fn get_tuple() -> (felt, felt) {
+    return (42, 99);
+}
+
 fn test_function_return_tuple_index() -> felt {
     return get_tuple().1;
 }
 
-fn get_tuple() -> (felt, felt) {
-    return (42, 99);
+fn test_simple_function_call_index() -> felt {
+    let result = get_tuple().1;
+    return result;
 }
 
 fn test_chain_tuple_operations() -> felt {

--- a/crates/compiler/mir/src/lib.rs
+++ b/crates/compiler/mir/src/lib.rs
@@ -1,4 +1,4 @@
-//! # Cairo-M Intermediate Representation (MIR)
+//a # Cairo-M Intermediate Representation (MIR)
 //!
 //! This crate defines the data structures for the Mid-level Intermediate Representation
 //! of the Cairo-M compiler. The MIR is a high-level, platform-independent representation

--- a/crates/compiler/parser/src/parser.rs
+++ b/crates/compiler/parser/src/parser.rs
@@ -556,22 +556,26 @@ where
             Spanned::new(TypeExpr::Named(Spanned::new(named_type, span)), span)
         });
 
-        // Tuple types: (felt, felt), (Vector, bool, felt), etc.
-        let tuple_type = type_expr
-            .clone()
-            .separated_by(just(TokenType::Comma))
-            .allow_trailing()
-            .collect::<Vec<_>>()
-            .delimited_by(just(TokenType::LParen), just(TokenType::RParen))
-            .map_with(|types, extra| {
+        // Tuple types: (felt,), (felt, felt), (Vector, bool, felt), etc.
+        let tuple_type = just(TokenType::LParen)
+            .ignore_then(
+                type_expr
+                    .clone()
+                    .separated_by(just(TokenType::Comma))
+                    .collect::<Vec<_>>()
+                    .then(just(TokenType::Comma).or_not()), // Check for trailing comma
+            )
+            .then_ignore(just(TokenType::RParen))
+            .map_with(|(types, trailing_comma), extra| {
                 let span = extra.span();
-                // Single type in parens is just a parenthesized type
-                if types.len() == 1 {
-                    // Extract the inner type but use the parentheses span
-                    types.into_iter().next().unwrap()
-                } else {
-                    // Multiple types form a tuple type
-                    Spanned::new(TypeExpr::Tuple(types), span)
+
+                match (types.len(), trailing_comma.is_some()) {
+                    // Single element with trailing comma -> tuple
+                    (1, true) => Spanned::new(TypeExpr::Tuple(types), span),
+                    // Single element without trailing comma -> parenthesized type
+                    (1, false) => types.into_iter().next().unwrap(),
+                    // Multiple elements -> always a tuple (regardless of trailing comma)
+                    (_, _) => Spanned::new(TypeExpr::Tuple(types), span),
                 }
             });
 
@@ -653,19 +657,22 @@ where
             .map_with(|expr, extra| Spanned::new(expr, extra.span()));
 
         // Tuple expressions and parenthesized expressions: "(a, b, c)" or "(expr)"
-        let tuple_expr = expr
-            .clone()
-            .separated_by(just(TokenType::Comma))
-            .allow_trailing()
-            .collect::<Vec<_>>()
-            .delimited_by(just(TokenType::LParen), just(TokenType::RParen))
-            .map(|exprs| {
-                // Single element in parens is just a parenthesized expression
-                if exprs.len() == 1 {
-                    exprs.into_iter().next().unwrap().value().clone()
-                } else {
-                    // Multiple elements form a tuple
-                    Expression::Tuple(exprs)
+        let tuple_expr = just(TokenType::LParen)
+            .ignore_then(
+                expr.clone()
+                    .separated_by(just(TokenType::Comma))
+                    .collect::<Vec<_>>()
+                    .then(just(TokenType::Comma).or_not()), // Check for trailing comma
+            )
+            .then_ignore(just(TokenType::RParen))
+            .map(|(exprs, trailing_comma)| {
+                match (exprs.len(), trailing_comma.is_some()) {
+                    // Single element with trailing comma -> tuple
+                    (1, true) => Expression::Tuple(exprs),
+                    // Single element without trailing comma -> parenthesized expression
+                    (1, false) => exprs.into_iter().next().unwrap().value().clone(),
+                    // Multiple elements -> always a tuple (regardless of trailing comma)
+                    (_, _) => Expression::Tuple(exprs),
                 }
             })
             .map_with(|expr, extra| Spanned::new(expr, extra.span()));

--- a/crates/compiler/parser/tests/parser/expressions.rs
+++ b/crates/compiler/parser/tests/parser/expressions.rs
@@ -205,6 +205,30 @@ fn tuple_parameterized() {
 }
 
 // ===================
+// Tuple Indexing
+// ===================
+
+#[test]
+fn tuple_indexing_parameterized() {
+    assert_parses_parameterized! {
+        ok: [
+            in_function("tt.0;"),
+            in_function("my_tuple.1;"),
+            in_function("(1, 2, 3).0;"),
+            in_function("foo(bar).2;"),
+            in_function("((1, 2), (3, 4)).0.1;"),
+            in_function("get_tuple().0;"),
+            in_function("tuple_ptr.3;"),
+        ],
+        err: [
+            in_function("tt.0u32;"),  // suffix not allowed
+            in_function("tt.0felt;"), // suffix not allowed
+            in_function("tt.;"),      // missing index
+        ]
+    }
+}
+
+// ===================
 // Parenthesized Expressions
 // ===================
 

--- a/crates/compiler/parser/tests/snapshots/parameterized__expressions::tuple_indexing_parameterized_err.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__expressions::tuple_indexing_parameterized_err.snap
@@ -1,0 +1,40 @@
+---
+source: crates/compiler/parser/tests/common.rs
+expression: snapshot
+---
+--- Input 1 (ERROR) ---
+fn test() { tt.0u32; }
+--- Diagnostics ---
+[02] Error: tuple indices cannot have a suffix
+   ╭─[ test.cairo:1:15 ]
+   │
+ 1 │ fn test() { tt.0u32; }
+   │               ──┬──  
+   │                 ╰──── tuple indices cannot have a suffix
+───╯
+
+============================================================
+
+--- Input 2 (ERROR) ---
+fn test() { tt.0felt; }
+--- Diagnostics ---
+[02] Error: tuple indices cannot have a suffix
+   ╭─[ test.cairo:1:15 ]
+   │
+ 1 │ fn test() { tt.0felt; }
+   │               ───┬──  
+   │                  ╰──── tuple indices cannot have a suffix
+───╯
+
+============================================================
+
+--- Input 3 (ERROR) ---
+fn test() { tt.; }
+--- Diagnostics ---
+[02] Error: found ';' expected something else, or identifier
+   ╭─[ test.cairo:1:16 ]
+   │
+ 1 │ fn test() { tt.; }
+   │                ┬  
+   │                ╰── found ';' expected something else, or identifier
+───╯

--- a/crates/compiler/parser/tests/snapshots/parameterized__expressions::tuple_indexing_parameterized_ok.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__expressions::tuple_indexing_parameterized_ok.snap
@@ -1,0 +1,418 @@
+---
+source: crates/compiler/parser/tests/common.rs
+expression: snapshot
+---
+--- Input 1 ---
+fn test() { tt.0; }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Expression(
+                            Spanned(
+                                TupleIndex {
+                                    tuple: Spanned(
+                                        Identifier(
+                                            Spanned(
+                                                "tt",
+                                                12..14,
+                                            ),
+                                        ),
+                                        12..14,
+                                    ),
+                                    index: 0,
+                                },
+                                12..16,
+                            ),
+                        ),
+                        12..17,
+                    ),
+                ],
+            },
+            0..19,
+        ),
+    ),
+]
+============================================================
+
+--- Input 2 ---
+fn test() { my_tuple.1; }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Expression(
+                            Spanned(
+                                TupleIndex {
+                                    tuple: Spanned(
+                                        Identifier(
+                                            Spanned(
+                                                "my_tuple",
+                                                12..20,
+                                            ),
+                                        ),
+                                        12..20,
+                                    ),
+                                    index: 1,
+                                },
+                                12..22,
+                            ),
+                        ),
+                        12..23,
+                    ),
+                ],
+            },
+            0..25,
+        ),
+    ),
+]
+============================================================
+
+--- Input 3 ---
+fn test() { (1, 2, 3).0; }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Expression(
+                            Spanned(
+                                TupleIndex {
+                                    tuple: Spanned(
+                                        Tuple(
+                                            [
+                                                Spanned(
+                                                    Literal(
+                                                        1,
+                                                        None,
+                                                    ),
+                                                    13..14,
+                                                ),
+                                                Spanned(
+                                                    Literal(
+                                                        2,
+                                                        None,
+                                                    ),
+                                                    16..17,
+                                                ),
+                                                Spanned(
+                                                    Literal(
+                                                        3,
+                                                        None,
+                                                    ),
+                                                    19..20,
+                                                ),
+                                            ],
+                                        ),
+                                        12..21,
+                                    ),
+                                    index: 0,
+                                },
+                                12..23,
+                            ),
+                        ),
+                        12..24,
+                    ),
+                ],
+            },
+            0..26,
+        ),
+    ),
+]
+============================================================
+
+--- Input 4 ---
+fn test() { foo(bar).2; }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Expression(
+                            Spanned(
+                                TupleIndex {
+                                    tuple: Spanned(
+                                        FunctionCall {
+                                            callee: Spanned(
+                                                Identifier(
+                                                    Spanned(
+                                                        "foo",
+                                                        12..15,
+                                                    ),
+                                                ),
+                                                12..15,
+                                            ),
+                                            args: [
+                                                Spanned(
+                                                    Identifier(
+                                                        Spanned(
+                                                            "bar",
+                                                            16..19,
+                                                        ),
+                                                    ),
+                                                    16..19,
+                                                ),
+                                            ],
+                                        },
+                                        12..19,
+                                    ),
+                                    index: 2,
+                                },
+                                12..22,
+                            ),
+                        ),
+                        12..23,
+                    ),
+                ],
+            },
+            0..25,
+        ),
+    ),
+]
+============================================================
+
+--- Input 5 ---
+fn test() { ((1, 2), (3, 4)).0.1; }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Expression(
+                            Spanned(
+                                TupleIndex {
+                                    tuple: Spanned(
+                                        TupleIndex {
+                                            tuple: Spanned(
+                                                Tuple(
+                                                    [
+                                                        Spanned(
+                                                            Tuple(
+                                                                [
+                                                                    Spanned(
+                                                                        Literal(
+                                                                            1,
+                                                                            None,
+                                                                        ),
+                                                                        14..15,
+                                                                    ),
+                                                                    Spanned(
+                                                                        Literal(
+                                                                            2,
+                                                                            None,
+                                                                        ),
+                                                                        17..18,
+                                                                    ),
+                                                                ],
+                                                            ),
+                                                            13..19,
+                                                        ),
+                                                        Spanned(
+                                                            Tuple(
+                                                                [
+                                                                    Spanned(
+                                                                        Literal(
+                                                                            3,
+                                                                            None,
+                                                                        ),
+                                                                        22..23,
+                                                                    ),
+                                                                    Spanned(
+                                                                        Literal(
+                                                                            4,
+                                                                            None,
+                                                                        ),
+                                                                        25..26,
+                                                                    ),
+                                                                ],
+                                                            ),
+                                                            21..27,
+                                                        ),
+                                                    ],
+                                                ),
+                                                12..28,
+                                            ),
+                                            index: 0,
+                                        },
+                                        12..30,
+                                    ),
+                                    index: 1,
+                                },
+                                12..32,
+                            ),
+                        ),
+                        12..33,
+                    ),
+                ],
+            },
+            0..35,
+        ),
+    ),
+]
+============================================================
+
+--- Input 6 ---
+fn test() { get_tuple().0; }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Expression(
+                            Spanned(
+                                TupleIndex {
+                                    tuple: Spanned(
+                                        FunctionCall {
+                                            callee: Spanned(
+                                                Identifier(
+                                                    Spanned(
+                                                        "get_tuple",
+                                                        12..21,
+                                                    ),
+                                                ),
+                                                12..21,
+                                            ),
+                                            args: [],
+                                        },
+                                        12..23,
+                                    ),
+                                    index: 0,
+                                },
+                                12..25,
+                            ),
+                        ),
+                        12..26,
+                    ),
+                ],
+            },
+            0..28,
+        ),
+    ),
+]
+============================================================
+
+--- Input 7 ---
+fn test() { tuple_ptr.3; }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Expression(
+                            Spanned(
+                                TupleIndex {
+                                    tuple: Spanned(
+                                        Identifier(
+                                            Spanned(
+                                                "tuple_ptr",
+                                                12..21,
+                                            ),
+                                        ),
+                                        12..21,
+                                    ),
+                                    index: 3,
+                                },
+                                12..23,
+                            ),
+                        ),
+                        12..24,
+                    ),
+                ],
+            },
+            0..26,
+        ),
+    ),
+]

--- a/crates/compiler/parser/tests/snapshots/parameterized__expressions::tuple_parameterized_ok.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__expressions::tuple_parameterized_ok.snap
@@ -165,11 +165,18 @@ fn test() { (single_element,); }
                     Spanned(
                         Expression(
                             Spanned(
-                                Identifier(
-                                    Spanned(
-                                        "single_element",
-                                        13..27,
-                                    ),
+                                Tuple(
+                                    [
+                                        Spanned(
+                                            Identifier(
+                                                Spanned(
+                                                    "single_element",
+                                                    13..27,
+                                                ),
+                                            ),
+                                            13..27,
+                                        ),
+                                    ],
                                 ),
                                 12..29,
                             ),

--- a/crates/compiler/parser/tests/snapshots/types::single_element_tuple_type.snap
+++ b/crates/compiler/parser/tests/snapshots/types::single_element_tuple_type.snap
@@ -20,13 +20,20 @@ fn test(x: (felt,)) { }
                             8..9,
                         ),
                         type_expr: Spanned(
-                            Named(
-                                Spanned(
-                                    Felt,
-                                    12..16,
-                                ),
+                            Tuple(
+                                [
+                                    Spanned(
+                                        Named(
+                                            Spanned(
+                                                Felt,
+                                                12..16,
+                                            ),
+                                        ),
+                                        12..16,
+                                    ),
+                                ],
                             ),
-                            12..16,
+                            11..18,
                         ),
                     },
                 ],

--- a/crates/compiler/semantic/src/semantic_index.rs
+++ b/crates/compiler/semantic/src/semantic_index.rs
@@ -1200,6 +1200,9 @@ impl<'db, 'sink> SemanticIndexBuilder<'db, 'sink> {
                     }
                 }
             }
+            Expression::TupleIndex { tuple, .. } => {
+                self.visit_expr(tuple);
+            }
             Expression::Literal(_, _) | Expression::BooleanLiteral(_) => {
                 // Leaf nodes - no sub-expressions
             }

--- a/crates/compiler/semantic/src/type_resolution.rs
+++ b/crates/compiler/semantic/src/type_resolution.rs
@@ -507,6 +507,24 @@ pub fn expression_semantic_type<'db>(
                 TypeId::new(db, TypeData::Error)
             }
         }
+        Expression::TupleIndex { tuple, index } => {
+            let tuple_id = semantic_index.expression_id_by_span(tuple.span()).unwrap();
+            let tuple_ty = expression_semantic_type(db, crate_id, file, tuple_id, None);
+            match tuple_ty.data(db) {
+                TypeData::Tuple(elems) => elems
+                    .get(*index)
+                    .copied()
+                    .unwrap_or_else(|| TypeId::new(db, TypeData::Error)),
+                TypeData::Pointer(inner) => match inner.data(db) {
+                    TypeData::Tuple(elems) => elems
+                        .get(*index)
+                        .copied()
+                        .unwrap_or_else(|| TypeId::new(db, TypeData::Error)),
+                    _ => TypeId::new(db, TypeData::Error),
+                },
+                _ => TypeId::new(db, TypeData::Error),
+            }
+        }
     }
 }
 

--- a/crates/compiler/semantic/src/type_resolution_tests.rs
+++ b/crates/compiler/semantic/src/type_resolution_tests.rs
@@ -253,6 +253,7 @@ fn test_expression_type_coverage() {
             Expression::IndexAccess { .. } => "IndexAccess",
             Expression::StructLiteral { .. } => "StructLiteral",
             Expression::Tuple(_) => "Tuple",
+            Expression::TupleIndex { .. } => "TupleIndex",
         };
         expression_types_found.insert(variant_name);
 

--- a/crates/compiler/semantic/src/types.rs
+++ b/crates/compiler/semantic/src/types.rs
@@ -171,6 +171,11 @@ impl<'db> TypeData<'db> {
         !self.is_error() && !self.is_unknown()
     }
 
+    /// Check if this type is a numeric type
+    pub const fn is_numeric(&self) -> bool {
+        matches!(self, TypeData::Felt | TypeData::U32)
+    }
+
     /// Get a human-readable display name for this type
     pub fn display_name(&self, db: &dyn SemanticDb) -> String {
         match self {
@@ -181,7 +186,11 @@ impl<'db> TypeData<'db> {
             TypeData::Tuple(types) => {
                 let type_names: Vec<String> =
                     types.iter().map(|t| t.data(db).display_name(db)).collect();
-                format!("({})", type_names.join(", "))
+                if types.len() == 1 {
+                    format!("({},)", type_names.join(", "))
+                } else {
+                    format!("({})", type_names.join(", "))
+                }
             }
             TypeData::Pointer(inner) => {
                 format!("{}*", inner.data(db).display_name(db))

--- a/crates/compiler/semantic/tests/common/snapshots/diagnostics__expressions::type_errors::test_bool_felt_addition_error.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/diagnostics__expressions::type_errors::test_bool_felt_addition_error.snap
@@ -23,4 +23,6 @@ Found 1 diagnostic(s):
  5 │             let resx = ybool + x;  // Expected type mismatch error
    │                        ──┬──  
    │                          ╰──── Operator `+` is not supported for type `bool`
+   │                          │    
+   │                          ╰──── Cannot use bool in arithmetic operations. Consider using logical operators (&&, ||) instead.
 ───╯

--- a/crates/compiler/semantic/tests/common/snapshots/diagnostics__expressions::type_errors::test_comparison_type_mismatch_with_context.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/diagnostics__expressions::type_errors::test_comparison_type_mismatch_with_context.snap
@@ -27,4 +27,6 @@ Found 1 diagnostic(s):
  7 │             if p == num {  // Type mismatch with context
    │                ┬  
    │                ╰── Operator `==` is not supported for type `Point`
+   │                │  
+   │                ╰── This struct has numeric fields that could be accessed
 ───╯

--- a/crates/compiler/semantic/tests/common/snapshots/diagnostics__expressions::type_errors::test_function_not_called_error.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/diagnostics__expressions::type_errors::test_function_not_called_error.snap
@@ -33,4 +33,6 @@ Found 2 diagnostic(s):
  7 │             let x = get_value + 5;  // Should suggest adding parentheses
    │                     ────┬────  
    │                         ╰────── Operator `+` is not supported for type `function`
+   │                         │      
+   │                         ╰────── Did you forget to call the function with parentheses?
 ───╯

--- a/crates/compiler/semantic/tests/common/snapshots/diagnostics__expressions::type_errors::test_struct_with_numeric_field_suggestion.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/diagnostics__expressions::type_errors::test_struct_with_numeric_field_suggestion.snap
@@ -32,4 +32,6 @@ Found 2 diagnostic(s):
  6 │             let result = c * 2;  // Should suggest accessing 'value' field
    │                          ┬  
    │                          ╰── Operator `*` is not supported for type `Counter`
+   │                          │  
+   │                          ╰── Did you mean to access the `value` field?
 ───╯

--- a/crates/compiler/semantic/tests/common/snapshots/diagnostics__expressions::type_errors::test_tuple_in_arithmetic_operation.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/diagnostics__expressions::type_errors::test_tuple_in_arithmetic_operation.snap
@@ -8,11 +8,11 @@ Source code:
 
         fn test() {
             let t = (42,);
-            let result = t + 10;  // Should suggest accessing with [0]
+            let result = t + 10;  // Should suggest accessing with `.0`
         }
     
 ============================================================
-Found 1 diagnostic(s):
+Found 2 diagnostic(s):
 
 --- Diagnostic 1 ---
 [3002] Error: Function 'test' doesn't return on all paths
@@ -21,4 +21,15 @@ Found 1 diagnostic(s):
  2 │         fn test() {
    │            ──┬─  
    │              ╰─── Function 'test' doesn't return on all paths
+───╯
+
+--- Diagnostic 2 ---
+[2001] Error: Operator `+` is not supported for type `(felt,)`
+   ╭─[ semantic_tests::expressions::type_errors::test_tuple_in_arithmetic_operation:4:26 ]
+   │
+ 4 │             let result = t + 10;  // Should suggest accessing with `.0`
+   │                          ┬  
+   │                          ╰── Operator `+` is not supported for type `(felt,)`
+   │                          │  
+   │                          ╰── Did you mean to access the tuple element with `.0`?
 ───╯

--- a/crates/compiler/semantic/tests/common/snapshots/diagnostics__expressions::type_errors::test_unary_op_type_error.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/diagnostics__expressions::type_errors::test_unary_op_type_error.snap
@@ -24,4 +24,6 @@ Found 1 diagnostic(s):
  6 │             let x = -p;  // Should show type error for negation on struct
    │                      ┬  
    │                      ╰── Operator `-` is not supported for type `Point`
+   │                      │  
+   │                      ╰── This struct has numeric fields that could be accessed
 ───╯

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::binary_expressions::test_arithmetic_operator_types.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::binary_expressions::test_arithmetic_operator_types.snap
@@ -89,4 +89,6 @@ struct Point { x: felt, y: felt } fn test() { let p1 = Point { x: 10, y: 20 }; l
  1 │ struct Point { x: felt, y: felt } fn test() { let p1 = Point { x: 10, y: 20 }; let p4 = p1 * 2; return; }
    │                                                                                         ─┬  
    │                                                                                          ╰── Operator `*` is not supported for type `Point`
+   │                                                                                          │  
+   │                                                                                          ╰── This struct has numeric fields that could be accessed
 ───╯

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::binary_expressions::test_comparison_operator_type_errors.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::binary_expressions::test_comparison_operator_type_errors.snap
@@ -160,6 +160,8 @@ struct Point { x: felt, y: felt } fn test() { let p = Point { x: 10, y: 20 }; le
  1 │ struct Point { x: felt, y: felt } fn test() { let p = Point { x: 10, y: 20 }; let x: felt = 42; let c8 = p == x; }
    │                                                                                                          ┬  
    │                                                                                                          ╰── Operator `==` is not supported for type `Point`
+   │                                                                                                          │  
+   │                                                                                                          ╰── This struct has numeric fields that could be accessed
 ───╯
 
 ============================================================

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::tuple_index::test_tuple_index_expressions.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::tuple_index::test_tuple_index_expressions.snap
@@ -1,0 +1,144 @@
+---
+source: crates/compiler/semantic/tests/common/mod.rs
+expression: snapshot
+---
+--- Input 1 (ERROR) ---
+fn test() { let t = (10, 20, 30); let x = t.3; return; }
+--- Diagnostics ---
+[2012] Error: no field `3` on type `(felt, felt, felt)`
+   ╭─[ semantic_tests::expressions::tuple_index::test_tuple_index_expressions:1:43 ]
+   │
+ 1 │ fn test() { let t = (10, 20, 30); let x = t.3; return; }
+   │                                           ┬  
+   │                                           ╰── no field `3` on type `(felt, felt, felt)`
+───╯
+
+============================================================
+
+--- Input 2 (ERROR) ---
+fn test() { let t = (10, 20, 30); let x = t.4; return; }
+--- Diagnostics ---
+[2012] Error: no field `4` on type `(felt, felt, felt)`
+   ╭─[ semantic_tests::expressions::tuple_index::test_tuple_index_expressions:1:43 ]
+   │
+ 1 │ fn test() { let t = (10, 20, 30); let x = t.4; return; }
+   │                                           ┬  
+   │                                           ╰── no field `4` on type `(felt, felt, felt)`
+───╯
+
+============================================================
+
+--- Input 3 (ERROR) ---
+fn test() { let t = (10, 20, 30); let x = t[3]; return; }
+--- Diagnostics ---
+[2013] Error: tuples must be accessed using `.index` syntax (e.g., `tup.0`), not `[]`
+   ╭─[ semantic_tests::expressions::tuple_index::test_tuple_index_expressions:1:43 ]
+   │
+ 1 │ fn test() { let t = (10, 20, 30); let x = t[3]; return; }
+   │                                           ┬  
+   │                                           ╰── tuples must be accessed using `.index` syntax (e.g., `tup.0`), not `[]`
+───╯
+
+============================================================
+
+--- Input 4 (ERROR) ---
+fn test() { let t = (42,); let x = t.1; return; }
+--- Diagnostics ---
+[2012] Error: no field `1` on type `(felt,)`
+   ╭─[ semantic_tests::expressions::tuple_index::test_tuple_index_expressions:1:36 ]
+   │
+ 1 │ fn test() { let t = (42,); let x = t.1; return; }
+   │                                    ┬  
+   │                                    ╰── no field `1` on type `(felt,)`
+───╯
+
+============================================================
+
+--- Input 5 (ERROR) ---
+fn test() { let t = (); let x = t.0; return; }
+--- Diagnostics ---
+[2012] Error: no field `0` on type `()`
+   ╭─[ semantic_tests::expressions::tuple_index::test_tuple_index_expressions:1:33 ]
+   │
+ 1 │ fn test() { let t = (); let x = t.0; return; }
+   │                                 ┬  
+   │                                 ╰── no field `0` on type `()`
+───╯
+
+============================================================
+
+--- Input 6 (ERROR) ---
+fn test() { let t = (10, 20, 30); let x = t[0]; return; }
+--- Diagnostics ---
+[2013] Error: tuples must be accessed using `.index` syntax (e.g., `tup.0`), not `[]`
+   ╭─[ semantic_tests::expressions::tuple_index::test_tuple_index_expressions:1:43 ]
+   │
+ 1 │ fn test() { let t = (10, 20, 30); let x = t[0]; return; }
+   │                                           ┬  
+   │                                           ╰── tuples must be accessed using `.index` syntax (e.g., `tup.0`), not `[]`
+───╯
+
+============================================================
+
+--- Input 7 (ERROR) ---
+fn test() { let t = (10, 20, 30); let x = t.-1; return; }
+--- Diagnostics ---
+[02] Error: found '-' expected something else, or identifier
+   ╭─[ semantic_tests::expressions::tuple_index::test_tuple_index_expressions:1:45 ]
+   │
+ 1 │ fn test() { let t = (10, 20, 30); let x = t.-1; return; }
+   │                                             ┬  
+   │                                             ╰── found '-' expected something else, or identifier
+───╯
+
+============================================================
+
+--- Input 8 (ERROR) ---
+fn test() { let x = 42; let y = x.0; return; }
+--- Diagnostics ---
+[2013] Error: Cannot use tuple index on type `felt`
+   ╭─[ semantic_tests::expressions::tuple_index::test_tuple_index_expressions:1:33 ]
+   │
+ 1 │ fn test() { let x = 42; let y = x.0; return; }
+   │                                 ┬  
+   │                                 ╰── Cannot use tuple index on type `felt`
+───╯
+
+============================================================
+
+--- Input 9 (ERROR) ---
+fn test() { let x = true; let y = x.0; return; }
+--- Diagnostics ---
+[2013] Error: Cannot use tuple index on type `bool`
+   ╭─[ semantic_tests::expressions::tuple_index::test_tuple_index_expressions:1:35 ]
+   │
+ 1 │ fn test() { let x = true; let y = x.0; return; }
+   │                                   ┬  
+   │                                   ╰── Cannot use tuple index on type `bool`
+───╯
+
+============================================================
+
+--- Input 10 (ERROR) ---
+fn test() { let t = ((1, 2), (3, 4)); let x = t.0.2; return; }
+--- Diagnostics ---
+[2012] Error: no field `2` on type `(felt, felt)`
+   ╭─[ semantic_tests::expressions::tuple_index::test_tuple_index_expressions:1:47 ]
+   │
+ 1 │ fn test() { let t = ((1, 2), (3, 4)); let x = t.0.2; return; }
+   │                                               ─┬─  
+   │                                                ╰─── no field `2` on type `(felt, felt)`
+───╯
+
+============================================================
+
+--- Input 11 (ERROR) ---
+fn test() { let t = ((1, 2), (3, 4)); let x = t.2; return; }
+--- Diagnostics ---
+[2012] Error: no field `2` on type `((felt, felt), (felt, felt))`
+   ╭─[ semantic_tests::expressions::tuple_index::test_tuple_index_expressions:1:47 ]
+   │
+ 1 │ fn test() { let t = ((1, 2), (3, 4)); let x = t.2; return; }
+   │                                               ┬  
+   │                                               ╰── no field `2` on type `((felt, felt), (felt, felt))`
+───╯

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::unary_expressions::test_unary_operator_types.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::unary_expressions::test_unary_operator_types.snap
@@ -11,6 +11,8 @@ fn test() { let b: bool = true; let neg_bool = -b; return; }
  1 │ fn test() { let b: bool = true; let neg_bool = -b; return; }
    │                                                 ┬  
    │                                                 ╰── Operator `-` is not supported for type `bool`
+   │                                                 │  
+   │                                                 ╰── Cannot use bool in arithmetic operations. Consider using logical operators (&&, ||) instead.
 ───╯
 
 ============================================================
@@ -50,6 +52,8 @@ struct Point { x: felt, y: felt } fn test() { let p = Point { x: 10, y: 20 }; le
  1 │ struct Point { x: felt, y: felt } fn test() { let p = Point { x: 10, y: 20 }; let neg_struct = -p; return; }
    │                                                                                                 ┬  
    │                                                                                                 ╰── Operator `-` is not supported for type `Point`
+   │                                                                                                 │  
+   │                                                                                                 ╰── This struct has numeric fields that could be accessed
 ───╯
 
 ============================================================
@@ -63,4 +67,6 @@ struct Point { x: felt, y: felt } fn test() { let p = Point { x: 10, y: 20 }; le
  1 │ struct Point { x: felt, y: felt } fn test() { let p = Point { x: 10, y: 20 }; let not_struct = !p; return; }
    │                                                                                                 ┬  
    │                                                                                                 ╰── Operator `!` is not supported for type `Point`
+   │                                                                                                 │  
+   │                                                                                                 ╰── This struct has numeric fields that could be accessed
 ───╯

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__functions::tuples::test_tuple_indexing.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__functions::tuples::test_tuple_indexing.snap
@@ -1,0 +1,53 @@
+---
+source: crates/compiler/semantic/tests/common/mod.rs
+expression: snapshot
+---
+--- Input 1 (ERROR) ---
+fn test() { let tt = (1, 2); let x = tt.2; return; }
+--- Diagnostics ---
+[2012] Error: no field `2` on type `(felt, felt)`
+   ╭─[ semantic_tests::functions::tuples::test_tuple_indexing:1:38 ]
+   │
+ 1 │ fn test() { let tt = (1, 2); let x = tt.2; return; }
+   │                                      ─┬  
+   │                                       ╰── no field `2` on type `(felt, felt)`
+───╯
+
+============================================================
+
+--- Input 2 (ERROR) ---
+fn test() { let tt = (1, 2, 3); let x = tt.3; return; }
+--- Diagnostics ---
+[2012] Error: no field `3` on type `(felt, felt, felt)`
+   ╭─[ semantic_tests::functions::tuples::test_tuple_indexing:1:41 ]
+   │
+ 1 │ fn test() { let tt = (1, 2, 3); let x = tt.3; return; }
+   │                                         ─┬  
+   │                                          ╰── no field `3` on type `(felt, felt, felt)`
+───╯
+
+============================================================
+
+--- Input 3 (ERROR) ---
+fn test() { let x = 42; let y = x.0; return; }
+--- Diagnostics ---
+[2013] Error: Cannot use tuple index on type `felt`
+   ╭─[ semantic_tests::functions::tuples::test_tuple_indexing:1:33 ]
+   │
+ 1 │ fn test() { let x = 42; let y = x.0; return; }
+   │                                 ┬  
+   │                                 ╰── Cannot use tuple index on type `felt`
+───╯
+
+============================================================
+
+--- Input 4 (ERROR) ---
+fn test() { let tt: (felt, felt) = (1, 2); let x: (felt, felt) = tt.0; return; }
+--- Diagnostics ---
+[2001] Error: Type mismatch for let statement `x`. Expected `(felt, felt)`, found `felt`
+   ╭─[ semantic_tests::functions::tuples::test_tuple_indexing:1:66 ]
+   │
+ 1 │ fn test() { let tt: (felt, felt) = (1, 2); let x: (felt, felt) = tt.0; return; }
+   │                                                                  ──┬─  
+   │                                                                    ╰─── Type mismatch for let statement `x`. Expected `(felt, felt)`, found `felt`
+───╯

--- a/crates/compiler/semantic/tests/expressions/mod.rs
+++ b/crates/compiler/semantic/tests/expressions/mod.rs
@@ -5,6 +5,7 @@
 pub mod type_errors;
 
 pub mod binary_expressions;
+pub mod tuple_index;
 pub mod unary_expressions;
 
 // TODO: Implement literal expression validation tests.

--- a/crates/compiler/semantic/tests/expressions/tuple_index.rs
+++ b/crates/compiler/semantic/tests/expressions/tuple_index.rs
@@ -1,0 +1,54 @@
+//! Tests for tuple index expressions
+use crate::{assert_semantic_parameterized, in_function};
+
+#[test]
+fn test_tuple_index_expressions() {
+    assert_semantic_parameterized! {
+        ok: [
+            // In range - basic cases
+            in_function("let t = (10, 20, 30); let x = t.0;"),
+            in_function("let t = (10, 20, 30); let x = t.1;"),
+            in_function("let t = (10, 20, 30); let x = t.2;"),
+
+            // Single element tuple
+            in_function("let t = (42,); let x = t.0;"),
+
+            // Nested tuples
+            in_function("let t = ((1, 2), (3, 4)); let x = t.0;"),
+            in_function("let t = ((1, 2), (3, 4)); let x = t.0.1;"),
+
+            // Different types in tuple
+            in_function("let t = (42, true); let x = t.0;"),
+            in_function("let t = (42, true); let b = t.1;"),
+
+            // Large index numbers (still valid)
+            in_function("let t = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10); let x = t.9;"),
+            ],
+            err: [
+            // Out of range
+            in_function("let t = (10, 20, 30); let x = t.3;"),
+            in_function("let t = (10, 20, 30); let x = t.4;"),
+            in_function("let t = (10, 20, 30); let x = t[3];"),
+
+            // Single element tuple - out of range
+            in_function("let t = (42,); let x = t.1;"),
+
+            // Empty tuple - any index should fail
+            in_function("let t = (); let x = t.0;"),
+
+            // Invalid index access (subscript operator)
+            in_function("let t = (10, 20, 30); let x = t[0];"),
+
+            // Negative indices (if numeric literals)
+            in_function("let t = (10, 20, 30); let x = t.-1;"),
+
+            // Non-tuple types with dot access
+            in_function("let x = 42; let y = x.0;"),
+            in_function("let x = true; let y = x.0;"),
+
+            // Nested access out of range
+            in_function("let t = ((1, 2), (3, 4)); let x = t.0.2;"),
+            in_function("let t = ((1, 2), (3, 4)); let x = t.2;"),
+        ]
+    }
+}

--- a/crates/compiler/semantic/tests/expressions/type_errors.rs
+++ b/crates/compiler/semantic/tests/expressions/type_errors.rs
@@ -22,7 +22,7 @@ fn test_tuple_in_arithmetic_operation() {
         r#"
         fn test() {
             let t = (42,);
-            let result = t + 10;  // Should suggest accessing with [0]
+            let result = t + 10;  // Should suggest accessing with `.0`
         }
     "#
     );

--- a/crates/compiler/semantic/tests/functions/tuples.rs
+++ b/crates/compiler/semantic/tests/functions/tuples.rs
@@ -29,3 +29,37 @@ fn test_tuple_destructuring_unused_variable() {
         ]
     }
 }
+
+#[test]
+fn test_tuple_indexing() {
+    assert_semantic_parameterized! {
+        ok: [
+            // Basic tuple indexing
+            in_function("let tt = (1, 2, 3); let x = tt.0;"),
+            in_function("let tt = (1, 2, 3); let y = tt.1; let z = tt.2;"),
+
+            // Tuple indexing with expressions
+            in_function("let x = (10, 20, 30).0;"),
+            in_function("let sum = (10, 20).0 + (30, 40).1;"),
+
+            // Nested tuple indexing
+            in_function("let nested = ((1, 2), (3, 4)); let x = nested.0.1;"),
+            in_function("let nested = ((1, 2), (3, 4)); let y = nested.1.0;"),
+
+            // Function returning tuple
+            "fn get_tuple() -> (felt, felt) { return (10, 20); } fn test() -> felt { return get_tuple().0; }",
+            "fn get_tuple() -> (felt, felt) { return (10, 20); } fn test() -> felt { let x = get_tuple().1; return x; }",
+        ],
+        err: [
+            // Out of bounds access
+            in_function("let tt = (1, 2); let x = tt.2;"),
+            in_function("let tt = (1, 2, 3); let x = tt.3;"),
+
+            // Indexing non-tuple
+            in_function("let x = 42; let y = x.0;"),
+
+            // Type mismatch
+            in_function("let tt: (felt, felt) = (1, 2); let x: (felt, felt) = tt.0;"),
+        ]
+    }
+}


### PR DESCRIPTION
### Feat: Implement Tuple Indexing (`expr.N`)

This PR introduces support for tuple indexing using the `expr.N` syntax (e.g., `my_tuple.0`). This feature is implemented across the entire compilation pipeline, from parsing to MIR generation, enabling both reading from and assigning to tuple elements.

#### Key Changes:

*   **Parser (`parser` crate):**
    *   Introduced a new `Expression::TupleIndex` AST node.
    *   Updated the parser to recognize the `.` followed by a number literal as a tuple index access.
    *   Added validation to reject indices with type suffixes (e.g., `t.0u32`).
    *   Included comprehensive parser tests for valid and invalid syntax.

*   **Semantic Analysis (`semantic` crate):**
    *   **Type Resolution:** Implemented type resolution for `TupleIndex` expressions, correctly determining the type of the accessed element from the parent tuple's type.
    *   **Validation:** Added a new validation pass (`check_tuple_index_types`) to:
        *   Detect and report out-of-bounds access (e.g., accessing index `2` on a 2-element tuple).
        *   Ensure indexing is only performed on expressions of tuple types.
    *   **Diagnostics:** Introduced new diagnostic codes `TupleIndexOutOfBounds` (2012) and `InvalidTupleIndexAccess` (2013) for clear error reporting.

*   **MIR Generation (`mir` crate):**
    *   Implemented MIR generation for `TupleIndex` expressions for both:
        *   **R-values (reading):** `let x = my_tuple.0;`
        *   **L-values (writing):** `my_tuple.0 = 42;`
    *   The implementation uses the `getelementptr` instruction to calculate the memory address of a tuple element based on its index and type layout.
    *   Added a new MIR test suite (`tuple_indexing`) with various scenarios, including basic access, l-value assignment, and nested tuple indexing.

#### Known Limitations:

*   Indexing a tuple returned directly from a function call (e.g., `get_tuple().1`) is not yet fully supported. This currently results in an `unreachable` terminator in the generated MIR. This is noted with a `TODO` in the code and will be addressed in a future PR.