### PR TITLE
feat(runner): implement all U32 arithmetic operations in VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 tmp
 tmp.out
 .worktrees
+.repo_ignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -270,6 +270,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,7 +359,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "pairing",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -617,7 +632,7 @@ dependencies = [
  "num-traits",
  "paste",
  "peak_alloc",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "smallvec",
@@ -642,6 +657,7 @@ dependencies = [
  "clap",
  "criterion",
  "num-traits",
+ "proptest",
  "smallvec",
  "sonic-rs 0.5.1",
  "stwo-prover",
@@ -1090,7 +1106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1101,7 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1304,7 +1320,7 @@ checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff 0.12.1",
  "memuse",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1315,7 +1331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.1",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1348,7 +1364,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "pasta_curves 0.4.1",
- "rand_core",
+ "rand_core 0.6.4",
  "rayon",
 ]
 
@@ -1686,7 +1702,7 @@ dependencies = [
  "bls12_381",
  "ff 0.12.1",
  "group 0.12.1",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2042,7 +2058,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
  "subtle",
 ]
@@ -2057,7 +2073,7 @@ dependencies = [
  "ff 0.13.1",
  "group 0.13.0",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
  "subtle",
 ]
@@ -2184,6 +2200,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.9.1",
+ "lazy_static",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax 0.8.5",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,6 +2247,12 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2249,8 +2291,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2260,7 +2312,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2270,6 +2332,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2484,6 +2564,18 @@ name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2878,7 +2970,7 @@ version = "0.1.1"
 dependencies = [
  "itertools 0.12.1",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "stwo-prover",
  "tracing",
@@ -2897,7 +2989,7 @@ dependencies = [
  "indexmap",
  "itertools 0.12.1",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "starknet-crypto",
@@ -3258,6 +3350,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3320,6 +3418,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -3889,7 +3996,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "pasta_curves 0.5.1",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2",
  "sha3",

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -17,6 +17,7 @@ cairo-m-common.workspace = true
 cairo-m-compiler.workspace = true
 clap.workspace = true
 num-traits.workspace = true
+proptest = "1.7.0"
 smallvec.workspace = true
 sonic-rs.workspace = true
 stwo-prover.workspace = true

--- a/crates/runner/src/memory/mod.rs
+++ b/crates/runner/src/memory/mod.rs
@@ -358,7 +358,7 @@ impl Memory {
     }
 
     /// Read a 32-bit value (little-endian) stored as two 16-bit limbs at `addr`.
-    pub fn read_u32(&self, addr: M31) -> Result<u32, MemoryError> {
+    pub fn get_u32(&self, addr: M31) -> Result<u32, MemoryError> {
         let limb_lo = self.get_data(addr)?;
         let limb_hi = self.get_data(addr + M31::one())?;
 
@@ -373,7 +373,7 @@ impl Memory {
     }
 
     /// Write `value` as two 16-bit limbs (little-endian) at `addr`.
-    pub fn write_u32(&mut self, addr: M31, value: u32) -> Result<(), MemoryError> {
+    pub fn insert_u32(&mut self, addr: M31, value: u32) -> Result<(), MemoryError> {
         let limb_lo = M31::from(value & U32_LIMB_MASK);
         let limb_hi = M31::from((value >> U32_LIMB_BITS) & U32_LIMB_MASK);
 

--- a/crates/runner/src/memory/mod.rs
+++ b/crates/runner/src/memory/mod.rs
@@ -11,13 +11,20 @@ use thiserror::Error;
 
 /// The number of M31 values that make up a single QM31.
 const M31S_IN_QM31: usize = 4;
+
 /// The maximum number of bits for a memory address, set to 30.
 /// This limits the memory size to 2^30 elements.
-/// TODO: check with Starkware
+// TODO: check with Starkware
 const MAX_MEMORY_SIZE_BITS: u8 = 30;
 
+/// Number of bits in a U32 limb (16 bits per limb for 32-bit values)
+pub const U32_LIMB_BITS: u32 = 16;
+
+/// Mask for a U32 limb (0xFFFF)
+pub const U32_LIMB_MASK: u32 = (1 << U32_LIMB_BITS) - 1;
+
 /// Custom error types for memory operations.
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum MemoryError {
     #[error("Address {addr} is out of bounds. Maximum allowed address is {max_addr}")]
     AddressOutOfBounds { addr: M31, max_addr: u32 },
@@ -25,6 +32,12 @@ pub enum MemoryError {
     BaseFieldProjectionFailed { addr: M31, value: QM31 },
     #[error("Memory cell at address {addr} is not initialized")]
     UninitializedMemoryCell { addr: M31 },
+    #[error(
+        "U32 source limbs exceed 16-bit range: limb_lo={}, limb_hi={}",
+        limb_lo,
+        limb_hi
+    )]
+    U32LimbOutOfRange { limb_lo: u32, limb_hi: u32 },
 }
 
 /// Represents the Cairo M VM's memory, a flat, read-write address space.
@@ -342,6 +355,31 @@ impl Memory {
             })
             .flat_map(u32::to_le_bytes)
             .collect()
+    }
+
+    /// Read a 32-bit value (little-endian) stored as two 16-bit limbs at `addr`.
+    pub fn read_u32(&self, addr: M31) -> Result<u32, MemoryError> {
+        let limb_lo = self.get_data(addr)?;
+        let limb_hi = self.get_data(addr + M31::one())?;
+
+        if limb_lo.0 > U32_LIMB_MASK || limb_hi.0 > U32_LIMB_MASK {
+            return Err(MemoryError::U32LimbOutOfRange {
+                limb_lo: limb_lo.0,
+                limb_hi: limb_hi.0,
+            });
+        }
+
+        Ok((limb_hi.0 << U32_LIMB_BITS) | limb_lo.0)
+    }
+
+    /// Write `value` as two 16-bit limbs (little-endian) at `addr`.
+    pub fn write_u32(&mut self, addr: M31, value: u32) -> Result<(), MemoryError> {
+        let limb_lo = M31::from(value & U32_LIMB_MASK);
+        let limb_hi = M31::from((value >> U32_LIMB_BITS) & U32_LIMB_MASK);
+
+        self.insert(addr, limb_lo.into())?;
+        self.insert(addr + M31::one(), limb_hi.into())?;
+        Ok(())
     }
 }
 

--- a/crates/runner/src/vm/instructions/mod.rs
+++ b/crates/runner/src/vm/instructions/mod.rs
@@ -110,7 +110,7 @@ macro_rules! extract_as {
 }
 
 /// Error type for instruction execution
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum InstructionExecutionError {
     #[error("Memory error: {0}")]
     Memory(#[from] MemoryError),

--- a/crates/runner/src/vm/instructions/store.rs
+++ b/crates/runner/src/vm/instructions/store.rs
@@ -3,7 +3,6 @@
 //! STORE instructions are used to store values in the memory.
 
 use cairo_m_common::{Instruction, State};
-use num_traits::One;
 use stwo_prover::core::fields::m31::M31;
 
 use super::InstructionExecutionError;

--- a/crates/runner/src/vm/instructions/store.rs
+++ b/crates/runner/src/vm/instructions/store.rs
@@ -181,40 +181,214 @@ pub fn store_div_fp_imm(
     Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 
-/// TODO: Implement U32 store add fp fp instruction
+/// U32 store add fp fp instruction.
+///
+/// u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src0_off], [fp + src0_off + 1]) + u32([fp + src1_off], [fp + src1_off + 1])
+/// This instruction supports 32-bit values stored as two 16-bit M31 limbs
 pub fn u32_store_add_fp_fp(
-    _memory: &mut Memory,
-    _state: State,
-    _instruction: &Instruction,
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
 ) -> Result<State, InstructionExecutionError> {
-    todo!("u32_store_add_fp_fp not implemented")
+    let (src0_off, src1_off, dst_off) =
+        extract_as!(instruction, U32StoreAddFpFp, (src0_off, src1_off, dst_off));
+
+    // Read first 32-bit value from memory as two limbs
+    let src0_limb_0 = memory.get_data(state.fp + src0_off)?;
+    let src0_limb_1 = memory.get_data(state.fp + src0_off + M31::from(1))?;
+
+    // Validate that source limbs are within 16-bit range
+    if src0_limb_0.0 > U32_LIMB_MASK || src0_limb_1.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 source 0 limbs exceed 16-bit range: limb_0={}, limb_1={}",
+            src0_limb_0.0, src0_limb_1.0
+        )));
+    }
+    let src0_value = (src0_limb_1.0 << U32_LIMB_BITS) | src0_limb_0.0;
+
+    // Read second 32-bit value from memory as two limbs
+    let src1_limb_0 = memory.get_data(state.fp + src1_off)?;
+    let src1_limb_1 = memory.get_data(state.fp + src1_off + M31::from(1))?;
+
+    // Validate that source limbs are within 16-bit range
+    if src1_limb_0.0 > U32_LIMB_MASK || src1_limb_1.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 source 1 limbs exceed 16-bit range: limb_0={}, limb_1={}",
+            src1_limb_0.0, src1_limb_1.0
+        )));
+    }
+    let src1_value = (src1_limb_1.0 << U32_LIMB_BITS) | src1_limb_0.0;
+
+    // Perform 32-bit addition with wrapping
+    let result = src0_value.wrapping_add(src1_value);
+
+    // Store result as two 16-bit limbs
+    let res_limb_0 = M31::from(result & U32_LIMB_MASK);
+    let res_limb_1 = M31::from((result >> U32_LIMB_BITS) & U32_LIMB_MASK);
+
+    memory.insert(state.fp + dst_off, res_limb_0.into())?;
+    memory.insert(state.fp + dst_off + M31::one(), res_limb_1.into())?;
+
+    Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 
-/// TODO: Implement U32 store sub fp fp instruction
+/// U32 store sub fp fp instruction.
+///
+/// u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src0_off], [fp + src0_off + 1]) - u32([fp + src1_off], [fp + src1_off + 1])
+/// This instruction supports 32-bit values stored as two 16-bit M31 limbs
 pub fn u32_store_sub_fp_fp(
-    _memory: &mut Memory,
-    _state: State,
-    _instruction: &Instruction,
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
 ) -> Result<State, InstructionExecutionError> {
-    todo!("u32_store_sub_fp_fp not implemented")
+    let (src0_off, src1_off, dst_off) =
+        extract_as!(instruction, U32StoreSubFpFp, (src0_off, src1_off, dst_off));
+
+    // Read first 32-bit value from memory as two limbs
+    let src0_limb_0 = memory.get_data(state.fp + src0_off)?;
+    let src0_limb_1 = memory.get_data(state.fp + src0_off + M31::from(1))?;
+
+    // Validate that source limbs are within 16-bit range
+    if src0_limb_0.0 > U32_LIMB_MASK || src0_limb_1.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 source 0 limbs exceed 16-bit range: limb_0={}, limb_1={}",
+            src0_limb_0.0, src0_limb_1.0
+        )));
+    }
+    let src0_value = (src0_limb_1.0 << U32_LIMB_BITS) | src0_limb_0.0;
+
+    // Read second 32-bit value from memory as two limbs
+    let src1_limb_0 = memory.get_data(state.fp + src1_off)?;
+    let src1_limb_1 = memory.get_data(state.fp + src1_off + M31::from(1))?;
+
+    // Validate that source limbs are within 16-bit range
+    if src1_limb_0.0 > U32_LIMB_MASK || src1_limb_1.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 source 1 limbs exceed 16-bit range: limb_0={}, limb_1={}",
+            src1_limb_0.0, src1_limb_1.0
+        )));
+    }
+    let src1_value = (src1_limb_1.0 << U32_LIMB_BITS) | src1_limb_0.0;
+
+    // Perform 32-bit subtraction with wrapping
+    let result = src0_value.wrapping_sub(src1_value);
+
+    // Store result as two 16-bit limbs
+    let res_limb_0 = M31::from(result & U32_LIMB_MASK);
+    let res_limb_1 = M31::from((result >> U32_LIMB_BITS) & U32_LIMB_MASK);
+
+    memory.insert(state.fp + dst_off, res_limb_0.into())?;
+    memory.insert(state.fp + dst_off + M31::one(), res_limb_1.into())?;
+
+    Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 
-/// TODO: Implement U32 store mul fp fp instruction
+/// U32 store mul fp fp instruction.
+///
+/// u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src0_off], [fp + src0_off + 1]) * u32([fp + src1_off], [fp + src1_off + 1])
+/// This instruction supports 32-bit values stored as two 16-bit M31 limbs
 pub fn u32_store_mul_fp_fp(
-    _memory: &mut Memory,
-    _state: State,
-    _instruction: &Instruction,
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
 ) -> Result<State, InstructionExecutionError> {
-    todo!("u32_store_mul_fp_fp not implemented")
+    let (src0_off, src1_off, dst_off) =
+        extract_as!(instruction, U32StoreMulFpFp, (src0_off, src1_off, dst_off));
+
+    // Read first 32-bit value from memory as two limbs
+    let src0_limb_0 = memory.get_data(state.fp + src0_off)?;
+    let src0_limb_1 = memory.get_data(state.fp + src0_off + M31::from(1))?;
+
+    // Validate that source limbs are within 16-bit range
+    if src0_limb_0.0 > U32_LIMB_MASK || src0_limb_1.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 source 0 limbs exceed 16-bit range: limb_0={}, limb_1={}",
+            src0_limb_0.0, src0_limb_1.0
+        )));
+    }
+    let src0_value = (src0_limb_1.0 << U32_LIMB_BITS) | src0_limb_0.0;
+
+    // Read second 32-bit value from memory as two limbs
+    let src1_limb_0 = memory.get_data(state.fp + src1_off)?;
+    let src1_limb_1 = memory.get_data(state.fp + src1_off + M31::from(1))?;
+
+    // Validate that source limbs are within 16-bit range
+    if src1_limb_0.0 > U32_LIMB_MASK || src1_limb_1.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 source 1 limbs exceed 16-bit range: limb_0={}, limb_1={}",
+            src1_limb_0.0, src1_limb_1.0
+        )));
+    }
+    let src1_value = (src1_limb_1.0 << U32_LIMB_BITS) | src1_limb_0.0;
+
+    // Perform 32-bit multiplication with wrapping
+    let result = src0_value.wrapping_mul(src1_value);
+
+    // Store result as two 16-bit limbs
+    let res_limb_0 = M31::from(result & U32_LIMB_MASK);
+    let res_limb_1 = M31::from((result >> U32_LIMB_BITS) & U32_LIMB_MASK);
+
+    memory.insert(state.fp + dst_off, res_limb_0.into())?;
+    memory.insert(state.fp + dst_off + M31::one(), res_limb_1.into())?;
+
+    Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 
-/// TODO: Implement U32 store div fp fp instruction
+/// U32 store div fp fp instruction.
+///
+/// u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src0_off], [fp + src0_off + 1]) / u32([fp + src1_off], [fp + src1_off + 1])
+/// This instruction supports 32-bit values stored as two 16-bit M31 limbs
+/// Division by zero returns 0xFFFFFFFF (all bits set) following RISC-V behavior
 pub fn u32_store_div_fp_fp(
-    _memory: &mut Memory,
-    _state: State,
-    _instruction: &Instruction,
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
 ) -> Result<State, InstructionExecutionError> {
-    todo!("u32_store_div_fp_fp not implemented")
+    let (src0_off, src1_off, dst_off) =
+        extract_as!(instruction, U32StoreDivFpFp, (src0_off, src1_off, dst_off));
+
+    // Read first 32-bit value from memory as two limbs
+    let src0_limb_0 = memory.get_data(state.fp + src0_off)?;
+    let src0_limb_1 = memory.get_data(state.fp + src0_off + M31::from(1))?;
+
+    // Validate that source limbs are within 16-bit range
+    if src0_limb_0.0 > U32_LIMB_MASK || src0_limb_1.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 source 0 limbs exceed 16-bit range: limb_0={}, limb_1={}",
+            src0_limb_0.0, src0_limb_1.0
+        )));
+    }
+    let src0_value = (src0_limb_1.0 << U32_LIMB_BITS) | src0_limb_0.0;
+
+    // Read second 32-bit value from memory as two limbs
+    let src1_limb_0 = memory.get_data(state.fp + src1_off)?;
+    let src1_limb_1 = memory.get_data(state.fp + src1_off + M31::from(1))?;
+
+    // Validate that source limbs are within 16-bit range
+    if src1_limb_0.0 > U32_LIMB_MASK || src1_limb_1.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 source 1 limbs exceed 16-bit range: limb_0={}, limb_1={}",
+            src1_limb_0.0, src1_limb_1.0
+        )));
+    }
+    let src1_value = (src1_limb_1.0 << U32_LIMB_BITS) | src1_limb_0.0;
+
+    // Perform 32-bit division
+    // Division by zero returns 0xFFFFFFFF following RISC-V specification
+    let result = if src1_value == 0 {
+        0xFFFFFFFF
+    } else {
+        src0_value / src1_value
+    };
+
+    // Store result as two 16-bit limbs
+    let res_limb_0 = M31::from(result & U32_LIMB_MASK);
+    let res_limb_1 = M31::from((result >> U32_LIMB_BITS) & U32_LIMB_MASK);
+
+    memory.insert(state.fp + dst_off, res_limb_0.into())?;
+    memory.insert(state.fp + dst_off + M31::one(), res_limb_1.into())?;
+
+    Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 
 /// U32 store add fp imm instruction.
