### PR TITLE
doc: expand macos lld note

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,39 @@ working with work tress from the root of the project
 git worktree add .worktrees/<branch-name>
 ```
 
-**Note for MacOS users**: You need to have `lld` installed, which can be done
-easily with `brew install lld`. Also, make sure that your `clang` is the
-Homebrew one (`brew install llvm`), not the Xcode one.
-
 The project uses [trunk.io](https://trunk.io/) for managing all the linters, so
 make sure to install both the CLI and the VScode extension.
 
+### Note for MacOS users
+
+You need to have LLVM and their LLD linker installed.
+
+```bash
+brew install llvm
+brew install lld
+```
+
+#### Troubleshooting
+
+Make sure that you are using the Homebrew version of `clang` and `llvm`, not the
+Xcode (Apple) one.
+
+```bash
+echo 'export CC=/opt/homebrew/opt/llvm/bin/clang' >> ~/.zshrc
+echo 'export CXX=/opt/homebrew/opt/llvm/bin/clang++' >> ~/.zshrc
+echo 'export AR=/opt/homebrew/opt/llvm/bin/llvm-ar' >> ~/.zshrc
+echo 'export RANLIB=/opt/homebrew/opt/llvm/bin/llvm-ranlib' >> ~/.zshrc
+```
+
 ## Benchmark VM
+
+### MacOS
+
+```bash
+RUSTFLAGS="-C link-arg=-fuse-ld=/opt/homebrew/bin/ld64.lld -C target-cpu=native" cargo bench --bench vm_benchmark -- --verbose
+```
+
+### Other Platforms
 
 ```bash
 RUSTFLAGS="-C target-cpu=native" cargo bench --bench vm_benchmark -- --verbose


### PR DESCRIPTION
Close CORE-1091

## Summary

This expands the lld note to be more explicit and gives a concrete tip for getting the path to use with the environment variable.

## Related

Fixes #166