### PR TITLE
feat: add cargo-cairo-m CLI tool for project scaffolding

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -41,6 +41,7 @@ lint:
     - linters: [ALL]
       paths:
         - "**/*.snap"
+        - "crates/cargo-cairo-m/templates"
 actions:
   enabled:
     - trunk-announce

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-cairo-m"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "thiserror",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "crates/cairo-m-ls",
   "crates/wasm",
   "crates/test_utils",
+  "crates/cargo-cairo-m",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,34 @@ The main design choices are
 To get started with Cairo M, read the
 [getting-started](./docs/getting-started.md)
 
+### Creating a New Cairo-M Project
+
+Cairo-M provides a CLI tool to quickly scaffold new projects with integrated
+testing:
+
+```bash
+# Build and install cargo-cairo-m
+cargo install --path crates/cargo-cairo-m
+
+# Create a new Cairo-M project
+cargo-cairo-m init my-project
+
+# Navigate to your project and run tests
+cd my-project
+cargo test
+```
+
+The generated project includes:
+
+- A sample Cairo-M fibonacci implementation
+- Rust tests that use `run_cairo_program` for differential testing
+- Pre-configured dependencies on cairo-m crates
+- Automatic RUSTFLAGS configuration for optimal performance
+- A README with common commands
+
+This setup allows you to write Cairo-M code and test it against Rust reference
+implementations using familiar Rust testing tools.
+
 ## Getting Started
 
 To get started with Cairo M, clone the repository and build the project using

--- a/crates/cargo-cairo-m/Cargo.toml
+++ b/crates/cargo-cairo-m/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cargo-cairo-m"
+version = "0.1.0"
+edition = "2021"
+authors = ["Cairo-M Team"]
+description = "Cargo subcommand for creating and managing Cairo-M projects"
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "cargo-cairo-m"
+path = "src/main.rs"
+
+[dependencies]
+clap.workspace = true
+anyhow.workspace = true
+thiserror.workspace = true

--- a/crates/cargo-cairo-m/Cargo.toml
+++ b/crates/cargo-cairo-m/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "cargo-cairo-m"
 version = "0.1.0"
-edition = "2021"
-authors = ["Cairo-M Team"]
-description = "Cargo subcommand for creating and managing Cairo-M projects"
+edition = "2024"
+description = "Binary for creating Cairo-M projects from a default template"
 license = "MIT OR Apache-2.0"
 
 [[bin]]

--- a/crates/cargo-cairo-m/src/main.rs
+++ b/crates/cargo-cairo-m/src/main.rs
@@ -38,14 +38,24 @@ fn init_project(name: &str) -> Result<()> {
         anyhow::bail!("Project name cannot be empty");
     }
 
-    // Create project directory
+    // Support paths
     let project_path = Path::new(name);
+    let project_name = project_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(name);
+
     if project_path.exists() {
-        anyhow::bail!("Directory '{}' already exists", name);
+        anyhow::bail!("Directory '{}' already exists", project_path.display());
     }
 
-    fs::create_dir(project_path)
-        .with_context(|| format!("Failed to create project directory '{}'", name))?;
+    // Create all parent directories if needed
+    fs::create_dir_all(project_path).with_context(|| {
+        format!(
+            "Failed to create project directory '{}'",
+            project_path.display()
+        )
+    })?;
 
     // Create directory structure
     fs::create_dir(project_path.join("src")).context("Failed to create src directory")?;