@@ -268,31 +442,163 @@ pub fn u32_store_add_fp_imm(
     Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 
-/// TODO: Implement U32 store sub fp imm instruction
+/// U32 store sub fp imm instruction.
+///
+/// u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src_off], [fp + src_off + 1]) - u32(imm_lo, imm_hi)
+/// This instruction supports 32-bit values stored as two 16-bit M31 limbs
 pub fn u32_store_sub_fp_imm(
-    _memory: &mut Memory,
-    _state: State,
-    _instruction: &Instruction,
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
 ) -> Result<State, InstructionExecutionError> {
-    todo!("u32_store_sub_fp_imm not implemented")
+    let (src_off, imm_hi, imm_lo, dst_off) = extract_as!(
+        instruction,
+        U32StoreSubFpImm,
+        (src_off, imm_hi, imm_lo, dst_off)
+    );
+
+    // Read 32-bit value from memory as two limbs
+    let src_limb_0 = memory.get_data(state.fp + src_off)?;
+    let src_limb_1 = memory.get_data(state.fp + src_off + M31::from(1))?;
+
+    // Validate that source limbs are within 16-bit range
+    if src_limb_0.0 > U32_LIMB_MASK || src_limb_1.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 source limbs exceed 16-bit range: limb_0={}, limb_1={}",
+            src_limb_0.0, src_limb_1.0
+        )));
+    }
+    let src_value = (src_limb_1.0 << U32_LIMB_BITS) | src_limb_0.0;
+
+    // Construct 32-bit immediate from two limbs
+    // Validate that immediate limbs are within 16-bit range
+    if imm_lo.0 > U32_LIMB_MASK || imm_hi.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 immediate limbs exceed 16-bit range: imm_lo={}, imm_hi={}",
+            imm_lo.0, imm_hi.0
+        )));
+    }
+    let imm_value = (imm_hi.0 << U32_LIMB_BITS) | imm_lo.0;
+
+    // Perform 32-bit subtraction with wrapping
+    let result = src_value.wrapping_sub(imm_value);
+
+    // Store result as two 16-bit limbs
+    let res_limb_0 = M31::from(result & U32_LIMB_MASK);
+    let res_limb_1 = M31::from((result >> U32_LIMB_BITS) & U32_LIMB_MASK);
+
+    memory.insert(state.fp + dst_off, res_limb_0.into())?;
+    memory.insert(state.fp + dst_off + M31::one(), res_limb_1.into())?;
+
+    Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 
-/// TODO: Implement U32 store mul fp imm instruction
+/// U32 store mul fp imm instruction.
+///
+/// u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src_off], [fp + src_off + 1]) * u32(imm_lo, imm_hi)
+/// This instruction supports 32-bit values stored as two 16-bit M31 limbs
 pub fn u32_store_mul_fp_imm(
-    _memory: &mut Memory,
-    _state: State,
-    _instruction: &Instruction,
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
 ) -> Result<State, InstructionExecutionError> {
-    todo!("u32_store_mul_fp_imm not implemented")
+    let (src_off, imm_hi, imm_lo, dst_off) = extract_as!(
+        instruction,
+        U32StoreMulFpImm,
+        (src_off, imm_hi, imm_lo, dst_off)
+    );
+
+    // Read 32-bit value from memory as two limbs
+    let src_limb_0 = memory.get_data(state.fp + src_off)?;
+    let src_limb_1 = memory.get_data(state.fp + src_off + M31::from(1))?;
+
+    // Validate that source limbs are within 16-bit range
+    if src_limb_0.0 > U32_LIMB_MASK || src_limb_1.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 source limbs exceed 16-bit range: limb_0={}, limb_1={}",
+            src_limb_0.0, src_limb_1.0
+        )));
+    }
+    let src_value = (src_limb_1.0 << U32_LIMB_BITS) | src_limb_0.0;
+
+    // Construct 32-bit immediate from two limbs
+    // Validate that immediate limbs are within 16-bit range
+    if imm_lo.0 > U32_LIMB_MASK || imm_hi.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 immediate limbs exceed 16-bit range: imm_lo={}, imm_hi={}",
+            imm_lo.0, imm_hi.0
+        )));
+    }
+    let imm_value = (imm_hi.0 << U32_LIMB_BITS) | imm_lo.0;
+
+    // Perform 32-bit multiplication with wrapping
+    let result = src_value.wrapping_mul(imm_value);
+
+    // Store result as two 16-bit limbs
+    let res_limb_0 = M31::from(result & U32_LIMB_MASK);
+    let res_limb_1 = M31::from((result >> U32_LIMB_BITS) & U32_LIMB_MASK);
+
+    memory.insert(state.fp + dst_off, res_limb_0.into())?;
+    memory.insert(state.fp + dst_off + M31::one(), res_limb_1.into())?;
+
+    Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 
-/// TODO: Implement U32 store div fp imm instruction
+/// U32 store div fp imm instruction.
+///
+/// u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src_off], [fp + src_off + 1]) / u32(imm_lo, imm_hi)
+/// This instruction supports 32-bit values stored as two 16-bit M31 limbs
+/// Division by zero returns 0xFFFFFFFF (all bits set) following RISC-V behavior
 pub fn u32_store_div_fp_imm(
-    _memory: &mut Memory,
-    _state: State,
-    _instruction: &Instruction,
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
 ) -> Result<State, InstructionExecutionError> {
-    todo!("u32_store_div_fp_imm not implemented")
+    let (src_off, imm_hi, imm_lo, dst_off) = extract_as!(
+        instruction,
+        U32StoreDivFpImm,
+        (src_off, imm_hi, imm_lo, dst_off)
+    );
+
+    // Read 32-bit value from memory as two limbs
+    let src_limb_0 = memory.get_data(state.fp + src_off)?;
+    let src_limb_1 = memory.get_data(state.fp + src_off + M31::from(1))?;
+
+    // Validate that source limbs are within 16-bit range
+    if src_limb_0.0 > U32_LIMB_MASK || src_limb_1.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 source limbs exceed 16-bit range: limb_0={}, limb_1={}",
+            src_limb_0.0, src_limb_1.0
+        )));
+    }
+    let src_value = (src_limb_1.0 << U32_LIMB_BITS) | src_limb_0.0;
+
+    // Construct 32-bit immediate from two limbs
+    // Validate that immediate limbs are within 16-bit range
+    if imm_lo.0 > U32_LIMB_MASK || imm_hi.0 > U32_LIMB_MASK {
+        return Err(InstructionExecutionError::InvalidOperand(format!(
+            "U32 immediate limbs exceed 16-bit range: imm_lo={}, imm_hi={}",
+            imm_lo.0, imm_hi.0
+        )));
+    }
+    let imm_value = (imm_hi.0 << U32_LIMB_BITS) | imm_lo.0;
+
+    // Perform 32-bit division
+    // Division by zero returns 0xFFFFFFFF following RISC-V specification
+    let result = if imm_value == 0 {
+        0xFFFFFFFF
+    } else {
+        src_value / imm_value
+    };
+
+    // Store result as two 16-bit limbs
+    let res_limb_0 = M31::from(result & U32_LIMB_MASK);
+    let res_limb_1 = M31::from((result >> U32_LIMB_BITS) & U32_LIMB_MASK);
+
+    memory.insert(state.fp + dst_off, res_limb_0.into())?;
+    memory.insert(state.fp + dst_off + M31::one(), res_limb_1.into())?;
+
+    Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 
 #[cfg(test)]

