### PR TITLE
feat(runner): implement U32 bitwise AND, OR, XOR opcodes

### DIFF
--- a/crates/common/src/instruction.rs
+++ b/crates/common/src/instruction.rs
@@ -279,7 +279,17 @@ define_instruction!(
     U32StoreGtFpImm = 32, 4, fields: [src_off, imm_lo, imm_hi, dst_off], size: 5, operands: [U32, U32];  // [fp + dst_off] = u32([fp + src_off], [fp + src_off + 1]) > u32(imm_lo, imm_hi)
     U32StoreGeFpImm = 33, 4, fields: [src_off, imm_lo, imm_hi, dst_off], size: 5, operands: [U32, U32];  // [fp + dst_off] = u32([fp + src_off], [fp + src_off + 1]) >= u32(imm_lo, imm_hi)
     U32StoreLtFpImm = 34, 4, fields: [src_off, imm_lo, imm_hi, dst_off], size: 5, operands: [U32, U32];  // [fp + dst_off] = u32([fp + src_off], [fp + src_off + 1]) < u32(imm_lo, imm_hi)
-    U32StoreLeFpImm = 35, 4, fields: [src_off, imm_lo, imm_hi, dst_off], size: 5, operands: [U32, U32]  // [fp + dst_off] = u32([fp + src_off], [fp + src_off + 1]) <= u32(imm_lo, imm_hi)
+    U32StoreLeFpImm = 35, 4, fields: [src_off, imm_lo, imm_hi, dst_off], size: 5, operands: [U32, U32];  // [fp + dst_off] = u32([fp + src_off], [fp + src_off + 1]) <= u32(imm_lo, imm_hi)
+
+    // U32 Bitwise operations
+    U32StoreAndFpFp = 36, 5, fields: [src0_off, src1_off, dst_off], size: 4, operands: [U32, U32, U32];                // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src0_off], [fp + src0_off + 1]) & u32([fp + src1_off], [fp + src1_off + 1])
+    U32StoreOrFpFp = 37, 5, fields: [src0_off, src1_off, dst_off], size: 4, operands: [U32, U32, U32];                 // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src0_off], [fp + src0_off + 1]) | u32([fp + src1_off], [fp + src1_off + 1])
+    U32StoreXorFpFp = 38, 5, fields: [src0_off, src1_off, dst_off], size: 4, operands: [U32, U32, U32];                // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src0_off], [fp + src0_off + 1]) ^ u32([fp + src1_off], [fp + src1_off + 1])
+
+    // U32 Bitwise operations with immediate
+    U32StoreAndFpImm = 39, 4, fields: [src_off, imm_lo, imm_hi, dst_off], size: 5, operands: [U32, U32];  // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src_off], [fp + src_off + 1]) & u32(imm_lo, imm_hi)
+    U32StoreOrFpImm = 40, 4, fields: [src_off, imm_lo, imm_hi, dst_off], size: 5, operands: [U32, U32];  // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src_off], [fp + src_off + 1]) | u32(imm_lo, imm_hi)
+    U32StoreXorFpImm = 41, 4, fields: [src_off, imm_lo, imm_hi, dst_off], size: 5, operands: [U32, U32]  // u32([fp + dst_off], [fp + dst_off + 1]) = u32([fp + src_off], [fp + src_off + 1]) ^ u32(imm_lo, imm_hi)
 );
 
 impl From<Instruction> for SmallVec<[M31; INSTRUCTION_MAX_SIZE]> {

--- a/crates/common/tests/instruction_tests.rs
+++ b/crates/common/tests/instruction_tests.rs
@@ -757,6 +757,82 @@ fn test_try_from_smallvec() {
             },
             "U32StoreLeFpImm instruction",
         ),
