### PR TITLE
feat(common): define u32 opcodes

### DIFF
--- a/crates/common/src/instruction.rs
+++ b/crates/common/src/instruction.rs
@@ -195,7 +195,7 @@ macro_rules! define_instruction {
         }
 
         // Generate the maximum opcode value
-        const MAX_OPCODE: u32 = {
+        pub const MAX_OPCODE: u32 = {
             let opcodes = [$($opcode),*];
             let mut max = 0;
             let mut i = 0;

--- a/crates/common/src/instruction.rs
+++ b/crates/common/src/instruction.rs
@@ -250,8 +250,17 @@ define_instruction!(
     // Conditional jumps
     JnzFpImm = 14, 1, fields: [cond_off, offset], size: 3, operands: [Felt];                              // jmp rel imm if [fp + cond_off] != 0
 
-    // U32 operations
-    U32StoreAddFpImm = 15, 4, fields: [src_off, imm_hi, imm_lo, dst_off], size: 5, operands: [U32, U32]   // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src_off], [fp + src_off + 1]) + u32(imm_lo, imm_hi)
+    // U32 operations with FP operands
+    U32StoreAddFpFp = 15, 6, fields: [src0_off, src1_off, dst_off], size: 4, operands: [U32, U32, U32];   // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src0_off], [fp + src0_off + 1]) + u32([fp + src1_off], [fp + src1_off + 1])
+    U32StoreSubFpFp = 16, 6, fields: [src0_off, src1_off, dst_off], size: 4, operands: [U32, U32, U32];   // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src0_off], [fp + src0_off + 1]) - u32([fp + src1_off], [fp + src1_off + 1])
+    U32StoreMulFpFp = 17, 6, fields: [src0_off, src1_off, dst_off], size: 4, operands: [U32, U32, U32];   // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src0_off], [fp + src0_off + 1]) * u32([fp + src1_off], [fp + src1_off + 1])
+    U32StoreDivFpFp = 18, 6, fields: [src0_off, src1_off, dst_off], size: 4, operands: [U32, U32, U32];   // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src0_off], [fp + src0_off + 1]) / u32([fp + src1_off], [fp + src1_off + 1])
+
+    // U32 operations with immediate
+    U32StoreAddFpImm = 19, 4, fields: [src_off, imm_hi, imm_lo, dst_off], size: 5, operands: [U32, U32];  // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src_off], [fp + src_off + 1]) + u32(imm_lo, imm_hi)
+    U32StoreSubFpImm = 20, 4, fields: [src_off, imm_hi, imm_lo, dst_off], size: 5, operands: [U32, U32];  // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src_off], [fp + src_off + 1]) - u32(imm_lo, imm_hi)
+    U32StoreMulFpImm = 21, 4, fields: [src_off, imm_hi, imm_lo, dst_off], size: 5, operands: [U32, U32];  // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src_off], [fp + src_off + 1]) * u32(imm_lo, imm_hi)
+    U32StoreDivFpImm = 22, 4, fields: [src_off, imm_hi, imm_lo, dst_off], size: 5, operands: [U32, U32]   // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src_off], [fp + src_off + 1]) / u32(imm_lo, imm_hi)
 );
 
 impl From<Instruction> for SmallVec<[M31; INSTRUCTION_MAX_SIZE]> {

--- a/crates/common/tests/instruction_tests.rs
+++ b/crates/common/tests/instruction_tests.rs
@@ -1,4 +1,4 @@
-use cairo_m_common::instruction::INSTRUCTION_MAX_SIZE;
+use cairo_m_common::instruction::{INSTRUCTION_MAX_SIZE, MAX_OPCODE};
 use cairo_m_common::{Instruction, InstructionError};
 use smallvec::{SmallVec, smallvec};
 use stwo_prover::core::fields::m31::M31;
@@ -60,146 +60,187 @@ fn test_instruction_sizes() {
 
 #[test]
 fn test_opcode_values() {
-    assert_eq!(
-        Instruction::StoreAddFpFp {
-            src0_off: M31::from(0),
-            src1_off: M31::from(0),
-            dst_off: M31::from(0)
-        }
-        .opcode_value(),
-        0
-    );
+    // Test cases: (instruction_constructor, expected_opcode)
+    let test_cases = [
+        (
+            Instruction::StoreAddFpFp {
+                src0_off: M31::from(0),
+                src1_off: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            0,
+        ),
+        (
+            Instruction::StoreSubFpFp {
+                src0_off: M31::from(0),
+                src1_off: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            1,
+        ),
+        (
+            Instruction::StoreMulFpFp {
+                src0_off: M31::from(0),
+                src1_off: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            2,
+        ),
+        (
+            Instruction::StoreDivFpFp {
+                src0_off: M31::from(0),
+                src1_off: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            3,
+        ),
+        (
+            Instruction::StoreAddFpImm {
+                src_off: M31::from(0),
+                imm: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            4,
+        ),
+        (
+            Instruction::StoreSubFpImm {
+                src_off: M31::from(0),
+                imm: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            5,
+        ),
+        (
+            Instruction::StoreMulFpImm {
+                src_off: M31::from(0),
+                imm: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            6,
+        ),
+        (
+            Instruction::StoreDivFpImm {
+                src_off: M31::from(0),
+                imm: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            7,
+        ),
+        (
+            Instruction::StoreDoubleDerefFp {
+                base_off: M31::from(0),
+                offset: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            8,
+        ),
+        (
+            Instruction::StoreImm {
+                imm: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            9,
+        ),
+        (
+            Instruction::CallAbsImm {
+                frame_off: M31::from(0),
+                target: M31::from(0),
+            },
+            10,
+        ),
+        (Instruction::Ret {}, 11),
+        (
+            Instruction::JmpAbsImm {
+                target: M31::from(0),
+            },
+            12,
+        ),
+        (
+            Instruction::JmpRelImm {
+                offset: M31::from(0),
+            },
+            13,
+        ),
+        (
+            Instruction::JnzFpImm {
+                cond_off: M31::from(0),
+                offset: M31::from(0),
+            },
+            14,
+        ),
+        (
+            Instruction::U32StoreAddFpFp {
+                src0_off: M31::from(0),
+                src1_off: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            15,
+        ),
+        (
+            Instruction::U32StoreSubFpFp {
+                src0_off: M31::from(0),
+                src1_off: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            16,
+        ),
+        (
+            Instruction::U32StoreMulFpFp {
+                src0_off: M31::from(0),
+                src1_off: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            17,
+        ),
+        (
+            Instruction::U32StoreDivFpFp {
+                src0_off: M31::from(0),
+                src1_off: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            18,
+        ),
+        (
+            Instruction::U32StoreAddFpImm {
+                src_off: M31::from(0),
+                imm_hi: M31::from(0),
+                imm_lo: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            19,
+        ),
+        (
+            Instruction::U32StoreSubFpImm {
+                src_off: M31::from(0),
+                imm_hi: M31::from(0),
+                imm_lo: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            20,
+        ),
+        (
+            Instruction::U32StoreMulFpImm {
+                src_off: M31::from(0),
+                imm_hi: M31::from(0),
+                imm_lo: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            21,
+        ),
+        (
+            Instruction::U32StoreDivFpImm {
+                src_off: M31::from(0),
+                imm_hi: M31::from(0),
+                imm_lo: M31::from(0),
+                dst_off: M31::from(0),
+            },
+            22,
+        ),
+    ];
 
-    assert_eq!(
-        Instruction::StoreSubFpFp {
-            src0_off: M31::from(0),
-            src1_off: M31::from(0),
-            dst_off: M31::from(0)
-        }
-        .opcode_value(),
-        1
-    );
-    assert_eq!(
-        Instruction::StoreMulFpFp {
-            src0_off: M31::from(0),
-            src1_off: M31::from(0),
-            dst_off: M31::from(0)
-        }
-        .opcode_value(),
-        2
-    );
-    assert_eq!(
-        Instruction::StoreDivFpFp {
-            src0_off: M31::from(0),
-            src1_off: M31::from(0),
-            dst_off: M31::from(0)
-        }
-        .opcode_value(),
-        3
-    );
-    assert_eq!(
-        Instruction::StoreAddFpImm {
-            src_off: M31::from(0),
-            imm: M31::from(0),
-            dst_off: M31::from(0)
-        }
-        .opcode_value(),
-        4
-    );
-    assert_eq!(
-        Instruction::StoreSubFpImm {
-            src_off: M31::from(0),
-            imm: M31::from(0),
-            dst_off: M31::from(0)
-        }
-        .opcode_value(),
-        5
-    );
-    assert_eq!(
-        Instruction::StoreMulFpImm {
-            src_off: M31::from(0),
-            imm: M31::from(0),
-            dst_off: M31::from(0)
-        }
-        .opcode_value(),
-        6
-    );
-    assert_eq!(
-        Instruction::StoreDivFpImm {
-            src_off: M31::from(0),
-            imm: M31::from(0),
-            dst_off: M31::from(0)
-        }
-        .opcode_value(),
-        7
-    );
-    assert_eq!(
-        Instruction::StoreDoubleDerefFp {
-            base_off: M31::from(0),
-            offset: M31::from(0),
-            dst_off: M31::from(0)
-        }
-        .opcode_value(),
-        8
-    );
-    assert_eq!(
-        Instruction::StoreImm {
-            imm: M31::from(0),
-            dst_off: M31::from(0)
-        }
-        .opcode_value(),
-        9
-    );
-    assert_eq!(
-        Instruction::CallAbsImm {
-            frame_off: M31::from(0),
-            target: M31::from(0)
-        }
-        .opcode_value(),
-        10
-    );
-    assert_eq!(Instruction::Ret {}.opcode_value(), 11);
-    assert_eq!(
-        Instruction::JmpAbsImm {
-            target: M31::from(0)
-        }
-        .opcode_value(),
-        12
-    );
-    assert_eq!(
-        Instruction::JmpRelImm {
-            offset: M31::from(0)
-        }
-        .opcode_value(),
-        13
-    );
-    assert_eq!(
-        Instruction::JnzFpImm {
-            cond_off: M31::from(0),
-            offset: M31::from(0)
-        }
-        .opcode_value(),
-        14
-    );
-    assert_eq!(
-        Instruction::U32StoreAddFpFp {
-            src0_off: M31::from(0),
-            src1_off: M31::from(0),
-            dst_off: M31::from(0)
-        }
-        .opcode_value(),
-        15
-    );
-    assert_eq!(
-        Instruction::U32StoreAddFpImm {
-            src_off: M31::from(0),
-            imm_hi: M31::from(0),
-            imm_lo: M31::from(0),
-            dst_off: M31::from(0)
-        }
-        .opcode_value(),
-        19
-    );
+    for (instruction, expected_opcode) in test_cases {
+        assert_eq!(instruction.opcode_value(), expected_opcode);
+    }
 }
 
 #[test]
@@ -318,79 +359,250 @@ fn test_operands() {
 
 #[test]
 fn test_try_from_smallvec() {
-    // Test Ret instruction
-    let values: SmallVec<[M31; INSTRUCTION_MAX_SIZE]> = smallvec![M31::from(11)];
-    let instruction = Instruction::try_from(values).unwrap();
-    assert!(matches!(instruction, Instruction::Ret {}));
-
-    // Test StoreImm instruction
-    let values: SmallVec<[M31; INSTRUCTION_MAX_SIZE]> =
-        smallvec![M31::from(9), M31::from(42), M31::from(3)];
-    let instruction = Instruction::try_from(values).unwrap();
-    match instruction {
-        Instruction::StoreImm { imm, dst_off } => {
-            assert_eq!(imm, M31::from(42));
-            assert_eq!(dst_off, M31::from(3));
-        }
-        _ => panic!("Wrong instruction type"),
-    }
-
-    // Test StoreAddFpFp instruction
-    let values: SmallVec<[M31; INSTRUCTION_MAX_SIZE]> =
-        smallvec![M31::from(0), M31::from(1), M31::from(2), M31::from(3)];
-    let instruction = Instruction::try_from(values).unwrap();
-    match instruction {
-        Instruction::StoreAddFpFp {
-            src0_off,
-            src1_off,
-            dst_off,
-        } => {
-            assert_eq!(src0_off, M31::from(1));
-            assert_eq!(src1_off, M31::from(2));
-            assert_eq!(dst_off, M31::from(3));
-        }
-        _ => panic!("Wrong instruction type"),
-    }
-
-    // Test U32StoreAddFpFp instruction
-    let values: SmallVec<[M31; INSTRUCTION_MAX_SIZE]> =
-        smallvec![M31::from(15), M31::from(1), M31::from(2), M31::from(3),];
-    let instruction = Instruction::try_from(values).unwrap();
-    match instruction {
-        Instruction::U32StoreAddFpFp {
-            src0_off,
-            src1_off,
-            dst_off,
-        } => {
-            assert_eq!(src0_off, M31::from(1));
-            assert_eq!(src1_off, M31::from(2));
-            assert_eq!(dst_off, M31::from(3));
-        }
-        _ => panic!("Wrong instruction type"),
-    }
-
-    // Test U32StoreAddFpImm instruction
-    let values: SmallVec<[M31; INSTRUCTION_MAX_SIZE]> = smallvec![
-        M31::from(19),
-        M31::from(1),
-        M31::from(0x1234),
-        M31::from(0x5678),
-        M31::from(4),
+    // Test cases: (smallvec_values, expected_instruction, description)
+    let test_cases: Vec<(SmallVec<[M31; INSTRUCTION_MAX_SIZE]>, Instruction, &str)> = vec![
+        // Basic instructions
+        (
+            smallvec![M31::from(11)],
+            Instruction::Ret {},
+            "Ret instruction",
+        ),
+        (
+            smallvec![M31::from(9), M31::from(42), M31::from(3)],
+            Instruction::StoreImm {
+                imm: M31::from(42),
+                dst_off: M31::from(3),
+            },
+            "StoreImm instruction",
+        ),
+        // Felt arithmetic operations
+        (
+            smallvec![M31::from(0), M31::from(1), M31::from(2), M31::from(3)],
+            Instruction::StoreAddFpFp {
+                src0_off: M31::from(1),
+                src1_off: M31::from(2),
+                dst_off: M31::from(3),
+            },
+            "StoreAddFpFp instruction",
+        ),
+        (
+            smallvec![M31::from(1), M31::from(4), M31::from(5), M31::from(6)],
+            Instruction::StoreSubFpFp {
+                src0_off: M31::from(4),
+                src1_off: M31::from(5),
+                dst_off: M31::from(6),
+            },
+            "StoreSubFpFp instruction",
+        ),
+        (
+            smallvec![M31::from(2), M31::from(7), M31::from(8), M31::from(9)],
+            Instruction::StoreMulFpFp {
+                src0_off: M31::from(7),
+                src1_off: M31::from(8),
+                dst_off: M31::from(9),
+            },
+            "StoreMulFpFp instruction",
+        ),
+        (
+            smallvec![M31::from(3), M31::from(10), M31::from(11), M31::from(12)],
+            Instruction::StoreDivFpFp {
+                src0_off: M31::from(10),
+                src1_off: M31::from(11),
+                dst_off: M31::from(12),
+            },
+            "StoreDivFpFp instruction",
+        ),
+        // Felt arithmetic with immediate
+        (
+            smallvec![M31::from(4), M31::from(1), M31::from(100), M31::from(3)],
+            Instruction::StoreAddFpImm {
+                src_off: M31::from(1),
+                imm: M31::from(100),
+                dst_off: M31::from(3),
+            },
+            "StoreAddFpImm instruction",
+        ),
+        (
+            smallvec![M31::from(5), M31::from(2), M31::from(200), M31::from(4)],
+            Instruction::StoreSubFpImm {
+                src_off: M31::from(2),
+                imm: M31::from(200),
+                dst_off: M31::from(4),
+            },
+            "StoreSubFpImm instruction",
+        ),
+        (
+            smallvec![M31::from(6), M31::from(3), M31::from(300), M31::from(5)],
+            Instruction::StoreMulFpImm {
+                src_off: M31::from(3),
+                imm: M31::from(300),
+                dst_off: M31::from(5),
+            },
+            "StoreMulFpImm instruction",
+        ),
+        (
+            smallvec![M31::from(7), M31::from(4), M31::from(400), M31::from(6)],
+            Instruction::StoreDivFpImm {
+                src_off: M31::from(4),
+                imm: M31::from(400),
+                dst_off: M31::from(6),
+            },
+            "StoreDivFpImm instruction",
+        ),
+        // U32 arithmetic operations
+        (
+            smallvec![M31::from(15), M31::from(1), M31::from(2), M31::from(3)],
+            Instruction::U32StoreAddFpFp {
+                src0_off: M31::from(1),
+                src1_off: M31::from(2),
+                dst_off: M31::from(3),
+            },
+            "U32StoreAddFpFp instruction",
+        ),
+        (
+            smallvec![M31::from(16), M31::from(4), M31::from(5), M31::from(6)],
+            Instruction::U32StoreSubFpFp {
+                src0_off: M31::from(4),
+                src1_off: M31::from(5),
+                dst_off: M31::from(6),
+            },
+            "U32StoreSubFpFp instruction",
+        ),
+        (
+            smallvec![M31::from(17), M31::from(7), M31::from(8), M31::from(9)],
+            Instruction::U32StoreMulFpFp {
+                src0_off: M31::from(7),
+                src1_off: M31::from(8),
+                dst_off: M31::from(9),
+            },
+            "U32StoreMulFpFp instruction",
+        ),
+        (
+            smallvec![M31::from(18), M31::from(10), M31::from(11), M31::from(12)],
+            Instruction::U32StoreDivFpFp {
+                src0_off: M31::from(10),
+                src1_off: M31::from(11),
+                dst_off: M31::from(12),
+            },
+            "U32StoreDivFpFp instruction",
+        ),
+        // U32 arithmetic with immediate
+        (
+            smallvec![
+                M31::from(19),
+                M31::from(1),
+                M31::from(0x1234),
+                M31::from(0x5678),
+                M31::from(4)
+            ],
+            Instruction::U32StoreAddFpImm {
+                src_off: M31::from(1),
+                imm_hi: M31::from(0x1234),
+                imm_lo: M31::from(0x5678),
+                dst_off: M31::from(4),
+            },
+            "U32StoreAddFpImm instruction",
+        ),
+        (
+            smallvec![
+                M31::from(20),
+                M31::from(2),
+                M31::from(0xabcd),
+                M31::from(0xef01),
+                M31::from(5)
+            ],
+            Instruction::U32StoreSubFpImm {
+                src_off: M31::from(2),
+                imm_hi: M31::from(0xabcd),
+                imm_lo: M31::from(0xef01),
+                dst_off: M31::from(5),
+            },
+            "U32StoreSubFpImm instruction",
+        ),
+        (
+            smallvec![
+                M31::from(21),
+                M31::from(3),
+                M31::from(0x2345),
+                M31::from(0x6789),
+                M31::from(6)
+            ],
+            Instruction::U32StoreMulFpImm {
+                src_off: M31::from(3),
+                imm_hi: M31::from(0x2345),
+                imm_lo: M31::from(0x6789),
+                dst_off: M31::from(6),
+            },
+            "U32StoreMulFpImm instruction",
+        ),
+        (
+            smallvec![
+                M31::from(22),
+                M31::from(4),
+                M31::from(0xcdef),
+                M31::from(0x0123),
+                M31::from(7)
+            ],
+            Instruction::U32StoreDivFpImm {
+                src_off: M31::from(4),
+                imm_hi: M31::from(0xcdef),
+                imm_lo: M31::from(0x0123),
+                dst_off: M31::from(7),
+            },
+            "U32StoreDivFpImm instruction",
+        ),
+        // Memory and control flow operations
+        (
+            smallvec![M31::from(8), M31::from(9), M31::from(10), M31::from(11)],
+            Instruction::StoreDoubleDerefFp {
+                base_off: M31::from(9),
+                offset: M31::from(10),
+                dst_off: M31::from(11),
+            },
+            "StoreDoubleDerefFp instruction",
+        ),
+        (
+            smallvec![M31::from(10), M31::from(19), M31::from(1000)],
+            Instruction::CallAbsImm {
+                frame_off: M31::from(19),
+                target: M31::from(1000),
+            },
+            "CallAbsImm instruction",
+        ),
+        (
+            smallvec![M31::from(12), M31::from(2000)],
+            Instruction::JmpAbsImm {
+                target: M31::from(2000),
+            },
+            "JmpAbsImm instruction",
+        ),
+        (
+            smallvec![M31::from(13), M31::from(50)],
+            Instruction::JmpRelImm {
+                offset: M31::from(50),
+            },
+            "JmpRelImm instruction",
+        ),
+        (
+            smallvec![M31::from(14), M31::from(21), M31::from(60)],
+            Instruction::JnzFpImm {
+                cond_off: M31::from(21),
+                offset: M31::from(60),
+            },
+            "JnzFpImm instruction",
+        ),
     ];
-    let instruction = Instruction::try_from(values).unwrap();
-    match instruction {
-        Instruction::U32StoreAddFpImm {
-            src_off,
-            imm_hi,
-            imm_lo,
-            dst_off,
-        } => {
-            assert_eq!(src_off, M31::from(1));
-            assert_eq!(imm_hi, M31::from(0x1234));
-            assert_eq!(imm_lo, M31::from(0x5678));
-            assert_eq!(dst_off, M31::from(4));
-        }
-        _ => panic!("Wrong instruction type"),
+
+    assert_eq!(test_cases.len(), MAX_OPCODE as usize + 1);
+
+    for (values, expected_instruction, description) in test_cases {
+        let instruction = Instruction::try_from(values)
+            .unwrap_or_else(|e| panic!("Failed to parse {}: {:?}", description, e));
+        assert_eq!(
+            instruction, expected_instruction,
+            "Mismatch for {}",
+            description
+        );
     }
 }
 

--- a/crates/common/tests/instruction_tests.rs
+++ b/crates/common/tests/instruction_tests.rs
@@ -182,10 +182,9 @@ fn test_opcode_values() {
         14
     );
     assert_eq!(
-        Instruction::U32StoreAddFpImm {
-            src_off: M31::from(0),
-            imm_hi: M31::from(0),
-            imm_lo: M31::from(0),
+        Instruction::U32StoreAddFpFp {
+            src0_off: M31::from(0),
+            src1_off: M31::from(0),
             dst_off: M31::from(0)
         }
         .opcode_value(),
@@ -199,7 +198,7 @@ fn test_opcode_values() {
             dst_off: M31::from(0)
         }
         .opcode_value(),
-        15
+        19
     );
 }
 
@@ -353,9 +352,26 @@ fn test_try_from_smallvec() {
         _ => panic!("Wrong instruction type"),
     }
 
+    // Test U32StoreAddFpFp instruction
+    let values: SmallVec<[M31; INSTRUCTION_MAX_SIZE]> =
+        smallvec![M31::from(15), M31::from(1), M31::from(2), M31::from(3),];
+    let instruction = Instruction::try_from(values).unwrap();
+    match instruction {
+        Instruction::U32StoreAddFpFp {
+            src0_off,
+            src1_off,
+            dst_off,
+        } => {
+            assert_eq!(src0_off, M31::from(1));
+            assert_eq!(src1_off, M31::from(2));
+            assert_eq!(dst_off, M31::from(3));
+        }
+        _ => panic!("Wrong instruction type"),
+    }
+
     // Test U32StoreAddFpImm instruction
     let values: SmallVec<[M31; INSTRUCTION_MAX_SIZE]> = smallvec![
-        M31::from(15),
+        M31::from(19),
         M31::from(1),
         M31::from(0x1234),
         M31::from(0x5678),
@@ -483,7 +499,7 @@ fn test_to_qm31_vec() {
     assert_eq!(qm31_vec.len(), 2);
 
     let m31_array = qm31_vec[0].to_m31_array();
-    assert_eq!(m31_array[0], M31::from(15)); // opcode
+    assert_eq!(m31_array[0], M31::from(19)); // opcode
     assert_eq!(m31_array[1], M31::from(1)); // src_off
     assert_eq!(m31_array[2], M31::from(0x1234)); // imm_hi
     assert_eq!(m31_array[3], M31::from(0x5678)); // imm_lo

--- a/crates/runner/src/memory/mod.rs
+++ b/crates/runner/src/memory/mod.rs
@@ -539,10 +539,10 @@ mod tests {
         let mut memory = Memory::default();
         let start_addr = M31(0);
 
-        // Insert a U32StoreAddFpImm instruction (opcode 15, size 5 M31s = 2 QM31s)
+        // Insert a U32StoreAddFpImm instruction (opcode 19, size 5 M31s = 2 QM31s)
         // Fields: src_off=1, imm_hi=2, imm_lo=3, dst_off=4
         let values = vec![
-            QM31::from_m31_array([15, 1, 2, 3].map(Into::into)), // First 4 M31s
+            QM31::from_m31_array([19, 1, 2, 3].map(Into::into)), // First 4 M31s
             QM31::from_m31_array([4, 0, 0, 0].map(Into::into)),  // Last M31 + padding
         ];
 
@@ -553,7 +553,7 @@ mod tests {
 
         // Get U32StoreAddFpImm instruction (5 M31s, spans 2 QM31s)
         let inst = memory.get_instruction(start_addr).unwrap();
-        assert_eq!(inst.as_slice(), &[M31(15), M31(1), M31(2), M31(3), M31(4)]);
+        assert_eq!(inst.as_slice(), &[M31(19), M31(1), M31(2), M31(3), M31(4)]);
 
         // Verify trace contains both QM31 accesses
         assert_eq!(memory.trace.borrow().len(), 2);

--- a/crates/runner/src/vm/instructions/mod.rs
+++ b/crates/runner/src/vm/instructions/mod.rs
@@ -172,52 +172,10 @@ pub fn opcode_to_instruction_fn(op: M31) -> Result<InstructionFn, InstructionErr
 
 #[cfg(test)]
 mod tests {
-    use cairo_m_common::Instruction;
-    use cairo_m_common::instruction::{
-        INSTRUCTION_MAX_SIZE, InstructionError, MAX_OPCODE, RET, STORE_ADD_FP_IMM,
-        U32_STORE_ADD_FP_IMM,
-    };
-    use smallvec::SmallVec;
+    use cairo_m_common::instruction::{InstructionError, MAX_OPCODE};
     use stwo_prover::core::fields::m31::M31;
 
     use super::opcode_to_instruction_fn;
-
-    #[test]
-    fn test_store_add_fp_imm_from_smallvec() {
-        // Test StoreAddFpImm (4 M31s)
-        let instruction_m31s =
-            SmallVec::<[M31; INSTRUCTION_MAX_SIZE]>::from_slice(&[M31(4), M31(2), M31(3), M31(4)]);
-        let instruction: Instruction = instruction_m31s.try_into().unwrap();
-        assert_eq!(instruction.opcode_value(), STORE_ADD_FP_IMM);
-        assert_eq!(instruction.operands(), vec![M31(2), M31(3), M31(4)]);
-    }
-
-    #[test]
-    fn test_ret_from_smallvec() {
-        // Test Ret (1 M31)
-        let ret_m31s = SmallVec::<[M31; INSTRUCTION_MAX_SIZE]>::from_slice(&[M31(11)]);
-        let ret_instruction: Instruction = ret_m31s.try_into().unwrap();
-        assert_eq!(ret_instruction.opcode_value(), RET);
-        assert_eq!(ret_instruction.operands(), vec![]);
-    }
-
-    #[test]
-    fn test_u32_store_add_fp_imm_from_smallvec() {
-        // Test U32StoreAddFpImm (5 M31s)
-        let u32_m31s = SmallVec::<[M31; INSTRUCTION_MAX_SIZE]>::from_slice(&[
-            M31(19),
-            M31(1),
-            M31(2),
-            M31(3),
-            M31(4),
-        ]);
-        let u32_instruction: Instruction = u32_m31s.try_into().unwrap();
-        assert_eq!(u32_instruction.opcode_value(), U32_STORE_ADD_FP_IMM);
-        assert_eq!(
-            u32_instruction.operands(),
-            vec![M31(1), M31(2), M31(3), M31(4)]
-        );
-    }
 
     #[test]
     fn test_opcode_to_instruction_fn_invalid_opcode() {

--- a/crates/runner/src/vm/instructions/mod.rs
+++ b/crates/runner/src/vm/instructions/mod.rs
@@ -157,7 +157,14 @@ pub fn opcode_to_instruction_fn(op: M31) -> Result<InstructionFn, InstructionErr
         JMP_ABS_IMM => jmp_abs_imm,
         JMP_REL_IMM => jmp_rel_imm,
         JNZ_FP_IMM => jnz_fp_imm,
+        U32_STORE_ADD_FP_FP => u32_store_add_fp_fp,
+        U32_STORE_SUB_FP_FP => u32_store_sub_fp_fp,
+        U32_STORE_MUL_FP_FP => u32_store_mul_fp_fp,
+        U32_STORE_DIV_FP_FP => u32_store_div_fp_fp,
         U32_STORE_ADD_FP_IMM => u32_store_add_fp_imm,
+        U32_STORE_SUB_FP_IMM => u32_store_sub_fp_imm,
+        U32_STORE_MUL_FP_IMM => u32_store_mul_fp_imm,
+        U32_STORE_DIV_FP_IMM => u32_store_div_fp_imm,
         _ => return Err(InstructionError::InvalidOpcode(op)),
     };
     Ok(f)
@@ -174,7 +181,7 @@ mod tests {
 
     use super::opcode_to_instruction_fn;
 
-    const LAST_VALID_OPCODE_ID: u32 = 15;
+    const LAST_VALID_OPCODE_ID: u32 = 22;
 
     #[test]
     fn test_store_add_fp_imm_from_smallvec() {
@@ -199,7 +206,7 @@ mod tests {
     fn test_u32_store_add_fp_imm_from_smallvec() {
         // Test U32StoreAddFpImm (5 M31s)
         let u32_m31s = SmallVec::<[M31; INSTRUCTION_MAX_SIZE]>::from_slice(&[
-            M31(15),
+            M31(19),
             M31(1),
             M31(2),
             M31(3),

--- a/crates/runner/src/vm/instructions/mod.rs
+++ b/crates/runner/src/vm/instructions/mod.rs
@@ -174,14 +174,13 @@ pub fn opcode_to_instruction_fn(op: M31) -> Result<InstructionFn, InstructionErr
 mod tests {
     use cairo_m_common::Instruction;
     use cairo_m_common::instruction::{
-        INSTRUCTION_MAX_SIZE, InstructionError, RET, STORE_ADD_FP_IMM, U32_STORE_ADD_FP_IMM,
+        INSTRUCTION_MAX_SIZE, InstructionError, MAX_OPCODE, RET, STORE_ADD_FP_IMM,
+        U32_STORE_ADD_FP_IMM,
     };
     use smallvec::SmallVec;
     use stwo_prover::core::fields::m31::M31;
 
     use super::opcode_to_instruction_fn;
-
-    const LAST_VALID_OPCODE_ID: u32 = 22;
 
     #[test]
     fn test_store_add_fp_imm_from_smallvec() {
@@ -229,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_opcode_to_instruction_fn_valid_opcodes() {
-        for opcode_value in 0..=LAST_VALID_OPCODE_ID {
+        for opcode_value in 0..=MAX_OPCODE {
             let opcode = M31(opcode_value);
             let result = opcode_to_instruction_fn(opcode);
             assert!(result.is_ok(), "Opcode {opcode_value} should be valid");

--- a/crates/runner/src/vm/instructions/store.rs
+++ b/crates/runner/src/vm/instructions/store.rs
@@ -232,6 +232,69 @@ pub fn u32_store_add_fp_imm(
     Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 
+/// TODO: Implement U32 store add fp fp instruction
+pub fn u32_store_add_fp_fp(
+    _memory: &mut Memory,
+    _state: State,
+    _instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    todo!("u32_store_add_fp_fp not implemented")
+}
+
+/// TODO: Implement U32 store sub fp fp instruction
+pub fn u32_store_sub_fp_fp(
+    _memory: &mut Memory,
+    _state: State,
+    _instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    todo!("u32_store_sub_fp_fp not implemented")
+}
+
+/// TODO: Implement U32 store mul fp fp instruction
+pub fn u32_store_mul_fp_fp(
+    _memory: &mut Memory,
+    _state: State,
+    _instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    todo!("u32_store_mul_fp_fp not implemented")
+}
+
+/// TODO: Implement U32 store div fp fp instruction
+pub fn u32_store_div_fp_fp(
+    _memory: &mut Memory,
+    _state: State,
+    _instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    todo!("u32_store_div_fp_fp not implemented")
+}
+
+/// TODO: Implement U32 store sub fp imm instruction
+pub fn u32_store_sub_fp_imm(
+    _memory: &mut Memory,
+    _state: State,
+    _instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    todo!("u32_store_sub_fp_imm not implemented")
+}
+
+/// TODO: Implement U32 store mul fp imm instruction
+pub fn u32_store_mul_fp_imm(
+    _memory: &mut Memory,
+    _state: State,
+    _instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    todo!("u32_store_mul_fp_imm not implemented")
+}
+
+/// TODO: Implement U32 store div fp imm instruction
+pub fn u32_store_div_fp_imm(
+    _memory: &mut Memory,
+    _state: State,
+    _instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    todo!("u32_store_div_fp_imm not implemented")
+}
+
 #[cfg(test)]
 #[path = "./store_tests.rs"]
 mod store_tests;

--- a/crates/runner/src/vm/instructions/store.rs
+++ b/crates/runner/src/vm/instructions/store.rs
@@ -181,6 +181,42 @@ pub fn store_div_fp_imm(
     Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 
+/// TODO: Implement U32 store add fp fp instruction
+pub fn u32_store_add_fp_fp(
+    _memory: &mut Memory,
+    _state: State,
+    _instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    todo!("u32_store_add_fp_fp not implemented")
+}
+
+/// TODO: Implement U32 store sub fp fp instruction
+pub fn u32_store_sub_fp_fp(
+    _memory: &mut Memory,
+    _state: State,
+    _instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    todo!("u32_store_sub_fp_fp not implemented")
+}
+
+/// TODO: Implement U32 store mul fp fp instruction
+pub fn u32_store_mul_fp_fp(
+    _memory: &mut Memory,
+    _state: State,
+    _instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    todo!("u32_store_mul_fp_fp not implemented")
+}
+
+/// TODO: Implement U32 store div fp fp instruction
+pub fn u32_store_div_fp_fp(
+    _memory: &mut Memory,
+    _state: State,
+    _instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    todo!("u32_store_div_fp_fp not implemented")
+}
+
 /// U32 store add fp imm instruction.
 ///
 /// u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src_off], [fp + src_off + 1]) + u32(imm_lo, imm_hi)
@@ -230,42 +266,6 @@ pub fn u32_store_add_fp_imm(
     memory.insert(state.fp + dst_off + M31::one(), res_limb_1.into())?;
 
     Ok(state.advance_by(instruction.size_in_qm31s()))
-}
-
-/// TODO: Implement U32 store add fp fp instruction
-pub fn u32_store_add_fp_fp(
-    _memory: &mut Memory,
-    _state: State,
-    _instruction: &Instruction,
-) -> Result<State, InstructionExecutionError> {
-    todo!("u32_store_add_fp_fp not implemented")
-}
-
-/// TODO: Implement U32 store sub fp fp instruction
-pub fn u32_store_sub_fp_fp(
-    _memory: &mut Memory,
-    _state: State,
-    _instruction: &Instruction,
-) -> Result<State, InstructionExecutionError> {
-    todo!("u32_store_sub_fp_fp not implemented")
-}
-
-/// TODO: Implement U32 store mul fp fp instruction
-pub fn u32_store_mul_fp_fp(
-    _memory: &mut Memory,
-    _state: State,
-    _instruction: &Instruction,
-) -> Result<State, InstructionExecutionError> {
-    todo!("u32_store_mul_fp_fp not implemented")
-}
-
-/// TODO: Implement U32 store div fp fp instruction
-pub fn u32_store_div_fp_fp(
-    _memory: &mut Memory,
-    _state: State,
-    _instruction: &Instruction,
-) -> Result<State, InstructionExecutionError> {
-    todo!("u32_store_div_fp_fp not implemented")
 }
 
 /// TODO: Implement U32 store sub fp imm instruction


### PR DESCRIPTION
## Summary
- Add u32 arithmetic opcodes for FP-FP operations (opcodes 15-18)
- Add u32 arithmetic opcodes for FP-IMM operations (opcodes 19-22)
- Update tests to reflect new opcode values

## Test plan
- [x] Run `cargo build` to ensure compilation
- [x] Run `cargo test -p cairo-m-common` to verify all tests pass
- [x] Run `trunk fmt` to ensure code formatting

Resolves: CORE-1095

🤖 Generated with Claude Code