--- a/crates/runner/src/vm/instructions/store.rs
+++ b/crates/runner/src/vm/instructions/store.rs
@@ -23,11 +23,11 @@ fn exec_u32_bin_op_fp_fp<F>(
 where
     F: Fn(u32, u32) -> u32,
 {
-    let lhs = memory.read_u32(state.fp + src0_off)?;
-    let rhs = memory.read_u32(state.fp + src1_off)?;
+    let lhs = memory.get_u32(state.fp + src0_off)?;
+    let rhs = memory.get_u32(state.fp + src1_off)?;
 
     let res = op(lhs, rhs);
-    memory.write_u32(state.fp + dst_off, res)?;
+    memory.insert_u32(state.fp + dst_off, res)?;
     Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 
@@ -56,10 +56,10 @@ where
     }
 
     let imm_value: u32 = (imm_hi.0 << U32_LIMB_BITS) | imm_lo.0;
-    let src_value = memory.read_u32(state.fp + src_off)?;
+    let src_value = memory.get_u32(state.fp + src_off)?;
 
     let res = op(src_value, imm_value);
-    memory.write_u32(state.fp + dst_off, res)?;
+    memory.insert_u32(state.fp + dst_off, res)?;
     Ok(state.advance_by(instruction.size_in_qm31s()))
 }
 

