### PR TITLE
feat(runner): add PrintM31 and PrintU32 debug opcodes

### DIFF
--- a/crates/common/src/instruction.rs
+++ b/crates/common/src/instruction.rs
@@ -296,7 +296,11 @@ define_instruction!(
     // 42 taken by StoreDoubleDerefFpFp; 43 taken by StoreFpImm
     // Reverse double deref operations - store TO computed addresses
     StoreToDoubleDerefFpImm = 44, 3, fields: [base_off, imm, src_off], size: 4, operands: [Felt, Felt, Felt]; // [[fp + base_off] + imm] = [fp + src_off]
-    StoreToDoubleDerefFpFp = 45, 3, fields: [base_off, offset_off, src_off], size: 4, operands: [Felt, Felt, Felt] // [[fp + base_off] + [fp + offset_off]] = [fp + src_off]
+    StoreToDoubleDerefFpFp = 45, 3, fields: [base_off, offset_off, src_off], size: 4, operands: [Felt, Felt, Felt]; // [[fp + base_off] + [fp + offset_off]] = [fp + src_off]
+
+    // Print operations for debugging
+    PrintM31 = 46, 1, fields: [offset], size: 2, operands: [Felt];                      // print [fp + offset] as M31
+    PrintU32 = 47, 2, fields: [offset], size: 2, operands: [U32]                        // print u32([fp + offset], [fp + offset + 1])
 );
 
 impl From<Instruction> for SmallVec<[M31; INSTRUCTION_MAX_SIZE]> {

--- a/crates/runner/src/vm/instructions/mod.rs
+++ b/crates/runner/src/vm/instructions/mod.rs
@@ -23,12 +23,14 @@ use stwo_prover::core::fields::m31::M31;
 use crate::vm::instructions::call::*;
 use crate::vm::instructions::jnz::*;
 use crate::vm::instructions::jump::*;
+use crate::vm::instructions::print::*;
 use crate::vm::instructions::store::*;
 use crate::vm::{Memory, MemoryError};
 
 pub mod call;
 pub mod jnz;
 pub mod jump;
+pub mod print;
 pub mod store;
 
 /// Extracts fields from a specific instruction variant or returns an InvalidOpcode error.
@@ -188,10 +190,15 @@ pub fn opcode_to_instruction_fn(op: M31) -> Result<InstructionFn, InstructionErr
         U32_STORE_XOR_FP_IMM => u32_store_xor_fp_imm,
         STORE_TO_DOUBLE_DEREF_FP_IMM => store_to_double_deref_fp_imm,
         STORE_TO_DOUBLE_DEREF_FP_FP => store_to_double_deref_fp_fp,
+        PRINT_M31 => print_m31,
+        PRINT_U32 => print_u32,
         _ => return Err(InstructionError::InvalidOpcode(op)),
     };
     Ok(f)
 }
+
+#[cfg(test)]
+mod print_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/runner/src/vm/instructions/print.rs
+++ b/crates/runner/src/vm/instructions/print.rs
@@ -1,0 +1,40 @@
+//! PRINT instructions for the Cairo M VM.
+//!
+//! PRINT instructions are no-op instructions that output values to stdout for debugging purposes.
+
+use crate::vm::state::VmState;
+use cairo_m_common::{Instruction, State};
+
+use super::InstructionExecutionError;
+use crate::extract_as;
+use crate::memory::Memory;
+
+/// Execute PrintM31 instruction.
+/// Reads a value from [fp + offset] and prints it as an M31 field element.
+/// This is a debugging instruction that doesn't modify the trace.
+pub fn print_m31(
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    let offset = extract_as!(instruction, PrintM31, offset);
+    let addr = state.fp + offset;
+    let value = memory.get_data_no_trace(addr)?;
+    println!("[PrintM31] [{}] = {}", addr, value);
+    Ok(state.advance_by(instruction.size_in_qm31s()))
+}
+
+/// Execute PrintU32 instruction.
+/// Reads a U32 value from [fp + offset] and prints it as a 32-bit unsigned integer.
+/// This is a debugging instruction that doesn't modify the trace.
+pub fn print_u32(
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    let offset = extract_as!(instruction, PrintU32, offset);
+    let addr = state.fp + offset;
+    let value = memory.get_u32_no_trace(addr)?;
+    println!("[PrintU32] [{}] = {}", addr, value);
+    Ok(state.advance_by(instruction.size_in_qm31s()))
+}

