### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/crates/compiler/CLAUDE.md
+++ b/crates/compiler/CLAUDE.md
@@ -5,7 +5,7 @@ code in this repository.
 
 You are running in an environment where `ast-grep` is installed (`sg`); whenever
 a search requires syntax-aware or structural matching in rust files, default to
-`sg --lang rust - p <pattern>` (or set --lang appropriately) and avoid failling
+`sg --lang rust - p <pattern>` (or set --lang appropriately) and avoid failing
 back to text-only tools like `rg` or `grep` unless requested explicitly.
 
 ## Building and Running the Compiler

--- a/crates/prover/src/adapter/mod.rs
+++ b/crates/prover/src/adapter/mod.rs
@@ -135,7 +135,7 @@ where
     memory.update_multiplicities(&public_address_ranges);
 
     // Assert that the keys are the same for both initial_memory and final_memory
-    // This is a sanity check that uses memory so it's desactivated in release builds.
+    // This is a sanity check that uses memory so it's deactivated in release builds.
     #[cfg(debug_assertions)]
     {
         let initial_keys: std::collections::HashSet<_> = memory.initial_memory.keys().collect();

--- a/crates/prover/src/preprocessed/range_check/range_check_20.rs
+++ b/crates/prover/src/preprocessed/range_check/range_check_20.rs
@@ -49,7 +49,7 @@ impl Claim {
     ///
     /// lookup_data contains all range_checks made in other components during main trace generation
     /// write_trace creates a column with all values from 0 to 2**20 - 1 included and counts how many times other components
-    /// have range_checked each values: every occurence of a range_checked value increases by 1 its multiplicity.
+    /// have range_checked each values: every occurrence of a range_checked value increases by 1 its multiplicity.
     /// These multiplicities are stored in a new column.
     pub fn write_trace<'a, MC: MerkleChannel>(
         lookup_data: impl ParallelIterator<Item = &'a PackedM31>,


### PR DESCRIPTION


## Description

This PR fixes three minor typos across the codebase:

- **`crates/compiler/CLAUDE.md`**: Fix "failling" → "failing"
- **`crates/prover/src/adapter/mod.rs`**: Fix "desactivated" → "deactivated" in comment
- **`crates/prover/src/preprocessed/range_check/range_check_20.rs`**: Fix "occurence" → "occurrence" in doc comment