+        // U32 Bitwise operations
+        (
+            smallvec![M31::from(36), M31::from(1), M31::from(2), M31::from(3)],
+            Instruction::U32StoreAndFpFp {
+                src0_off: M31::from(1),
+                src1_off: M31::from(2),
+                dst_off: M31::from(3),
+            },
+            "U32StoreAndFpFp instruction",
+        ),
+        (
+            smallvec![M31::from(37), M31::from(1), M31::from(2), M31::from(3)],
+            Instruction::U32StoreOrFpFp {
+                src0_off: M31::from(1),
+                src1_off: M31::from(2),
+                dst_off: M31::from(3),
+            },
+            "U32StoreOrFpFp instruction",
+        ),
+        (
+            smallvec![M31::from(38), M31::from(1), M31::from(2), M31::from(3)],
+            Instruction::U32StoreXorFpFp {
+                src0_off: M31::from(1),
+                src1_off: M31::from(2),
+                dst_off: M31::from(3),
+            },
+            "U32StoreXorFpFp instruction",
+        ),
+        (
+            smallvec![
+                M31::from(39),
+                M31::from(1),
+                M31::from(0x1234),
+                M31::from(0x5678),
+                M31::from(3)
+            ],
+            Instruction::U32StoreAndFpImm {
+                src_off: M31::from(1),
+                imm_lo: M31::from(0x1234),
+                imm_hi: M31::from(0x5678),
+                dst_off: M31::from(3),
+            },
+            "U32StoreAndFpImm instruction",
+        ),
+        (
+            smallvec![
+                M31::from(40),
+                M31::from(1),
+                M31::from(0x1234),
+                M31::from(0x5678),
+                M31::from(3)
+            ],
+            Instruction::U32StoreOrFpImm {
+                src_off: M31::from(1),
+                imm_lo: M31::from(0x1234),
+                imm_hi: M31::from(0x5678),
+                dst_off: M31::from(3),
+            },
+            "U32StoreOrFpImm instruction",
+        ),
+        (
+            smallvec![
+                M31::from(41),
+                M31::from(1),
+                M31::from(0x1234),
+                M31::from(0x5678),
+                M31::from(3)
+            ],
+            Instruction::U32StoreXorFpImm {
+                src_off: M31::from(1),
+                imm_lo: M31::from(0x1234),
+                imm_hi: M31::from(0x5678),
+                dst_off: M31::from(3),
+            },
+            "U32StoreXorFpImm instruction",
+        ),
     ];
 
     assert_eq!(test_cases.len(), MAX_OPCODE as usize + 1);

--- a/crates/runner/src/vm/instructions/mod.rs
+++ b/crates/runner/src/vm/instructions/mod.rs
@@ -178,6 +178,12 @@ pub fn opcode_to_instruction_fn(op: M31) -> Result<InstructionFn, InstructionErr
         U32_STORE_GE_FP_IMM => u32_store_ge_fp_imm,
         U32_STORE_LT_FP_IMM => u32_store_lt_fp_imm,
         U32_STORE_LE_FP_IMM => u32_store_le_fp_imm,
+        U32_STORE_AND_FP_FP => u32_store_and_fp_fp,
+        U32_STORE_OR_FP_FP => u32_store_or_fp_fp,
+        U32_STORE_XOR_FP_FP => u32_store_xor_fp_fp,
+        U32_STORE_AND_FP_IMM => u32_store_and_fp_imm,
+        U32_STORE_OR_FP_IMM => u32_store_or_fp_imm,
+        U32_STORE_XOR_FP_IMM => u32_store_xor_fp_imm,
         _ => return Err(InstructionError::InvalidOpcode(op)),
     };
     Ok(f)

--- a/crates/runner/src/vm/instructions/store.rs
+++ b/crates/runner/src/vm/instructions/store.rs
@@ -388,6 +388,20 @@ impl_u32_cmp_op_fp_imm!(u32_store_ge_fp_imm, U32StoreGeFpImm, |a, b| a >= b);
 impl_u32_cmp_op_fp_imm!(u32_store_lt_fp_imm, U32StoreLtFpImm, |a, b| a < b);
 impl_u32_cmp_op_fp_imm!(u32_store_le_fp_imm, U32StoreLeFpImm, |a, b| a <= b);
 
+// -------------------------------------------------------------------------------------------------
+// U32 Bitwise operations
+// -------------------------------------------------------------------------------------------------
+
+// -- U32 Bitwise FP-FP variants ------------------------------------------
+impl_u32_store_bin_op_fp_fp!(u32_store_and_fp_fp, U32StoreAndFpFp, |a, b| a & b);
+impl_u32_store_bin_op_fp_fp!(u32_store_or_fp_fp, U32StoreOrFpFp, |a, b| a | b);
+impl_u32_store_bin_op_fp_fp!(u32_store_xor_fp_fp, U32StoreXorFpFp, |a, b| a ^ b);
+
+// -- U32 Bitwise FP-IMM variants ------------------------------------------
+impl_u32_store_bin_op_fp_imm!(u32_store_and_fp_imm, U32StoreAndFpImm, |a, b| a & b);
+impl_u32_store_bin_op_fp_imm!(u32_store_or_fp_imm, U32StoreOrFpImm, |a, b| a | b);
+impl_u32_store_bin_op_fp_imm!(u32_store_xor_fp_imm, U32StoreXorFpImm, |a, b| a ^ b);
+
 #[cfg(test)]
 #[path = "./store_tests.rs"]
 mod store_tests;

--- a/crates/runner/src/vm/instructions/store_tests.rs
+++ b/crates/runner/src/vm/instructions/store_tests.rs
@@ -668,3 +668,126 @@ proptest! {
         }));
     }
 }
