### PR TITLE
fix(semantic): add validation for const variable reassignment

### DIFF
--- a/crates/compiler/diagnostics/src/diagnostics.rs
+++ b/crates/compiler/diagnostics/src/diagnostics.rs
@@ -117,6 +117,7 @@ pub enum DiagnosticCode {
     MissingReturnValue,
     TupleIndexOutOfBounds,
     InvalidTupleIndexAccess,
+    AssignmentToConst,
     // TODO: Add more type-related diagnostic codes:
     // - InvalidTypeAnnotation
     // - TypeArgumentMismatch
@@ -178,6 +179,7 @@ impl From<DiagnosticCode> for u32 {
             DiagnosticCode::MissingReturnValue => 2011,
             DiagnosticCode::TupleIndexOutOfBounds => 2012,
             DiagnosticCode::InvalidTupleIndexAccess => 2013,
+            DiagnosticCode::AssignmentToConst => 2014,
             DiagnosticCode::InternalError => 9001,
         }
     }

--- a/crates/compiler/semantic/src/validation/type_validator.rs
+++ b/crates/compiler/semantic/src/validation/type_validator.rs
@@ -1179,10 +1179,32 @@ impl TypeValidator {
                         .expression(lhs_expr_id)
                         .expect("No expression info found")
                         .scope_id;
-                    if let Some((_def_idx, _def)) =
+                    if let Some((_def_idx, def)) =
                         index.resolve_name_to_definition(ident.value(), scope_id)
                     {
-                        // TODO: Check if the definition is mutable
+                        // Check if the variable is const
+                        if let Some(place_table) = index.place_table(def.scope_id) {
+                            if let Some(place) = place_table.place(def.place_id) {
+                                if place.flags.contains(crate::place::PlaceFlags::CONSTANT) {
+                                    sink.push(
+                                        Diagnostic::error(
+                                            DiagnosticCode::AssignmentToConst,
+                                            format!(
+                                                "cannot assign to const variable `{}`",
+                                                ident.value()
+                                            ),
+                                        )
+                                        .with_location(file.file_path(db).to_string(), lhs.span())
+                                        .with_related_span(
+                                            file.file_path(db).to_string(),
+                                            def.name_span,
+                                            "const variable defined here".to_string(),
+                                        ),
+                                    );
+                                    return;
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__statements::assignments::test_assignments.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__statements::assignments::test_assignments.snap
@@ -159,3 +159,18 @@ fn test() { let x: felt = 42; let y: felt = 100; let z: felt = (x != y); return;
    │                                                                ────┬───  
    │                                                                    ╰───── Type mismatch for let statement `z`. Expected `felt`, found `bool`
 ───╯
+
+============================================================
+
+--- Input 13 (ERROR) ---
+fn test() { const x = 42; x = 100; return; }
+--- Diagnostics ---
+[2014] Error: cannot assign to const variable `x`
+   ╭─[ semantic_tests::statements::assignments::test_assignments:1:27 ]
+   │
+ 1 │ fn test() { const x = 42; x = 100; return; }
+   │                   ┬       ┬  
+   │                   ╰────────── const variable defined here
+   │                           │  
+   │                           ╰── cannot assign to const variable `x`
+───╯

--- a/crates/compiler/semantic/tests/statements/assignments.rs
+++ b/crates/compiler/semantic/tests/statements/assignments.rs
@@ -29,9 +29,8 @@ fn test_assignments() {
             in_function("let x: felt = 42; let y: felt = 100; let z: felt = (x == y);"),
             in_function("let x: felt = 42; let y: felt = 100; let z: felt = (x != y);"),
 
-            // TODO: This should be fixed.
             // Assignment to consts
-            // in_function("const x = 42; x = 100;"),
+            in_function("const x = 42; x = 100;"),
         ]
     }
 }


### PR DESCRIPTION
## Summary
- Added semantic validation to prevent reassignment to const variables
- Previously, const variables could be reassigned without any compiler error

## Test plan
- Added test case `in_function("const x = 42; x = 100;")` to verify const reassignment is caught
- All existing tests pass
- `cargo test -p cairo-m-compiler-semantic` passes

## Related
Fixes https://linear.app/kkrt-labs/issue/CORE-1065/bug-const-are-in-fact-not-const

🤖 Generated with [Claude Code](https://claude.ai/code)