--- a/crates/runner/src/vm/instructions/print_tests.rs
+++ b/crates/runner/src/vm/instructions/print_tests.rs
@@ -1,0 +1,123 @@
+use cairo_m_common::{Instruction, State};
+use stwo_prover::core::fields::m31::M31;
+
+use crate::memory::Memory;
+use crate::vm::instructions::print::{print_m31, print_u32};
+use crate::vm::instructions::InstructionExecutionError;
+
+#[test]
+fn test_print_m31() -> Result<(), InstructionExecutionError> {
+    // Setup memory with a value at address 10
+    let mut memory = Memory::default();
+    memory.insert(M31(10), M31(42).into())?;
+
+    // Setup state with fp = 5, so [fp + 5] = address 10
+    let state = State {
+        pc: M31(0),
+        fp: M31(5),
+    };
+
+    // Create PrintM31 instruction with offset 5
+    let instruction = Instruction::PrintM31 { offset: M31(5) };
+
+    // Execute the instruction - should print "[PrintM31] [10] = 42"
+    let new_state = print_m31(&mut memory, state, &instruction)?;
+
+    // Verify state advances by instruction size (1 QM31)
+    assert_eq!(new_state.pc, M31(1));
+    assert_eq!(new_state.fp, M31(5));
+
+    // Verify memory trace is NOT modified by print instruction
+    // (the initial insert will have created 1 trace entry)
+    assert_eq!(memory.trace.borrow().len(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn test_print_u32() -> Result<(), InstructionExecutionError> {
+    // Setup memory with a U32 value 0x12345678 at address 20
+    // Low limb: 0x5678, High limb: 0x1234
+    let mut memory = Memory::default();
+    memory.insert(M31(20), M31(0x5678).into())?; // Low limb
+    memory.insert(M31(21), M31(0x1234).into())?; // High limb
+
+    // Setup state with fp = 10, so [fp + 10] = address 20
+    let state = State {
+        pc: M31(0),
+        fp: M31(10),
+    };
+
+    // Create PrintU32 instruction with offset 10
+    let instruction = Instruction::PrintU32 { offset: M31(10) };
+
+    // Execute the instruction - should print "[PrintU32] [20] = 305419896" (0x12345678)
+    let new_state = print_u32(&mut memory, state, &instruction)?;
+
+    // Verify state advances by instruction size (1 QM31)
+    assert_eq!(new_state.pc, M31(1));
+    assert_eq!(new_state.fp, M31(10));
+
+    // Verify memory trace is NOT modified (no trace entries for print)
+    // The initial inserts will have created 2 trace entries, but print_u32 should not add any
+    let initial_trace_len = memory.trace.borrow().len();
+    assert_eq!(initial_trace_len, 2); // From the two inserts
+
+    Ok(())
+}
+
+#[test]
+fn test_print_m31_invalid_value() -> Result<(), InstructionExecutionError> {
+    // Setup memory with an invalid M31 value (has extension components)
+    let mut memory = Memory::default();
+    let invalid_value = stwo_prover::core::fields::qm31::QM31::from_u32_unchecked(1, 2, 0, 0);
+    memory.insert(M31(10), invalid_value)?;
+
+    // Setup state
+    let state = State {
+        pc: M31(0),
+        fp: M31(5),
+    };
+
+    // Create PrintM31 instruction
+    let instruction = Instruction::PrintM31 { offset: M31(5) };
+
+    // Execute should fail with BaseFieldProjectionFailed
+    let result = print_m31(&mut memory, state, &instruction);
+    assert!(matches!(
+        result,
+        Err(InstructionExecutionError::Memory(
+            crate::memory::MemoryError::BaseFieldProjectionFailed { .. }
+        ))
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn test_print_u32_invalid_limbs() -> Result<(), InstructionExecutionError> {
+    // Setup memory with invalid U32 limbs (exceeding 16-bit range)
+    let mut memory = Memory::default();
+    memory.insert(M31(20), M31(0x10000).into())?; // Invalid low limb (> 0xFFFF)
+    memory.insert(M31(21), M31(0x1234).into())?; // Valid high limb
+
+    // Setup state
+    let state = State {
+        pc: M31(0),
+        fp: M31(10),
+    };
+
+    // Create PrintU32 instruction
+    let instruction = Instruction::PrintU32 { offset: M31(10) };
+
+    // Execute should fail with U32LimbOutOfRange
+    let result = print_u32(&mut memory, state, &instruction);
+    assert!(matches!(
+        result,
+        Err(InstructionExecutionError::Memory(
+            crate::memory::MemoryError::U32LimbOutOfRange { .. }
+        ))
+    ));
+
+    Ok(())
+}


### PR DESCRIPTION
Close CORE-1136

Add non-tracing print instructions for debugging Cairo-M programs:
- PrintM31: prints M31 field element at [fp + offset]
- PrintU32: prints 32-bit unsigned integer at [fp + offset]
- Output format: [PrintM31/U32] [address] = value

These are true no-op instructions that don't modify execution trace.