--- a/crates/runner/src/vm/instructions/store_tests.rs
+++ b/crates/runner/src/vm/instructions/store_tests.rs
@@ -67,7 +67,7 @@ fn run_u32_fp_imm_test(
 ) -> Result<(), InstructionExecutionError> {
     let mut memory = Memory::default();
     let initial_fp = M31(10);
-    memory.write_u32(initial_fp, src_value).unwrap();
+    memory.insert_u32(initial_fp, src_value).unwrap();
     let state = State {
         pc: M31(0),
         fp: initial_fp,
@@ -75,7 +75,7 @@ fn run_u32_fp_imm_test(
 
     let new_state = exec_fn(&mut memory, state, &instruction)?;
     assert_eq!(
-        memory.read_u32(initial_fp + M31(dst_off)).unwrap(),
+        memory.get_u32(initial_fp + M31(dst_off)).unwrap(),
         expected_res
     );
     assert_eq!(new_state.pc, M31(expected_pc));
@@ -95,8 +95,8 @@ fn run_u32_fp_fp_test(
 ) -> Result<(), InstructionExecutionError> {
     let mut memory = Memory::default();
     let initial_fp = M31(10);
-    memory.write_u32(initial_fp, src0).unwrap(); // fp+0 / fp+1
-    memory.write_u32(initial_fp + M31(2), src1).unwrap(); // fp+2 / fp+3
+    memory.insert_u32(initial_fp, src0).unwrap(); // fp+0 / fp+1
+    memory.insert_u32(initial_fp + M31(2), src1).unwrap(); // fp+2 / fp+3
     let state = State {
         pc: M31(0),
         fp: initial_fp,
@@ -104,7 +104,7 @@ fn run_u32_fp_fp_test(
 
     let new_state = exec_fn(&mut memory, state, &instruction)?;
     assert_eq!(
-        memory.read_u32(initial_fp + M31(dst_off)).unwrap(),
+        memory.get_u32(initial_fp + M31(dst_off)).unwrap(),
         expected_res
     );
     assert_eq!(new_state.pc, M31(expected_pc));
@@ -372,7 +372,7 @@ fn test_store_div_fp_imm_by_zero() {
 
 proptest! {
     #[test]
-    fn test_u32_store_add_fp_imm(src_value: u32, imm_val_hi in 0..=0xFFFFu32, imm_val_lo in 0..=0xFFFFu32) {
+    fn test_u32_store_add_fp_imm(src_value: u32, imm_val_hi in 0..=u16::MAX as u32, imm_val_lo in 0..=u16::MAX as u32) {
         let imm_val = (imm_val_hi << 16) | imm_val_lo;
         let expected_res = src_value.wrapping_add(imm_val);
         run_u32_fp_imm_test(
@@ -391,7 +391,7 @@ proptest! {
     }
 
     #[test]
-    fn test_u32_store_sub_fp_imm(src_value: u32, imm_val_hi in 0..=0xFFFFu32, imm_val_lo in 0..=0xFFFFu32) {
+    fn test_u32_store_sub_fp_imm(src_value: u32, imm_val_hi in 0..=u16::MAX as u32, imm_val_lo in 0..=u16::MAX as u32) {
         let imm_val = (imm_val_hi << 16) | imm_val_lo;
         let expected_res = src_value.wrapping_sub(imm_val);
         run_u32_fp_imm_test(
@@ -410,7 +410,7 @@ proptest! {
     }
 
     #[test]
-    fn test_u32_store_mul_fp_imm(src_value: u32, imm_val_hi in 0..=0xFFFFu32, imm_val_lo in 0..=0xFFFFu32) {
+    fn test_u32_store_mul_fp_imm(src_value: u32, imm_val_hi in 0..=u16::MAX as u32, imm_val_lo in 0..=u16::MAX as u32) {
         let imm_val = (imm_val_hi << 16) | imm_val_lo;
         let expected_res = src_value.wrapping_mul(imm_val);
         run_u32_fp_imm_test(
@@ -429,7 +429,7 @@ proptest! {
     }
 
     #[test]
-    fn test_u32_store_div_fp_imm(src_value: u32, imm_val_hi in 0..=0xFFFFu32, imm_val_lo in 0..=0xFFFFu32) {
+    fn test_u32_store_div_fp_imm(src_value: u32, imm_val_hi in 0..=u16::MAX as u32, imm_val_lo in 0..=u16::MAX as u32) {
         let imm_val = (imm_val_hi << 16) | imm_val_lo;
         prop_assume!(imm_val != 0, "attempt to divide by zero");
         let expected_res = src_value / imm_val;
@@ -453,7 +453,7 @@ proptest! {
 fn test_u32_store_add_fp_imm_invalid_immediate_limbs() {
     // build memory with valid 0 value so the only failure comes from immediates
     let mut memory = Memory::default();
-    memory.write_u32(M31::zero(), 0).unwrap();
+    memory.insert_u32(M31::zero(), 0).unwrap();
 
     let state = State::default();
     let instruction = Instruction::U32StoreAddFpImm {

--- a/crates/runner/src/vm/instructions/store_tests.rs
+++ b/crates/runner/src/vm/instructions/store_tests.rs
@@ -1,188 +1,367 @@
 use num_traits::{One, Zero};
+use proptest::{prelude::*, proptest};
 use stwo_prover::core::fields::m31::M31;
 
+use crate::memory::MemoryError;
+
 use super::{InstructionExecutionError, *};
-use crate::vm::test_utils::*;
 
-#[test]
-fn test_store_add_fp_fp() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::from_iter([0, 4, 7].map(Into::into));
-    let state = State::default();
-    let instruction = Instruction::StoreAddFpFp {
-        src0_off: M31(1),
-        src1_off: M31(2),
-        dst_off: M31(3),
-    };
+// ---------------------------------------------------------------------------
+// Generic helpers (scalar instructions)
+// ---------------------------------------------------------------------------
 
-    let new_state = store_add_fp_fp(&mut memory, state, &instruction)?;
+/// Signature of every store-style execution helper.
+type ExecFn = fn(&mut Memory, State, &Instruction) -> Result<State, InstructionExecutionError>;
 
-    let expected_memory = Memory::from_iter([0, 4, 7, 11].map(Into::into));
-    assert_eq!(memory.data, expected_memory.data);
+/// Run an instruction end-to-end and assert on *all* side-effects.
+fn run_store_test(
+    initial_mem: &[u32],
+    state: State,
+    instruction: Instruction,
+    exec_fn: ExecFn,
+    expected_mem: &[u32],
+    expected_pc: u32,
+    expected_fp: u32,
+) -> Result<(), InstructionExecutionError> {
+    let mut memory = Memory::from_iter(initial_mem.iter().copied().map(Into::into));
+    let new_state = exec_fn(&mut memory, state, &instruction)?;
 
-    assert_eq!(new_state.fp, M31::zero());
-    assert_eq!(new_state.pc, M31::one());
-
-    Ok(())
-}
-
-#[test]
-fn test_store_add_fp_imm() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::from_iter([0, 4, 7].map(Into::into));
-    let expected_memory = Memory::from_iter([0, 4, 7, 6].map(Into::into));
-    let state = State::default();
-    let instruction = Instruction::StoreAddFpImm {
-        src_off: M31(1),
-        imm: M31(2),
-        dst_off: M31(3),
-    };
-
-    let new_state = store_add_fp_imm(&mut memory, state, &instruction)?;
-
-    assert_eq!(memory.data, expected_memory.data);
-    assert_vm_state!(new_state, 1, 0);
+    let expected_memory = Memory::from_iter(expected_mem.iter().copied().map(Into::into));
+    assert_eq!(
+        memory.data, expected_memory.data,
+        "memory mismatch after executing {instruction:?}"
+    );
+    assert_eq!(new_state.pc, M31(expected_pc));
+    assert_eq!(new_state.fp, M31(expected_fp));
 
     Ok(())
 }
 
-#[test]
-fn test_store_sub_fp_fp() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::from_iter([0, 7, 4].map(Into::into));
-    let state = State::default();
-    let instruction = Instruction::StoreSubFpFp {
-        src0_off: M31(1),
-        src1_off: M31(2),
-        dst_off: M31(3),
+/// Same as [`run_store_test`] but starting from `State::default()`.
+fn run_simple_store_test(
+    initial_mem: &[u32],
+    instruction: Instruction,
+    exec_fn: ExecFn,
+    expected_mem: &[u32],
+    expected_pc: u32,
+) -> Result<(), InstructionExecutionError> {
+    run_store_test(
+        initial_mem,
+        State::default(),
+        instruction,
+        exec_fn,
+        expected_mem,
+        expected_pc,
+        0,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// U32-specific helpers
+// ---------------------------------------------------------------------------
+
+const LOW_MASK: u32 = 0xFFFF;
+
+/// Split a `u32` into (`low`, `high`) 16-bit limbs.
+fn split_u32(value: u32) -> (u32, u32) {
+    (value & LOW_MASK, value >> 16)
+}
+
+/// Insert a 32-bit value into memory as two 16-bit limbs.
+fn insert_u32(memory: &mut Memory, addr: M31, value: u32) {
+    let (lo, hi) = split_u32(value);
+    memory.insert(addr, M31(lo).into()).unwrap();
+    memory.insert(addr + M31(1), M31(hi).into()).unwrap();
+}
+
+/// Assert that the memory at `addr` holds the 32-bit `expected` (low limb
+/// first, high limb second).
+fn assert_u32(memory: &Memory, addr: M31, expected: u32) {
+    let (lo, hi) = split_u32(expected);
+    assert_eq!(memory.get_data(addr).unwrap(), M31(lo));
+    assert_eq!(memory.get_data(addr + M31(1)).unwrap(), M31(hi));
+}
+
+/// Run an FP-IMM-style U32 instruction and validate state + result.
+fn run_u32_fp_imm_test(
+    src_value: u32,
+    instruction: Instruction,
+    exec_fn: ExecFn,
+    expected_res: u32,
+    dst_off: u32,
+    expected_pc: u32,
+) -> Result<(), InstructionExecutionError> {
+    let mut memory = Memory::default();
+    let initial_fp = M31(10);
+    insert_u32(&mut memory, initial_fp, src_value);
+    let state = State {
+        pc: M31(0),
+        fp: initial_fp,
     };
 
-    let new_state = store_sub_fp_fp(&mut memory, state, &instruction)?;
-
-    let expected_memory = Memory::from_iter([0, 7, 4, 3].map(Into::into));
-    assert_eq!(memory.data, expected_memory.data);
-    assert_vm_state!(new_state, 1, 0);
-
+    let new_state = exec_fn(&mut memory, state, &instruction)?;
+    assert_u32(&memory, initial_fp + M31(dst_off), expected_res);
+    assert_eq!(new_state.pc, M31(expected_pc));
+    assert_eq!(new_state.fp, initial_fp);
     Ok(())
 }
 
-#[test]
-fn test_store_sub_fp_imm() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::from_iter([0, 4, 7].map(Into::into));
-    let state = State::default();
-    let instruction = Instruction::StoreSubFpImm {
-        src_off: M31(1),
-        imm: M31(2),
-        dst_off: M31(3),
+/// Run an FP-FP-style U32 instruction and validate state + result.
+fn run_u32_fp_fp_test(
+    src0: u32,
+    src1: u32,
+    instruction: Instruction,
+    exec_fn: ExecFn,
+    expected_res: u32,
+    dst_off: u32,
+    expected_pc: u32,
+) -> Result<(), InstructionExecutionError> {
+    let mut memory = Memory::default();
+    let initial_fp = M31(10);
+    insert_u32(&mut memory, initial_fp, src0); // fp+0 / fp+1
+    insert_u32(&mut memory, initial_fp + M31(2), src1); // fp+2 / fp+3
+    let state = State {
+        pc: M31(0),
+        fp: initial_fp,
     };
 
-    let new_state = store_sub_fp_imm(&mut memory, state, &instruction)?;
-
-    let expected_memory = Memory::from_iter([0, 4, 7, 2].map(Into::into));
-    assert_eq!(memory.data, expected_memory.data);
-    assert_vm_state!(new_state, 1, 0);
-
+    let new_state = exec_fn(&mut memory, state, &instruction)?;
+    assert_u32(&memory, initial_fp + M31(dst_off), expected_res);
+    assert_eq!(new_state.pc, M31(expected_pc));
+    assert_eq!(new_state.fp, initial_fp);
     Ok(())
 }
 
-#[test]
-fn test_store_double_deref_fp() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::from_iter([0, 1, 7, 9].map(Into::into));
-    let state = State::default();
-    let instruction = Instruction::StoreDoubleDerefFp {
-        base_off: M31(1),
-        offset: M31(2),
-        dst_off: M31(2),
-    };
+// -----------------------------------------------------------------------------
+// Scalar store_* instruction tests
+// -----------------------------------------------------------------------------
 
-    let new_state = store_double_deref_fp(&mut memory, state, &instruction)?;
+proptest! {
+    #[test]
+    fn test_store_add_fp_fp(src0_val: u32, src1_val: u32) {
+        let src0 = M31::from(src0_val);
+        let src1 = M31::from(src1_val);
+        let expected_res = src0 + src1;
 
-    let expected_memory = Memory::from_iter([0, 1, 9, 9].map(Into::into));
-    assert_eq!(memory.data, expected_memory.data);
-    assert_vm_state!(new_state, 1, 0);
+        let mut initial_mem = vec![0; 4];
+        initial_mem[1] = src0_val;
+        initial_mem[2] = src1_val;
+        let mut expected_mem = initial_mem.clone();
+        expected_mem[3] = expected_res.0;
 
-    Ok(())
-}
+        run_simple_store_test(
+            &initial_mem,
+            Instruction::StoreAddFpFp {
+                src0_off: M31(1),
+                src1_off: M31(2),
+                dst_off: M31(3),
+            },
+            store_add_fp_fp,
+            &expected_mem,
+            1,
+        ).unwrap();
+    }
 
-#[test]
-fn test_store_imm() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::from_iter([0, 4].map(Into::into));
-    let state = State::default();
-    let instruction = Instruction::StoreImm {
-        imm: M31(1),
-        dst_off: M31(2),
-    };
+    #[test]
+    fn test_store_add_fp_imm(src_val: u32, imm_val: u32) {
+        let src = M31::from(src_val);
+        let imm = M31::from(imm_val);
+        let expected_res = src + imm;
 
-    let new_state = store_imm(&mut memory, state, &instruction)?;
+        let mut initial_mem = vec![0; 4];
+        initial_mem[1] = src_val;
+        let mut expected_mem = initial_mem.clone();
+        expected_mem[3] = expected_res.0;
 
-    let expected_memory = Memory::from_iter([0, 4, 1].map(Into::into));
-    assert_eq!(memory.data, expected_memory.data);
+        run_simple_store_test(
+            &initial_mem,
+            Instruction::StoreAddFpImm {
+                src_off: M31(1),
+                imm,
+                dst_off: M31(3),
+            },
+            store_add_fp_imm,
+            &expected_mem,
+            1,
+        ).unwrap();
+    }
 
-    assert_eq!(new_state.fp, M31::zero());
-    assert_eq!(new_state.pc, M31::one());
+    #[test]
+    fn test_store_sub_fp_fp(src0_val: u32, src1_val: u32) {
+        let src0 = M31::from(src0_val);
+        let src1 = M31::from(src1_val);
+        let expected_res = src0 - src1;
 
-    Ok(())
-}
+        let mut initial_mem = vec![0; 4];
+        initial_mem[1] = src0_val;
+        initial_mem[2] = src1_val;
+        let mut expected_mem = initial_mem.clone();
+        expected_mem[3] = expected_res.0;
 
-#[test]
-fn test_store_mul_fp_fp() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::from_iter([0, 4, 7].map(Into::into));
-    let state = State::default();
-    let instruction = Instruction::StoreMulFpFp {
-        src0_off: M31(1),
-        src1_off: M31(2),
-        dst_off: M31(3),
-    };
+        run_simple_store_test(
+            &initial_mem,
+            Instruction::StoreSubFpFp {
+                src0_off: M31(1),
+                src1_off: M31(2),
+                dst_off: M31(3),
+            },
+            store_sub_fp_fp,
+            &expected_mem,
+            1,
+        ).unwrap();
+    }
 
-    let new_state = store_mul_fp_fp(&mut memory, state, &instruction)?;
+    #[test]
+    fn test_store_sub_fp_imm(src_val: u32, imm_val: u32) {
+        let src = M31::from(src_val);
+        let imm = M31::from(imm_val);
+        let expected_res = src - imm;
 
-    let expected_memory = Memory::from_iter([0, 4, 7, 28].map(Into::into));
-    assert_eq!(memory.data, expected_memory.data);
-    assert_vm_state!(new_state, 1, 0);
+        let mut initial_mem = vec![0; 4];
+        initial_mem[1] = src_val;
+        let mut expected_mem = initial_mem.clone();
+        expected_mem[3] = expected_res.0;
 
-    Ok(())
-}
+        run_simple_store_test(
+            &initial_mem,
+            Instruction::StoreSubFpImm {
+                src_off: M31(1),
+                imm,
+                dst_off: M31(3),
+            },
+            store_sub_fp_imm,
+            &expected_mem,
+            1,
+        ).unwrap();
+    }
 
-#[test]
-fn test_store_mul_fp_imm() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::from_iter([0, 4].map(Into::into));
-    let state = State::default();
-    let instruction = Instruction::StoreMulFpImm {
-        src_off: M31(1),
-        imm: M31(2),
-        dst_off: M31(2),
-    };
+    #[test]
+    fn test_store_double_deref_fp(val_to_store: u32, dst_val: u32) {
+        run_simple_store_test(
+            &[0, 1, dst_val, val_to_store],
+            Instruction::StoreDoubleDerefFp {
+                base_off: M31(1),
+                offset: M31(2),
+                dst_off: M31(2),
+            },
+            store_double_deref_fp,
+            &[0, 1, val_to_store, val_to_store],
+            1,
+        )
+        .unwrap();
+    }
 
-    let new_state = store_mul_fp_imm(&mut memory, state, &instruction)?;
+    #[test]
+    fn test_store_imm(imm_val: u32) {
+        let imm = M31::from(imm_val);
+        run_simple_store_test(
+            &[0, 4],
+            Instruction::StoreImm {
+                imm,
+                dst_off: M31(2),
+            },
+            store_imm,
+            &[0, 4, imm.0],
+            1,
+        )
+        .unwrap();
+    }
 
-    let expected_memory = Memory::from_iter([0, 4, 8].map(Into::into));
-    assert_eq!(memory.data, expected_memory.data);
-    assert_vm_state!(new_state, 1, 0);
+    #[test]
+    fn test_store_mul_fp_fp(src0_val: u32, src1_val: u32) {
+        let src0 = M31::from(src0_val);
+        let src1 = M31::from(src1_val);
+        let expected_res = src0 * src1;
 
-    Ok(())
-}
+        let mut initial_mem = vec![0; 4];
+        initial_mem[1] = src0_val;
+        initial_mem[2] = src1_val;
+        let mut expected_mem = initial_mem.clone();
+        expected_mem[3] = expected_res.0;
 
-#[test]
-fn test_store_div_fp_fp() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::from_iter([0, 4, 7].map(Into::into));
-    let state = State::default();
-    let instruction = Instruction::StoreDivFpFp {
-        src0_off: M31(1),
-        src1_off: M31(2),
-        dst_off: M31(3),
-    };
+        run_simple_store_test(
+            &initial_mem,
+            Instruction::StoreMulFpFp {
+                src0_off: M31(1),
+                src1_off: M31(2),
+                dst_off: M31(3),
+            },
+            store_mul_fp_fp,
+            &expected_mem,
+            1,
+        ).unwrap();
+    }
 
-    let new_state = store_div_fp_fp(&mut memory, state, &instruction)?;
+    #[test]
+    fn test_store_mul_fp_imm(src_val: u32, imm_val: u32) {
+        let src = M31::from(src_val);
+        let imm = M31::from(imm_val);
+        let expected_res = src * imm;
+        run_simple_store_test(
+            &[0, src_val],
+            Instruction::StoreMulFpImm {
+                src_off: M31(1),
+                imm,
+                dst_off: M31(2),
+            },
+            store_mul_fp_imm,
+            &[0, src_val, expected_res.0],
+            1,
+        ).unwrap();
+    }
 
-    let expected_div = M31::from(4) / M31::from(7);
-    let expected_memory = Memory::from_iter([0, 4, 7, expected_div.0].map(Into::into));
-    assert_eq!(memory.data, expected_memory.data);
-    assert_vm_state!(new_state, 1, 0);
+    #[test]
+    fn test_store_div_fp_fp(src0_val: u32, src1_val: u32) {
+        let src1 = M31::from(src1_val);
+        prop_assume!(src1 != M31::zero(), "division by zero");
 
-    Ok(())
+        let src0 = M31::from(src0_val);
+        let expected_res = src0 / src1;
+
+        let mut initial_mem = vec![0; 4];
+        initial_mem[1] = src0_val;
+        initial_mem[2] = src1_val;
+        let mut expected_mem = initial_mem.clone();
+        expected_mem[3] = expected_res.0;
+
+        run_simple_store_test(
+            &initial_mem,
+            Instruction::StoreDivFpFp {
+                src0_off: M31(1),
+                src1_off: M31(2),
+                dst_off: M31(3),
+            },
+            store_div_fp_fp,
+            &expected_mem,
+            1,
+        ).unwrap();
+    }
+
+    #[test]
+    fn test_store_div_fp_imm(src_val: u32, imm_val: u32) {
+        let imm = M31::from(imm_val);
+        prop_assume!(imm != M31::zero(), "division by zero");
+
+        let src = M31::from(src_val);
+        let expected_res = src / imm;
+        run_simple_store_test(
+            &[0, src_val],
+            Instruction::StoreDivFpImm {
+                src_off: M31(1),
+                imm,
+                dst_off: M31(2),
+            },
+            store_div_fp_imm,
+            &[0, src_val, expected_res.0],
+            1,
+        ).unwrap();
+    }
 }
 
 #[test]
 #[should_panic(expected = "0 has no inverse")]
 fn test_store_div_fp_fp_by_zero() {
-    let mut memory = Memory::from_iter([0, 4, 0].map(Into::into));
+    let mut memory = Memory::from_iter([0u32, 4, 0].map(Into::into));
     let state = State::default();
     let instruction = Instruction::StoreDivFpFp {
         src0_off: M31(1),
@@ -194,28 +373,9 @@ fn test_store_div_fp_fp_by_zero() {
 }
 
 #[test]
-fn test_store_div_fp_imm() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::from_iter([0, 4].map(Into::into));
-    let state = State::default();
-    let instruction = Instruction::StoreDivFpImm {
-        src_off: M31(1),
-        imm: M31(2),
-        dst_off: M31(2),
-    };
-
-    let new_state = store_div_fp_imm(&mut memory, state, &instruction)?;
-
-    let expected_memory = Memory::from_iter([0, 4, 2].map(Into::into));
-    assert_eq!(memory.data, expected_memory.data);
-    assert_vm_state!(new_state, 1, 0);
-
-    Ok(())
-}
-
-#[test]
 #[should_panic(expected = "0 has no inverse")]
 fn test_store_div_fp_imm_by_zero() {
-    let mut memory = Memory::from_iter([0, 4].map(Into::into));
+    let mut memory = Memory::from_iter([0u32, 4].map(Into::into));
     let state = State::default();
     let instruction = Instruction::StoreDivFpImm {
         src_off: M31(1),
@@ -226,125 +386,120 @@ fn test_store_div_fp_imm_by_zero() {
     let _ = store_div_fp_imm(&mut memory, state, &instruction);
 }
 
-#[test]
-fn test_u32_store_add_fp_imm() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    // Set up 32-bit value in memory stored as two limbs
-    // Value: 0x12345678 stored as [0x5678, 0x1234] at [fp+0] and [fp+1]
-    let initial_fp = M31(10); // Use non-zero FP to avoid confusion with addresses
-    memory.insert(initial_fp, M31(0x5678).into())?;
-    memory.insert(initial_fp + M31(1), M31(0x1234).into())?;
+// -----------------------------------------------------------------------------
+// U32 FP-IMM instruction tests
+// -----------------------------------------------------------------------------
 
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreAddFpImm {
-        src_off: M31(0),
-        imm_hi: M31(0x9876),
-        imm_lo: M31(0xABCD),
-        dst_off: M31(2),
-    };
+proptest! {
+    #[test]
+    fn test_u32_store_add_fp_imm(src_value: u32, imm_val_hi in 0..=0xFFFFu32, imm_val_lo in 0..=0xFFFFu32) {
+        let imm_val = (imm_val_hi << 16) | imm_val_lo;
+        let expected_res = src_value.wrapping_add(imm_val);
+        run_u32_fp_imm_test(
+            src_value,
+            Instruction::U32StoreAddFpImm {
+                src_off: M31(0),
+                imm_hi: M31(imm_val_hi),
+                imm_lo: M31(imm_val_lo),
+                dst_off: M31(2),
+            },
+            u32_store_add_fp_imm,
+            expected_res,
+            2,
+            2,
+        ).unwrap();
+    }
 
-    let new_state = u32_store_add_fp_imm(&mut memory, state, &instruction)?;
+    #[test]
+    fn test_u32_store_sub_fp_imm(src_value: u32, imm_val_hi in 0..=0xFFFFu32, imm_val_lo in 0..=0xFFFFu32) {
+        let imm_val = (imm_val_hi << 16) | imm_val_lo;
+        let expected_res = src_value.wrapping_sub(imm_val);
+        run_u32_fp_imm_test(
+            src_value,
+            Instruction::U32StoreSubFpImm {
+                src_off: M31(0),
+                imm_hi: M31(imm_val_hi),
+                imm_lo: M31(imm_val_lo),
+                dst_off: M31(2),
+            },
+            u32_store_sub_fp_imm,
+            expected_res,
+            2,
+            2,
+        ).unwrap();
+    }
 
-    // Expected: 0x12345678 + 0x9876ABCD = 0xAAAB0245
-    // Low limb: 0x0245, High limb: 0xAAAB
-    assert_eq!(memory.get_data(initial_fp + M31(2))?, M31(0x0245));
-    assert_eq!(memory.get_data(initial_fp + M31(3))?, M31(0xAAAB));
+    #[test]
+    fn test_u32_store_mul_fp_imm(src_value: u32, imm_val_hi in 0..=0xFFFFu32, imm_val_lo in 0..=0xFFFFu32) {
+        let imm_val = (imm_val_hi << 16) | imm_val_lo;
+        let expected_res = src_value.wrapping_mul(imm_val);
+        run_u32_fp_imm_test(
+            src_value,
+            Instruction::U32StoreMulFpImm {
+                src_off: M31(0),
+                imm_hi: M31(imm_val_hi),
+                imm_lo: M31(imm_val_lo),
+                dst_off: M31(2),
+            },
+            u32_store_mul_fp_imm,
+            expected_res,
+            2,
+            2,
+        ).unwrap();
+    }
 
-    // Check state advancement (instruction size is 5 M31s = 2 QM31s)
-    assert_eq!(new_state.pc, M31(2));
-    assert_eq!(new_state.fp, initial_fp);
-
-    Ok(())
-}
-
-#[test]
-fn test_u32_store_add_fp_imm_overflow() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
-    // Set up maximum 32-bit value: 0xFFFFFFFF
-    memory.insert(initial_fp, M31(U32_LIMB_MASK).into())?;
-    memory.insert(initial_fp + M31(1), M31(U32_LIMB_MASK).into())?;
-
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreAddFpImm {
-        src_off: M31(0),
-        imm_hi: M31(0),
-        imm_lo: M31(1),
-        dst_off: M31(2),
-    };
-
-    let new_state = u32_store_add_fp_imm(&mut memory, state, &instruction)?;
-
-    // Expected: 0xFFFFFFFF + 0x00000001 = 0x00000000 (wrapping)
-    assert_eq!(memory.get_data(initial_fp + M31(2))?, M31(0));
-    assert_eq!(memory.get_data(initial_fp + M31(3))?, M31(0));
-
-    assert_eq!(new_state.pc, M31(2));
-
-    Ok(())
-}
-
-#[test]
-fn test_u32_store_add_fp_imm_partial_overflow() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
-    // Set up value that will overflow low limb: 0x0000FFFF
-    memory.insert(initial_fp, M31(U32_LIMB_MASK).into())?;
-    memory.insert(initial_fp + M31(1), M31(0x0000).into())?;
-
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreAddFpImm {
-        src_off: M31(0),
-        imm_hi: M31(0),
-        imm_lo: M31(1),
-        dst_off: M31(2),
-    };
-
-    let new_state = u32_store_add_fp_imm(&mut memory, state, &instruction)?;
-
-    // Expected: 0x0000FFFF + 0x00000001 = 0x00010000
-    assert_eq!(memory.get_data(initial_fp + M31(2))?, M31(0));
-    assert_eq!(memory.get_data(initial_fp + M31(3))?, M31(1));
-
-    assert_eq!(new_state.pc, M31(2));
-
-    Ok(())
+    #[test]
+    fn test_u32_store_div_fp_imm(src_value: u32, imm_val_hi in 0..=0xFFFFu32, imm_val_lo in 0..=0xFFFFu32) {
+        let imm_val = (imm_val_hi << 16) | imm_val_lo;
+        prop_assume!(imm_val != 0, "attempt to divide by zero");
+        let expected_res = src_value / imm_val;
+        run_u32_fp_imm_test(
+            src_value,
+            Instruction::U32StoreDivFpImm {
+                src_off: M31(0),
+                imm_hi: M31(imm_val_hi),
+                imm_lo: M31(imm_val_lo),
+                dst_off: M31(2),
+            },
+            u32_store_div_fp_imm,
+            expected_res,
+            2,
+            2,
+        ).unwrap();
+    }
 }
 
 #[test]
 fn test_u32_store_add_fp_imm_invalid_immediate_limbs() {
+    // build memory with valid 0 value so the only failure comes from immediates
     let mut memory = Memory::default();
-    memory.insert(M31::zero(), M31(0).into()).unwrap();
-    memory.insert(M31::one(), M31(0).into()).unwrap();
+    insert_u32(&mut memory, M31::zero(), 0);
 
     let state = State::default();
     let instruction = Instruction::U32StoreAddFpImm {
         src_off: M31(0),
-        imm_hi: M31(0x10000), // Exceeds 16-bit limit
-        imm_lo: M31(0x10000), // Exceeds 16-bit limit
+        imm_hi: M31(0x1_0000), // > 16-bit
+        imm_lo: M31(0x1_0000), // > 16-bit
         dst_off: M31(2),
     };
 
-    assert!(matches!(
-        u32_store_add_fp_imm(&mut memory, state, &instruction),
-        Err(InstructionExecutionError::InvalidOperand(_))
-    ));
+    assert!(
+        u32_store_add_fp_imm(&mut memory, state, &instruction)
+            == Err(InstructionExecutionError::Memory(
+                MemoryError::U32LimbOutOfRange {
+                    limb_lo: 0x1_0000,
+                    limb_hi: 0x1_0000,
+                }
+            ))
+    );
 }
 
 #[test]
 fn test_u32_store_add_fp_imm_invalid_source_limbs() {
     let mut memory = Memory::default();
-    memory.insert(M31::zero(), M31(0x10000).into()).unwrap(); // Exceeds 16-bit limit
-    memory.insert(M31::one(), M31(0x10000).into()).unwrap();
+    // Insert invalid (>16-bit) limbs into fp+0 / fp+1
+    memory.insert(M31::zero(), M31(0x1_0000).into()).unwrap();
+    memory.insert(M31::one(), M31(0x1_0000).into()).unwrap();
 
     let state = State::default();
     let instruction = Instruction::U32StoreAddFpImm {
@@ -354,387 +509,131 @@ fn test_u32_store_add_fp_imm_invalid_source_limbs() {
         dst_off: M31(2),
     };
 
-    assert!(matches!(
-        u32_store_add_fp_imm(&mut memory, state, &instruction),
-        Err(InstructionExecutionError::InvalidOperand(_))
-    ));
+    assert!(
+        u32_store_add_fp_imm(&mut memory, state, &instruction)
+            == Err(InstructionExecutionError::Memory(
+                MemoryError::U32LimbOutOfRange {
+                    limb_lo: 0x1_0000,
+                    limb_hi: 0x1_0000,
+                }
+            ))
+    );
 }
 
 #[test]
-fn test_u32_store_add_fp_imm_max_valid_values() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    memory.insert(M31::zero(), M31(0xFFFF).into())?;
-    memory.insert(M31::one(), M31(0xFFFF).into())?;
-
-    let state = State::default();
-    let instruction = Instruction::U32StoreAddFpImm {
-        src_off: M31(0),
-        imm_hi: M31(0xFFFF),
-        imm_lo: M31(0xFFFF),
-        dst_off: M31(2),
-    };
-
-    let new_state = u32_store_add_fp_imm(&mut memory, state, &instruction)?;
-
-    // 0xFFFFFFFF + 0xFFFFFFFF = 0xFFFFFFFE (with wrapping)
-    assert_eq!(memory.get_data(M31(2))?, M31(0xFFFE));
-    assert_eq!(memory.get_data(M31(3))?, M31(0xFFFF));
-    assert_eq!(new_state.pc, M31(2));
-
-    Ok(())
+#[should_panic(expected = "attempt to divide by zero")]
+fn test_u32_store_div_fp_imm_by_zero() {
+    let src_value = 0x1234_5678;
+    let _ = run_u32_fp_imm_test(
+        src_value,
+        Instruction::U32StoreDivFpImm {
+            src_off: M31(0),
+            imm_hi: M31(0x0000),
+            imm_lo: M31(0x0000),
+            dst_off: M31(2),
+        },
+        u32_store_div_fp_imm,
+        0,
+        2,
+        2,
+    );
 }
 
-// ==================== U32 FP-FP Operations Tests ====================
+// -----------------------------------------------------------------------------
+// U32 FP-FP instruction tests
+// -----------------------------------------------------------------------------
 
-#[test]
-fn test_u32_store_add_fp_fp() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
+proptest! {
+    #[test]
+    fn test_u32_store_add_fp_fp(src0_value: u32, src1_value: u32) {
+        let expected_res = src0_value.wrapping_add(src1_value);
+        run_u32_fp_fp_test(
+            src0_value,
+            src1_value,
+            Instruction::U32StoreAddFpFp {
+                src0_off: M31(0),
+                src1_off: M31(2),
+                dst_off: M31(4),
+            },
+            u32_store_add_fp_fp,
+            expected_res,
+            4,
+            1,
+        ).unwrap();
+    }
 
-    // Set up first 32-bit value: 0x12345678
-    memory.insert(initial_fp, M31(0x5678).into())?;
-    memory.insert(initial_fp + M31(1), M31(0x1234).into())?;
+    #[test]
+    fn test_u32_store_sub_fp_fp(src0_value: u32, src1_value: u32) {
+        let expected_res = src0_value.wrapping_sub(src1_value);
+        run_u32_fp_fp_test(
+            src0_value,
+            src1_value,
+            Instruction::U32StoreSubFpFp {
+                src0_off: M31(0),
+                src1_off: M31(2),
+                dst_off: M31(4),
+            },
+            u32_store_sub_fp_fp,
+            expected_res,
+            4,
+            1,
+        ).unwrap();
+    }
 
-    // Set up second 32-bit value: 0x9876ABCD
-    memory.insert(initial_fp + M31(2), M31(0xABCD).into())?;
-    memory.insert(initial_fp + M31(3), M31(0x9876).into())?;
+    #[test]
+    fn test_u32_store_mul_fp_fp(src0_value: u32, src1_value: u32) {
+        let expected_res = src0_value.wrapping_mul(src1_value);
+        run_u32_fp_fp_test(
+            src0_value,
+            src1_value,
+            Instruction::U32StoreMulFpFp {
+                src0_off: M31(0),
+                src1_off: M31(2),
+                dst_off: M31(4),
+            },
+            u32_store_mul_fp_fp,
+            expected_res,
+            4,
+            1,
+        ).unwrap();
+    }
 
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreAddFpFp {
-        src0_off: M31(0),
-        src1_off: M31(2),
-        dst_off: M31(4),
-    };
-
-    let new_state = u32_store_add_fp_fp(&mut memory, state, &instruction)?;
-
-    // Expected: 0x12345678 + 0x9876ABCD = 0xAAAB0245
-    assert_eq!(memory.get_data(initial_fp + M31(4))?, M31(0x0245));
-    assert_eq!(memory.get_data(initial_fp + M31(5))?, M31(0xAAAB));
-    assert_eq!(new_state.pc, M31(1));
-
-    Ok(())
-}
-
-#[test]
-fn test_u32_store_sub_fp_fp() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
-
-    // Set up first 32-bit value: 0x9876ABCD
-    memory.insert(initial_fp, M31(0xABCD).into())?;
-    memory.insert(initial_fp + M31(1), M31(0x9876).into())?;
-
-    // Set up second 32-bit value: 0x12345678
-    memory.insert(initial_fp + M31(2), M31(0x5678).into())?;
-    memory.insert(initial_fp + M31(3), M31(0x1234).into())?;
-
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreSubFpFp {
-        src0_off: M31(0),
-        src1_off: M31(2),
-        dst_off: M31(4),
-    };
-
-    let new_state = u32_store_sub_fp_fp(&mut memory, state, &instruction)?;
-
-    // Expected: 0x9876ABCD - 0x12345678 = 0x86425555
-    assert_eq!(memory.get_data(initial_fp + M31(4))?, M31(0x5555));
-    assert_eq!(memory.get_data(initial_fp + M31(5))?, M31(0x8642));
-    assert_eq!(new_state.pc, M31(1));
-
-    Ok(())
-}
-
-#[test]
-fn test_u32_store_sub_fp_fp_underflow() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
-
-    // Set up first 32-bit value: 0x00000001
-    memory.insert(initial_fp, M31(0x0001).into())?;
-    memory.insert(initial_fp + M31(1), M31(0x0000).into())?;
-
-    // Set up second 32-bit value: 0x00000002
-    memory.insert(initial_fp + M31(2), M31(0x0002).into())?;
-    memory.insert(initial_fp + M31(3), M31(0x0000).into())?;
-
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreSubFpFp {
-        src0_off: M31(0),
-        src1_off: M31(2),
-        dst_off: M31(4),
-    };
-
-    let new_state = u32_store_sub_fp_fp(&mut memory, state, &instruction)?;
-
-    // Expected: 0x00000001 - 0x00000002 = 0xFFFFFFFF (wrapping)
-    assert_eq!(memory.get_data(initial_fp + M31(4))?, M31(0xFFFF));
-    assert_eq!(memory.get_data(initial_fp + M31(5))?, M31(0xFFFF));
-    assert_eq!(new_state.pc, M31(1));
-
-    Ok(())
+    #[test]
+    fn test_u32_store_div_fp_fp(src0_value: u32, src1_value: u32) {
+        prop_assume!(src1_value != 0, "attempt to divide by zero");
+        let expected_res = src0_value / src1_value;
+        run_u32_fp_fp_test(
+            src0_value,
+            src1_value,
+            Instruction::U32StoreDivFpFp {
+                src0_off: M31(0),
+                src1_off: M31(2),
+                dst_off: M31(4),
+            },
+            u32_store_div_fp_fp,
+            expected_res,
+            4,
+            1,
+        ).unwrap();
+    }
 }
 
 #[test]
-fn test_u32_store_mul_fp_fp() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
-
-    // Set up first 32-bit value: 0x00001234
-    memory.insert(initial_fp, M31(0x1234).into())?;
-    memory.insert(initial_fp + M31(1), M31(0x0000).into())?;
-
-    // Set up second 32-bit value: 0x00005678
-    memory.insert(initial_fp + M31(2), M31(0x5678).into())?;
-    memory.insert(initial_fp + M31(3), M31(0x0000).into())?;
-
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreMulFpFp {
-        src0_off: M31(0),
-        src1_off: M31(2),
-        dst_off: M31(4),
-    };
-
-    let new_state = u32_store_mul_fp_fp(&mut memory, state, &instruction)?;
-
-    // Expected: 0x00001234 * 0x00005678 = 0x06260060
-    assert_eq!(memory.get_data(initial_fp + M31(4))?, M31(0x0060));
-    assert_eq!(memory.get_data(initial_fp + M31(5))?, M31(0x0626));
-    assert_eq!(new_state.pc, M31(1));
-
-    Ok(())
-}
-
-#[test]
-fn test_u32_store_mul_fp_fp_overflow() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
-
-    // Set up first 32-bit value: 0xFFFFFFFF
-    memory.insert(initial_fp, M31(0xFFFF).into())?;
-    memory.insert(initial_fp + M31(1), M31(0xFFFF).into())?;
-
-    // Set up second 32-bit value: 0x00000002
-    memory.insert(initial_fp + M31(2), M31(0x0002).into())?;
-    memory.insert(initial_fp + M31(3), M31(0x0000).into())?;
-
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreMulFpFp {
-        src0_off: M31(0),
-        src1_off: M31(2),
-        dst_off: M31(4),
-    };
-
-    let new_state = u32_store_mul_fp_fp(&mut memory, state, &instruction)?;
-
-    // Expected: 0xFFFFFFFF * 0x00000002 = 0xFFFFFFFE (with wrapping)
-    assert_eq!(memory.get_data(initial_fp + M31(4))?, M31(0xFFFE));
-    assert_eq!(memory.get_data(initial_fp + M31(5))?, M31(0xFFFF));
-    assert_eq!(new_state.pc, M31(1));
-
-    Ok(())
-}
-
-#[test]
-fn test_u32_store_div_fp_fp() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
-
-    // Set up first 32-bit value: 0x00006260
-    memory.insert(initial_fp, M31(0x6260).into())?;
-    memory.insert(initial_fp + M31(1), M31(0x0000).into())?;
-
-    // Set up second 32-bit value: 0x00000004
-    memory.insert(initial_fp + M31(2), M31(0x0004).into())?;
-    memory.insert(initial_fp + M31(3), M31(0x0000).into())?;
-
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreDivFpFp {
-        src0_off: M31(0),
-        src1_off: M31(2),
-        dst_off: M31(4),
-    };
-
-    let new_state = u32_store_div_fp_fp(&mut memory, state, &instruction)?;
-
-    // Expected: 0x00006260 / 0x00000004 = 0x00001898
-    assert_eq!(memory.get_data(initial_fp + M31(4))?, M31(0x1898));
-    assert_eq!(memory.get_data(initial_fp + M31(5))?, M31(0x0000));
-    assert_eq!(new_state.pc, M31(1));
-
-    Ok(())
-}
-
-#[test]
-fn test_u32_store_div_fp_fp_by_zero() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
-
-    // Set up first 32-bit value: 0x12345678
-    memory.insert(initial_fp, M31(0x5678).into())?;
-    memory.insert(initial_fp + M31(1), M31(0x1234).into())?;
-
-    // Set up second 32-bit value: 0x00000000
-    memory.insert(initial_fp + M31(2), M31(0x0000).into())?;
-    memory.insert(initial_fp + M31(3), M31(0x0000).into())?;
-
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreDivFpFp {
-        src0_off: M31(0),
-        src1_off: M31(2),
-        dst_off: M31(4),
-    };
-
-    let new_state = u32_store_div_fp_fp(&mut memory, state, &instruction)?;
-
-    // Expected: division by zero returns 0xFFFFFFFF
-    assert_eq!(memory.get_data(initial_fp + M31(4))?, M31(0xFFFF));
-    assert_eq!(memory.get_data(initial_fp + M31(5))?, M31(0xFFFF));
-    assert_eq!(new_state.pc, M31(1));
-
-    Ok(())
-}
-
-// ==================== U32 FP-IMM Operations Tests ====================
-
-#[test]
-fn test_u32_store_sub_fp_imm() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
-
-    // Set up 32-bit value: 0x9876ABCD
-    memory.insert(initial_fp, M31(0xABCD).into())?;
-    memory.insert(initial_fp + M31(1), M31(0x9876).into())?;
-
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreSubFpImm {
-        src_off: M31(0),
-        imm_hi: M31(0x1234),
-        imm_lo: M31(0x5678),
-        dst_off: M31(2),
-    };
-
-    let new_state = u32_store_sub_fp_imm(&mut memory, state, &instruction)?;
-
-    // Expected: 0x9876ABCD - 0x12345678 = 0x86425555
-    assert_eq!(memory.get_data(initial_fp + M31(2))?, M31(0x5555));
-    assert_eq!(memory.get_data(initial_fp + M31(3))?, M31(0x8642));
-    assert_eq!(new_state.pc, M31(2));
-
-    Ok(())
-}
-
-#[test]
-fn test_u32_store_mul_fp_imm() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
-
-    // Set up 32-bit value: 0x00001234
-    memory.insert(initial_fp, M31(0x1234).into())?;
-    memory.insert(initial_fp + M31(1), M31(0x0000).into())?;
-
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreMulFpImm {
-        src_off: M31(0),
-        imm_hi: M31(0x0000),
-        imm_lo: M31(0x5678),
-        dst_off: M31(2),
-    };
-
-    let new_state = u32_store_mul_fp_imm(&mut memory, state, &instruction)?;
-
-    // Expected: 0x00001234 * 0x00005678 = 0x06260060
-    assert_eq!(memory.get_data(initial_fp + M31(2))?, M31(0x0060));
-    assert_eq!(memory.get_data(initial_fp + M31(3))?, M31(0x0626));
-    assert_eq!(new_state.pc, M31(2));
-
-    Ok(())
-}
-
-#[test]
-fn test_u32_store_div_fp_imm() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
-
-    // Set up 32-bit value: 0x00006260
-    memory.insert(initial_fp, M31(0x6260).into())?;
-    memory.insert(initial_fp + M31(1), M31(0x0000).into())?;
-
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreDivFpImm {
-        src_off: M31(0),
-        imm_hi: M31(0x0000),
-        imm_lo: M31(0x0004),
-        dst_off: M31(2),
-    };
-
-    let new_state = u32_store_div_fp_imm(&mut memory, state, &instruction)?;
-
-    // Expected: 0x00006260 / 0x00000004 = 0x00001898
-    assert_eq!(memory.get_data(initial_fp + M31(2))?, M31(0x1898));
-    assert_eq!(memory.get_data(initial_fp + M31(3))?, M31(0x0000));
-    assert_eq!(new_state.pc, M31(2));
-
-    Ok(())
-}
-
-#[test]
-fn test_u32_store_div_fp_imm_by_zero() -> Result<(), InstructionExecutionError> {
-    let mut memory = Memory::default();
-    let initial_fp = M31(10);
-
-    // Set up 32-bit value: 0x12345678
-    memory.insert(initial_fp, M31(0x5678).into())?;
-    memory.insert(initial_fp + M31(1), M31(0x1234).into())?;
-
-    let state = State {
-        pc: M31(0),
-        fp: initial_fp,
-    };
-    let instruction = Instruction::U32StoreDivFpImm {
-        src_off: M31(0),
-        imm_hi: M31(0x0000),
-        imm_lo: M31(0x0000),
-        dst_off: M31(2),
-    };
-
-    let new_state = u32_store_div_fp_imm(&mut memory, state, &instruction)?;
-
-    // Expected: division by zero returns 0xFFFFFFFF
-    assert_eq!(memory.get_data(initial_fp + M31(2))?, M31(0xFFFF));
-    assert_eq!(memory.get_data(initial_fp + M31(3))?, M31(0xFFFF));
-    assert_eq!(new_state.pc, M31(2));
-
-    Ok(())
+#[should_panic(expected = "attempt to divide by zero")]
+fn test_u32_store_div_fp_fp_by_zero() {
+    let src0_value = 0x1234_5678;
+    let src1_value = 0x0000_0000;
+    let _ = run_u32_fp_fp_test(
+        src0_value,
+        src1_value,
+        Instruction::U32StoreDivFpFp {
+            src0_off: M31(0),
+            src1_off: M31(2),
+            dst_off: M31(4),
+        },
+        u32_store_div_fp_fp,
+        0,
+        4,
+        1,
+    );
 }


### PR DESCRIPTION
## Summary
- Implements all U32 arithmetic operations for Cairo-M VM runner with RISC-V-compliant behavior
- Adds comprehensive tests for all operations including edge cases

## Implementation Details

This PR implements all the U32 store operations defined in the Linear epic CORE-985:

### FP-FP Operations
- `U32StoreAddFpFp`: Addition of two U32 values from memory
- `U32StoreSubFpFp`: Subtraction of two U32 values from memory
- `U32StoreMulFpFp`: Multiplication of two U32 values from memory
- `U32StoreDivFpFp`: Division of two U32 values from memory

### FP-IMM Operations
- `U32StoreSubFpImm`: Subtraction with immediate value
- `U32StoreMulFpImm`: Multiplication with immediate value
- `U32StoreDivFpImm`: Division with immediate value

Note: `U32StoreAddFpImm` was already implemented.

### Key Design Decisions

1. **RISC-V-like operations**: All _except division_ operations follow RISC-V unsigned 32-bit arithmetic behavior:
   - All operations use wrapping arithmetic (no overflow traps)
   - Division by zero **panics instead**.

2. **Memory Layout**: U32 values are stored as two 16-bit M31 limbs in consecutive memory cells:
   - Limb0 (16 first bits) at `fp + offset`
   - Limb1 (16 last bits) at `fp + offset + 1`

3. **Validation**: All operations validate that limbs are within 16-bit range to prevent malformed data

## Test Plan
- [x] Unit tests for all U32 operations
- [x] Tests for edge cases (overflow, underflow, division by zero)
- [x] All tests pass (`cargo test -p cairo-m-runner`)
- [x] Code formatted with `trunk fmt`
- [x] Build succeeds (`cargo build -p cairo-m-runner`)

🤖 Generated with [Claude Code](https://claude.ai/code)