@@ -53,251 +63,83 @@ fn init_project(name: &str) -> Result<()> {
     fs::create_dir(project_path.join(".cargo")).context("Failed to create .cargo directory")?;
 
     // Write template files
-    write_cargo_toml(project_path, name)?;
-    write_cairom_toml(project_path, name)?;
+    write_cargo_toml(project_path, project_name)?;
+    write_cairom_toml(project_path, project_name)?;
     write_gitignore(project_path)?;
     write_rust_toolchain(project_path)?;
     write_cargo_config(project_path)?;
-    write_readme(project_path, name)?;
+    write_readme(project_path, project_name)?;
     write_lib_rs(project_path)?;
     write_fibonacci_cm(project_path)?;
     write_integration_test(project_path)?;
 
-    println!("✅ Created new Cairo-M project '{}'", name);
+    println!(
+        "✅ Created new Cairo-M project '{}'",
+        project_path.display()
+    );
     println!("\nTo get started:");
-    println!("  cd {}", name);
+    println!("  cd {}", project_path.display());
     println!("  cargo test");
 
     Ok(())
 }
 
 fn write_cairom_toml(project_path: &Path, name: &str) -> Result<()> {
-    let content = format!(
-        r#"# Cairo-M project manifest file
-name = "{}"
-version = "0.1.0"
-entry_point = "fibonacci.cm"
-"#,
-        name
-    );
-
+    let template = include_str!("../templates/cairom.toml");
+    let content = template.replace("{{name}}", name);
     fs::write(project_path.join("cairom.toml"), content).context("Failed to write cairom.toml")?;
     Ok(())
 }
 
 fn write_cargo_toml(project_path: &Path, name: &str) -> Result<()> {
-    let content = format!(
-        r#"[package]
-name = "{}"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-
-[dev-dependencies]
-cairo-m-common = {{ git = "https://github.com/kkrt-labs/cairo-m" }}
-cairo-m-runner = {{ git = "https://github.com/kkrt-labs/cairo-m" }}
-cairo-m-compiler = {{ git = "https://github.com/kkrt-labs/cairo-m" }}
-anyhow = "1.0"
-proptest = "1.0"
-"#,
-        name
-    );
-
+    let template = include_str!("../templates/Cargo.toml");
+    let content = template.replace("{{name}}", name);
     fs::write(project_path.join("Cargo.toml"), content).context("Failed to write Cargo.toml")?;
     Ok(())
 }
 
 fn write_gitignore(project_path: &Path) -> Result<()> {
-    let content = r#"/target
-/Cargo.lock
-**/*.rs.bk
-*.pdb
-.DS_Store
-"#;
-
+    let content = include_str!("../templates/gitignore");
     fs::write(project_path.join(".gitignore"), content).context("Failed to write .gitignore")?;
     Ok(())
 }
 
 fn write_rust_toolchain(project_path: &Path) -> Result<()> {
-    let content = r#"[toolchain]
-channel = "nightly-2025-04-06"
-"#;
-
+    let content = include_str!("../templates/rust-toolchain.toml");
     fs::write(project_path.join("rust-toolchain.toml"), content)
         .context("Failed to write rust-toolchain.toml")?;
     Ok(())
 }
 
 fn write_cargo_config(project_path: &Path) -> Result<()> {
-    let content = r#"[target.'cfg(target_os = "macos")']
-rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/opt/lld/bin/ld64.lld", "-C", "target-cpu=native"]
-
-[target.'cfg(not(target_os = "macos"))']
-rustflags = ["-C", "target-cpu=native"]
-"#;
-
+    let content = include_str!("../templates/cargo-config.toml");
     fs::write(project_path.join(".cargo/config.toml"), content)
         .context("Failed to write .cargo/config.toml")?;
     Ok(())
 }
 
 fn write_readme(project_path: &Path, name: &str) -> Result<()> {
-    let content = format!(
-        r#"# {}
-
-A Cairo-M project with integrated Rust testing.
-
-## Project Structure
-
-- `cairom.toml` - Cairo-M project manifest file
-- `src/` - Cairo-M source files
-  - `fibonacci.cm` - Example fibonacci implementation
-- `tests/` - Rust integration tests
-- `Cargo.toml` - Rust project configuration
-
-## Prerequisites
-
-### macOS Users
-You need to have LLVM installed:
-```bash
-brew install llvm
-```
-
-## Common Commands
-
-### Run all tests
-```bash
-cargo test
-```
-
-### Run a specific test
-```bash
-cargo test test_fibonacci
-```
-
-### Show test output
-```bash
-cargo test -- --nocapture
-```
-
-Note: The required RUSTFLAGS are automatically configured in `.cargo/config.toml`
-
-## Adding New Cairo-M Files
-
-1. Create a new `.cm` file in the `src/` directory
-2. If needed, update the `entry_point` in `cairom.toml` to point to your main file
-3. Write a corresponding test in `tests/`
-4. Use `compile_cairo` with the source directory path (e.g., "src/")
-5. Use `run_cairo_program` to execute your compiled Cairo-M code
-6. Compare results with Rust reference implementations
-
-## Resources
-
-- [Cairo-M Documentation](https://github.com/kkrt-labs/cairo-m)
-- [Cairo-M Language Reference](https://github.com/kkrt-labs/cairo-m/docs)
-"#,
-        name
-    );
-
+    let template = include_str!("../templates/README.md");
+    let content = template.replace("{{name}}", name);
     fs::write(project_path.join("README.md"), content).context("Failed to write README.md")?;
     Ok(())
 }
 
 fn write_lib_rs(project_path: &Path) -> Result<()> {
-    let content = "// This file is required by Cargo but can remain empty\n";
-
+    let content = include_str!("../templates/lib.rs");
     fs::write(project_path.join("src/lib.rs"), content).context("Failed to write src/lib.rs")?;
     Ok(())
 }
 
 fn write_fibonacci_cm(project_path: &Path) -> Result<()> {
-    let content = r#"// Iterative Fibonacci implementation
-fn fibonacci(n: felt) -> felt {
-    let current = 0;
-    let next = 1;
-
-    let counter = 0;
-    while (counter != n) {
-        let new_next = current + next;
-        current = next;
-        next = new_next;
-        counter = counter + 1;
-    }
-
-    return current;
-}
-"#;
-
+    let content = include_str!("../templates/fibonacci.cm");
     fs::write(project_path.join("src/fibonacci.cm"), content)
         .context("Failed to write src/fibonacci.cm")?;
     Ok(())
 }
 
 fn write_integration_test(project_path: &Path) -> Result<()> {
-    let content = r#"use cairo_m_compiler::{compile_cairo, CompilerOptions};
-use cairo_m_runner::{run_cairo_program, RunnerOptions};
-use cairo_m_common::{InputValue, CairoMValue};
-use proptest::prelude::*;
-
-// Rust reference implementation (iterative)
-fn fibonacci_rust(n: u32) -> u32 {
-    let mut current = 0;
-    let mut next = 1;
-    for _ in 0..n {
-        let new_next = current + next;
-        current = next;
-        next = new_next;
-    }
-    current
-}
-
-// Helper function to run Cairo-M program and compare with Rust
-fn test_fibonacci_value(n: u32) -> anyhow::Result<()> {
-    // Compile the Cairo-M source
-    let source = std::fs::read_to_string("src/fibonacci.cm")?;
-    let output = compile_cairo(
-        source,
-        "src/".to_string(),
-        CompilerOptions::default()
-    )?;
-
-    // Prepare arguments
-    let args = vec![InputValue::Number(n as i64)];
-
-    // Run the Cairo-M program
-    let result = run_cairo_program(
-        &output.program,
-        "fibonacci",
-        &args,
-        RunnerOptions::default()
-    )?;
-
-    // Get the Cairo-M result
-    let cairo_result = match &result.return_values[0] {
-        CairoMValue::Felt(value) => value.0 as u32,
-        _ => panic!("Expected Felt return value"),
-    };
-
-    // Compare with Rust implementation
-    let rust_result = fibonacci_rust(n);
-    assert_eq!(
-        cairo_result, rust_result,
-        "Mismatch for fibonacci({n}): Cairo-M returned {cairo_result}, Rust returned {rust_result}"
-    );
-
-    Ok(())
-}
-
-proptest! {
-    #[test]
-    fn test_fibonacci_property(n in 0u32..30) {
-        test_fibonacci_value(n).unwrap();
-    }
-}
-"#;
-
+    let content = include_str!("../templates/integration_test.rs");
     fs::write(project_path.join("tests/integration_test.rs"), content)
         .context("Failed to write tests/integration_test.rs")?;
     Ok(())

--- a/crates/cargo-cairo-m/src/main.rs
+++ b/crates/cargo-cairo-m/src/main.rs
@@ -54,6 +54,7 @@ fn init_project(name: &str) -> Result<()> {
 
     // Write template files
     write_cargo_toml(project_path, name)?;
+    write_cairom_toml(project_path, name)?;
     write_gitignore(project_path)?;
     write_rust_toolchain(project_path)?;
     write_cargo_config(project_path)?;
@@ -67,6 +68,20 @@ fn init_project(name: &str) -> Result<()> {
     println!("  cd {}", name);
     println!("  cargo test");
 
+    Ok(())
+}
+
+fn write_cairom_toml(project_path: &Path, name: &str) -> Result<()> {
+    let content = format!(
+        r#"# Cairo-M project manifest file
+name = "{}"
+version = "0.1.0"
+entry_point = "fibonacci.cm"
+"#,
+        name
+    );
+
+    fs::write(project_path.join("cairom.toml"), content).context("Failed to write cairom.toml")?;
     Ok(())
 }
 
@@ -136,7 +151,9 @@ A Cairo-M project with integrated Rust testing.
 
 ## Project Structure
 
+- `cairom.toml` - Cairo-M project manifest file
 - `src/` - Cairo-M source files
+  - `fibonacci.cm` - Example fibonacci implementation
 - `tests/` - Rust integration tests
 - `Cargo.toml` - Rust project configuration
 
@@ -170,9 +187,11 @@ Note: The required RUSTFLAGS are automatically configured in `.cargo/config.toml
 ## Adding New Cairo-M Files
 
 1. Create a new `.cm` file in the `src/` directory
-2. Write a corresponding test in `tests/`
-3. Use `run_cairo_program` to execute your Cairo-M code
-4. Compare results with Rust reference implementations
+2. If needed, update the `entry_point` in `cairom.toml` to point to your main file
+3. Write a corresponding test in `tests/`
+4. Use `compile_cairo` with the source directory path (e.g., "src/")
+5. Use `run_cairo_program` to execute your compiled Cairo-M code
+6. Compare results with Rust reference implementations
 
 ## Resources
 
@@ -240,7 +259,7 @@ fn test_fibonacci_value(n: u32) -> anyhow::Result<()> {
     let source = std::fs::read_to_string("src/fibonacci.cm")?;
     let output = compile_cairo(
         source,
-        "fibonacci.cm".to_string(),
+        "src/".to_string(),
         CompilerOptions::default()
     )?;
 

--- a/crates/cargo-cairo-m/src/main.rs
+++ b/crates/cargo-cairo-m/src/main.rs
@@ -1,0 +1,272 @@
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use std::fs;
+use std::path::Path;
+
+#[derive(Parser)]
+#[command(
+    name = "cargo-cairo-m",
+    bin_name = "cargo-cairo-m",
+    version,
+    about = "Tool for creating and managing Cairo-M projects"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Initialize a new Cairo-M project
+    Init {
+        /// Name of the project to create
+        name: String,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Init { name } => init_project(&name),
+    }
+}
+
+fn init_project(name: &str) -> Result<()> {
+    // Validate project name
+    if name.is_empty() {
+        anyhow::bail!("Project name cannot be empty");
+    }
+
+    // Create project directory
+    let project_path = Path::new(name);
+    if project_path.exists() {
+        anyhow::bail!("Directory '{}' already exists", name);
+    }
+
+    fs::create_dir(project_path)
+        .with_context(|| format!("Failed to create project directory '{}'", name))?;
+
+    // Create directory structure
+    fs::create_dir(project_path.join("src")).context("Failed to create src directory")?;
+    fs::create_dir(project_path.join("tests")).context("Failed to create tests directory")?;
+    fs::create_dir(project_path.join(".cargo")).context("Failed to create .cargo directory")?;
+
+    // Write template files
+    write_cargo_toml(project_path, name)?;
+    write_gitignore(project_path)?;
+    write_rust_toolchain(project_path)?;
+    write_cargo_config(project_path)?;
+    write_readme(project_path, name)?;
+    write_lib_rs(project_path)?;
+    write_fibonacci_cm(project_path)?;
+    write_integration_test(project_path)?;
+
+    println!("✅ Created new Cairo-M project '{}'", name);
+    println!("\nTo get started:");
+    println!("  cd {}", name);
+    println!("  cargo test");
+
+    Ok(())
+}
+
+fn write_cargo_toml(project_path: &Path, name: &str) -> Result<()> {
+    let content = format!(
+        r#"[package]
+name = "{}"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[dev-dependencies]
+cairo-m-common = {{ git = "https://github.com/kkrt-labs/cairo-m" }}
+cairo-m-runner = {{ git = "https://github.com/kkrt-labs/cairo-m" }}
+cairo-m-compiler = {{ git = "https://github.com/kkrt-labs/cairo-m" }}
+anyhow = "1.0"
+"#,
+        name
+    );
+
+    fs::write(project_path.join("Cargo.toml"), content).context("Failed to write Cargo.toml")?;
+    Ok(())
+}
+
+fn write_gitignore(project_path: &Path) -> Result<()> {
+    let content = r#"/target
+/Cargo.lock
+**/*.rs.bk
+*.pdb
+.DS_Store
+"#;
+
+    fs::write(project_path.join(".gitignore"), content).context("Failed to write .gitignore")?;
+    Ok(())
+}
+
+fn write_rust_toolchain(project_path: &Path) -> Result<()> {
+    let content = r#"[toolchain]
+channel = "nightly-2025-04-06"
+"#;
+
+    fs::write(project_path.join("rust-toolchain.toml"), content)
+        .context("Failed to write rust-toolchain.toml")?;
+    Ok(())
+}
+
+fn write_cargo_config(project_path: &Path) -> Result<()> {
+    let content = r#"[target.'cfg(target_os = "macos")']
+rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/opt/lld/bin/ld64.lld", "-C", "target-cpu=native"]
+
+[target.'cfg(not(target_os = "macos"))']
+rustflags = ["-C", "target-cpu=native"]
+"#;
+
+    fs::write(project_path.join(".cargo/config.toml"), content)
+        .context("Failed to write .cargo/config.toml")?;
+    Ok(())
+}
+
+fn write_readme(project_path: &Path, name: &str) -> Result<()> {
+    let content = format!(
+        r#"# {}
+
+A Cairo-M project with integrated Rust testing.
+
+## Project Structure
+
+- `src/` - Cairo-M source files
+- `tests/` - Rust integration tests
+- `Cargo.toml` - Rust project configuration
+
+## Prerequisites
+
+### macOS Users
+You need to have LLVM installed:
+```bash
+brew install llvm
+```
+
+## Common Commands
+
+### Run all tests
+```bash
+cargo test
+```
+
+### Run a specific test
+```bash
+cargo test test_fibonacci
+```
+
+### Show test output
+```bash
+cargo test -- --nocapture
+```
+
+Note: The required RUSTFLAGS are automatically configured in `.cargo/config.toml`
+
+## Adding New Cairo-M Files
+
+1. Create a new `.cm` file in the `src/` directory
+2. Write a corresponding test in `tests/`
+3. Use `run_cairo_program` to execute your Cairo-M code
+4. Compare results with Rust reference implementations
+
+## Resources
+
+- [Cairo-M Documentation](https://github.com/kkrt-labs/cairo-m)
+- [Cairo-M Language Reference](https://github.com/kkrt-labs/cairo-m/docs)
+"#,
+        name
+    );
+
+    fs::write(project_path.join("README.md"), content).context("Failed to write README.md")?;
+    Ok(())
+}
+
+fn write_lib_rs(project_path: &Path) -> Result<()> {
+    let content = "// This file is required by Cargo but can remain empty\n";
+
+    fs::write(project_path.join("src/lib.rs"), content).context("Failed to write src/lib.rs")?;
+    Ok(())
+}
+
+fn write_fibonacci_cm(project_path: &Path) -> Result<()> {
+    let content = r#"fn fibonacci(n: felt) -> felt {
+    if (n == 0) {
+        return 0;
+    }
+    if (n == 1) {
+        return 1;
+    }
+    return fibonacci(n - 1) + fibonacci(n - 2);
+}
+"#;
+
+    fs::write(project_path.join("src/fibonacci.cm"), content)
+        .context("Failed to write src/fibonacci.cm")?;
+    Ok(())
+}
+
+fn write_integration_test(project_path: &Path) -> Result<()> {
+    let content = r#"use cairo_m_compiler::{compile_cairo, CompilerOptions};
+use cairo_m_runner::{run_cairo_program, RunnerOptions};
+use cairo_m_common::{InputValue, CairoMValue};
+
+// Rust reference implementation
+fn fibonacci_rust(n: u32) -> u32 {
+    if n == 0 {
+        return 0;
+    }
+    if n == 1 {
+        return 1;
+    }
+    fibonacci_rust(n - 1) + fibonacci_rust(n - 2)
+}
+
+#[test]
+fn test_fibonacci() -> anyhow::Result<()> {
+    // Compile the Cairo-M source
+    let source = std::fs::read_to_string("src/fibonacci.cm")?;
+    let output = compile_cairo(
+        source,
+        "fibonacci.cm".to_string(),
+        CompilerOptions::default()
+    )?;
+
+    // Test multiple values
+    for n in 0..=10 {
+        // Prepare arguments
+        let args = vec![InputValue::Number(n as i64)];
+
+        // Run the Cairo-M program
+        let result = run_cairo_program(
+            &output.program,
+            "fibonacci",
+            &args,
+            RunnerOptions::default()
+        )?;
+
+        // Get the Cairo-M result
+        let cairo_result = match &result.return_values[0] {
+            CairoMValue::Felt(value) => value.0 as u32,
+            _ => panic!("Expected Felt return value"),
+        };
+
+        // Compare with Rust implementation
+        let rust_result = fibonacci_rust(n);
+        assert_eq!(
+            cairo_result, rust_result,
+            "Mismatch for fibonacci({n}): Cairo-M returned {cairo_result}, Rust returned {rust_result}"
+        );
+    }
+
+    Ok(())
+}
+"#;
+
+    fs::write(project_path.join("tests/integration_test.rs"), content)
+        .context("Failed to write tests/integration_test.rs")?;
+    Ok(())
+}

--- a/crates/cargo-cairo-m/templates/Cargo.toml
+++ b/crates/cargo-cairo-m/templates/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "{{name}}"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[dev-dependencies]
+cairo-m-common = { git = "https://github.com/kkrt-labs/cairo-m" }
+cairo-m-runner = { git = "https://github.com/kkrt-labs/cairo-m" }
+cairo-m-compiler = { git = "https://github.com/kkrt-labs/cairo-m" }
+anyhow = "1.0"
+proptest = "1.0"

--- a/crates/cargo-cairo-m/templates/README.md
+++ b/crates/cargo-cairo-m/templates/README.md
@@ -1,0 +1,59 @@
+# {{name}}
+
+A Cairo-M project with integrated Rust testing.
+
+## Project Structure
+
+- `cairom.toml` - Cairo-M project manifest file
+- `src/` - Cairo-M source files
+  - `fibonacci.cm` - Example fibonacci implementation
+- `tests/` - Rust integration tests
+- `Cargo.toml` - Rust project configuration
+
+## Prerequisites
+
+### macOS Users
+
+You need to have LLVM installed:
+
+```bash
+brew install llvm
+```
+
+## Common Commands
+
+### Run all tests
+
+```bash
+cargo test
+```
+
+### Run a specific test
+
+```bash
+cargo test test_fibonacci
+```
+
+### Show test output
+
+```bash
+cargo test -- --nocapture
+```
+
+Note: The required RUSTFLAGS are automatically configured in
+`.cargo/config.toml`
+
+## Adding New Cairo-M Files
+
+1. Create a new `.cm` file in the `src/` directory
+2. If needed, update the `entry_point` in `cairom.toml` to point to your main
+   file
+3. Write a corresponding test in `tests/`
+4. Use `compile_cairo` with the source directory path (e.g., "src/")
+5. Use `run_cairo_program` to execute your compiled Cairo-M code
+6. Compare results with Rust reference implementations
+
+## Resources
+
+- [Cairo-M Documentation](https://github.com/kkrt-labs/cairo-m)
+- [Cairo-M Language Reference](https://github.com/kkrt-labs/cairo-m/docs)

--- a/crates/cargo-cairo-m/templates/cairom.toml
+++ b/crates/cargo-cairo-m/templates/cairom.toml
@@ -1,0 +1,4 @@
+# Cairo-M project manifest file
+name = "{{name}}"
+version = "0.1.0"
+entry_point = "fibonacci.cm"

--- a/crates/cargo-cairo-m/templates/cargo-config.toml
+++ b/crates/cargo-cairo-m/templates/cargo-config.toml
@@ -1,0 +1,10 @@
+[target.'cfg(target_os = "macos")']
+rustflags = [
+  "-C",
+  "link-arg=-fuse-ld=/opt/homebrew/opt/lld/bin/ld64.lld",
+  "-C",
+  "target-cpu=native",
+]
+
+[target.'cfg(not(target_os = "macos"))']
+rustflags = ["-C", "target-cpu=native"]

--- a/crates/cargo-cairo-m/templates/fibonacci.cm
+++ b/crates/cargo-cairo-m/templates/fibonacci.cm
@@ -1,0 +1,15 @@
+// Iterative Fibonacci implementation
+fn fibonacci(n: felt) -> felt {
+    let current = 0;
+    let next = 1;
+
+    let counter = 0;
+    while (counter != n) {
+        let new_next = current + next;
+        current = next;
+        next = new_next;
+        counter = counter + 1;
+    }
+
+    return current;
+}

--- a/crates/cargo-cairo-m/templates/gitignore
+++ b/crates/cargo-cairo-m/templates/gitignore
@@ -1,0 +1,5 @@
+/target
+/Cargo.lock
+**/*.rs.bk
+*.pdb
+.DS_Store

--- a/crates/cargo-cairo-m/templates/integration_test.rs
+++ b/crates/cargo-cairo-m/templates/integration_test.rs
@@ -1,0 +1,68 @@
+use cairo_m_common::{CairoMValue, InputValue};
+use cairo_m_compiler::{compile_cairo, CompilerOptions};
+use cairo_m_runner::{run_cairo_program, RunnerOptions};
+use proptest::prelude::*;
+
+// Macro for asserting Cairo-M program results match expected values
+macro_rules! assert_cairo_result {
+    ($source_path:expr, $entrypoint:expr, $args:expr, $expected:expr) => {{
+        // Compile the Cairo-M source
+        let source = std::fs::read_to_string($source_path)
+            .expect(&format!("Failed to read source file: {}", $source_path));
+
+        let output = compile_cairo(source, "src/".to_string(), CompilerOptions::default())
+            .expect(&format!("Failed to compile {}", $source_path));
+
+        // Run the Cairo-M program
+        let result = run_cairo_program(
+            &output.program,
+            $entrypoint,
+            &$args,
+            RunnerOptions::default(),
+        )
+        .expect(&format!(
+            "Failed to run {} with entry point {}",
+            $source_path, $entrypoint
+        ));
+
+        // Extract the return value
+        assert!(
+            !result.return_values.is_empty(),
+            "Program {} with entry point {} returned no values",
+            $source_path,
+            $entrypoint
+        );
+
+        let cairo_result = match &result.return_values[0] {
+            CairoMValue::Felt(value) => value.0 as u32,
+            _ => panic!("Expected Felt return value from {}", $entrypoint),
+        };
+
+        // Compare with expected value (convert expected to u32)
+        let expected_u32 = $expected as u32;
+        assert_eq!(
+            cairo_result, expected_u32,
+            "Cairo-M program {} with entry point {} returned {} but expected {}",
+            $source_path, $entrypoint, cairo_result, expected_u32
+        );
+    }};
+}
+
+// Rust reference implementation (iterative)
+fn fibonacci_rust(n: u32) -> u32 {
+    let mut current = 0;
+    let mut next = 1;
+    for _ in 0..n {
+        let new_next = current + next;
+        current = next;
+        next = new_next;
+    }
+    current
+}
+
+proptest! {
+    #[test]
+    fn test_fibonacci_property(n in 0u32..30) {
+        assert_cairo_result!("src/fibonacci.cm", "fibonacci", vec![InputValue::Number(n as i64)], fibonacci_rust(n));
+    }
+}

--- a/crates/cargo-cairo-m/templates/lib.rs
+++ b/crates/cargo-cairo-m/templates/lib.rs
@@ -1,0 +1,1 @@
+// This file is required by Cargo but can remain empty

--- a/crates/cargo-cairo-m/templates/rust-toolchain.toml
+++ b/crates/cargo-cairo-m/templates/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2025-04-06"


### PR DESCRIPTION
Close CORE-1140

Introduces a new CLI tool that makes it easy to create Cairo-M projects with integrated testing infrastructure.

Key features:
- Simple command: `cargo-cairo-m init <project-name>`
- Generates a complete project structure with Cairo-M source and Rust tests
- Includes fibonacci example demonstrating differential testing
- Pre-configured dependencies
- Automatic RUSTFLAGS configuration via .cargo/config.toml
- Platform-specific optimizations (macOS LLVM linker support)
- Rust nightly toolchain configuration

The tool significantly improves developer experience by:
- Eliminating boilerplate setup
- Providing a working example out of the box
- Enabling immediate testing with `cargo test`
- Following Cairo-M best practices for testing

Usage:
```bash
cargo install --path crates/cargo-cairo-m
cargo-cairo-m init my-project
cd my-project
cargo test
```