+
+// -----------------------------------------------------------------------------
+// U32 Bitwise FP-FP instruction tests
+// -----------------------------------------------------------------------------
+
+proptest! {
+    #[test]
+    fn test_u32_store_and_fp_fp(src0_value: u32, src1_value: u32) {
+        let expected_res = src0_value & src1_value;
+        run_u32_fp_fp_test(
+            src0_value,
+            src1_value,
+            Instruction::U32StoreAndFpFp {
+                src0_off: M31(0),
+                src1_off: M31(2),
+                dst_off: M31(4),
+            },
+            u32_store_and_fp_fp,
+            expected_res,
+            4,
+            1,
+        ).unwrap();
+    }
+
+    #[test]
+    fn test_u32_store_or_fp_fp(src0_value: u32, src1_value: u32) {
+        let expected_res = src0_value | src1_value;
+        run_u32_fp_fp_test(
+            src0_value,
+            src1_value,
+            Instruction::U32StoreOrFpFp {
+                src0_off: M31(0),
+                src1_off: M31(2),
+                dst_off: M31(4),
+            },
+            u32_store_or_fp_fp,
+            expected_res,
+            4,
+            1,
+        ).unwrap();
+    }
+
+    #[test]
+    fn test_u32_store_xor_fp_fp(src0_value: u32, src1_value: u32) {
+        let expected_res = src0_value ^ src1_value;
+        run_u32_fp_fp_test(
+            src0_value,
+            src1_value,
+            Instruction::U32StoreXorFpFp {
+                src0_off: M31(0),
+                src1_off: M31(2),
+                dst_off: M31(4),
+            },
+            u32_store_xor_fp_fp,
+            expected_res,
+            4,
+            1,
+        ).unwrap();
+    }
+}
+
+// -----------------------------------------------------------------------------
+// U32 Bitwise FP-IMM instruction tests
+// -----------------------------------------------------------------------------
+
+proptest! {
+    #[test]
+    fn test_u32_store_and_fp_imm(src_value: u32, imm_val_lo in 0..=u16::MAX as u32, imm_val_hi in 0..=u16::MAX as u32) {
+        let imm_value: u32 = (imm_val_hi << U32_LIMB_BITS) | imm_val_lo;
+        let expected_res = src_value & imm_value;
+        run_u32_fp_imm_test(
+            src_value,
+            Instruction::U32StoreAndFpImm {
+                src_off: M31(0),
+                imm_lo: M31(imm_val_lo),
+                imm_hi: M31(imm_val_hi),
+                dst_off: M31(2),
+            },
+            u32_store_and_fp_imm,
+            expected_res,
+            2,
+            2,
+        ).unwrap();
+    }
+
+    #[test]
+    fn test_u32_store_or_fp_imm(src_value: u32, imm_val_lo in 0..=u16::MAX as u32, imm_val_hi in 0..=u16::MAX as u32) {
+        let imm_value: u32 = (imm_val_hi << U32_LIMB_BITS) | imm_val_lo;
+        let expected_res = src_value | imm_value;
+        run_u32_fp_imm_test(
+            src_value,
+            Instruction::U32StoreOrFpImm {
+                src_off: M31(0),
+                imm_lo: M31(imm_val_lo),
+                imm_hi: M31(imm_val_hi),
+                dst_off: M31(2),
+            },
+            u32_store_or_fp_imm,
+            expected_res,
+            2,
+            2,
+        ).unwrap();
+    }
+
+    #[test]
+    fn test_u32_store_xor_fp_imm(src_value: u32, imm_val_lo in 0..=u16::MAX as u32, imm_val_hi in 0..=u16::MAX as u32) {
+        let imm_value: u32 = (imm_val_hi << U32_LIMB_BITS) | imm_val_lo;
+        let expected_res = src_value ^ imm_value;
+        run_u32_fp_imm_test(
+            src_value,
+            Instruction::U32StoreXorFpImm {
+                src_off: M31(0),
+                imm_lo: M31(imm_val_lo),
+                imm_hi: M31(imm_val_hi),
+                dst_off: M31(2),
+            },
+            u32_store_xor_fp_imm,
+            expected_res,
+            2,
+            2,
+        ).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements bitwise operations for U32 types in the Cairo-M runner, adding support for AND, OR, and XOR operations following the same pattern as the U32 comparison opcodes from PR #228.

### New Opcodes (36-41)
- `U32StoreAndFpFp` - Bitwise AND between two U32 values from memory
- `U32StoreOrFpFp` - Bitwise OR between two U32 values from memory
- `U32StoreXorFpFp` - Bitwise XOR between two U32 values from memory
- `U32StoreAndFpImm` - Bitwise AND with immediate value
- `U32StoreOrFpImm` - Bitwise OR with immediate value
- `U32StoreXorFpImm` - Bitwise XOR with immediate value

### Implementation Details
- Added 6 new instruction definitions in `common/instruction.rs` with proper opcodes and field layouts
- Implemented bitwise operations in `runner/vm/instructions/store.rs` using existing macros
- Registered new opcodes in the instruction dispatch table
- Added comprehensive proptest-based tests for all new operations

### Testing
All tests pass including:
- Instruction serialization/deserialization tests
- Bitwise operation execution tests with property-based testing
- Opcode registration validation

## Test Plan
- [x] All existing tests continue to pass
- [x] New proptest-based tests for bitwise operations
- [x] Instruction roundtrip tests for new opcodes
- [x] Verified MAX_OPCODE is correctly updated to 41