### PR TITLE
feat(runner): add AssertEqFpFp and AssertEqFpImm instructions

### DIFF
--- a/crates/common/src/instruction.rs
+++ b/crates/common/src/instruction.rs
@@ -16,6 +16,8 @@ pub enum InstructionError {
     InvalidOpcode(M31),
     #[error("Size mismatch for instruction: expected {expected}, found {found}")]
     SizeMismatch { expected: usize, found: usize },
+    #[error("Assertion failed: {0} != {1}")]
+    AssertionFailed(M31, M31),
 }
 
 pub const INSTRUCTION_MAX_SIZE: usize = 5;
@@ -300,7 +302,10 @@ define_instruction!(
 
     // Print operations for debugging
     PrintM31 = 46, 1, fields: [offset], size: 2, operands: [Felt];                      // print [fp + offset] as M31
-    PrintU32 = 47, 2, fields: [offset], size: 2, operands: [U32]                        // print u32([fp + offset], [fp + offset + 1])
+    PrintU32 = 47, 2, fields: [offset], size: 2, operands: [U32];                        // print u32([fp + offset], [fp + offset + 1])
+
+    AssertEqFpFp = 49, 2, fields: [src0_off, src1_off], size: 3, operands: [Felt, Felt]; // assert [fp + src0_off] == [fp + src1_off]
+    AssertEqFpImm = 50, 1, fields: [src_off, imm], size: 3, operands: [Felt] // assert [fp + src_off] == imm
 );
 
 impl From<Instruction> for SmallVec<[M31; INSTRUCTION_MAX_SIZE]> {

--- a/crates/common/tests/instruction_tests.rs
+++ b/crates/common/tests/instruction_tests.rs
@@ -883,6 +883,22 @@ fn test_try_from_smallvec() {
             },
             "PrintU32 instruction",
         ),
+        (
+            smallvec![M31::from(49), M31::from(1), M31::from(2)],
+            Instruction::AssertEqFpFp {
+                src0_off: M31::from(1),
+                src1_off: M31::from(2),
+            },
+            "AssertEqFpFp instruction",
+        ),
+        (
+            smallvec![M31::from(50), M31::from(1), M31::from(2)],
+            Instruction::AssertEqFpImm {
+                src_off: M31::from(1),
+                imm: M31::from(2),
+            },
+            "AssertEqFpImm instruction",
+        ),
     ];
 
     assert_eq!(test_cases.len(), MAX_OPCODE as usize + 1);
@@ -1123,6 +1139,14 @@ fn test_roundtrip_all_instructions() {
             imm_hi: M31::from(0x1234),
             imm_lo: M31::from(0x5678),
             dst_off: M31::from(23),
+        },
+        Instruction::AssertEqFpFp {
+            src0_off: M31::from(27),
+            src1_off: M31::from(28),
+        },
+        Instruction::AssertEqFpImm {
+            src_off: M31::from(29),
+            imm: M31::from(30),
         },
     ];
 

--- a/crates/runner/src/vm/instructions/assert.rs
+++ b/crates/runner/src/vm/instructions/assert.rs
@@ -1,0 +1,104 @@
+// Assert instructions for the Cairo M VM.
+
+use cairo_m_common::{Instruction, InstructionError, State};
+
+use super::InstructionExecutionError;
+use crate::extract_as;
+use crate::memory::Memory;
+use crate::vm::state::VmState;
+
+pub fn assert_eq_fp_fp(
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    let (src0_off, src1_off) = extract_as!(instruction, AssertEqFpFp, (src0_off, src1_off));
+    let value0 = memory.get_data(state.fp + src0_off)?;
+    let value1 = memory.get_data(state.fp + src1_off)?;
+    if value0 != value1 {
+        return Err(InstructionExecutionError::Instruction(
+            InstructionError::AssertionFailed(value0, value1),
+        ));
+    }
+    Ok(state.advance_by(instruction.size_in_qm31s()))
+}
+
+pub fn assert_eq_fp_imm(
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    let (src_off, imm) = extract_as!(instruction, AssertEqFpImm, (src_off, imm));
+    let value = memory.get_data(state.fp + src_off)?;
+    if value != imm {
+        return Err(InstructionExecutionError::Instruction(
+            InstructionError::AssertionFailed(value, imm),
+        ));
+    }
+    Ok(state.advance_by(instruction.size_in_qm31s()))
+}
+
+#[cfg(test)]
+mod assert_tests {
+    use super::*;
+    use crate::memory::Memory;
+    use cairo_m_common::State;
+    use stwo_prover::core::fields::m31::M31;
+
+    #[test]
+    fn test_assert_eq_fp_fp() {
+        let mut memory = Memory::from_iter([0, 1, 1].map(Into::into));
+        let state = State {
+            pc: M31::from(1),
+            fp: M31::from(0),
+        };
+        let instruction = Instruction::AssertEqFpFp {
+            src0_off: M31::from(1),
+            src1_off: M31::from(2),
+        };
+        let result = assert_eq_fp_fp(&mut memory, state, &instruction);
+        assert!(result.is_ok());
+        assert_eq!(state.pc, M31::from(2));
+
+        let mut memory = Memory::from_iter([0, 1, 2].map(Into::into));
+        let state = State {
+            pc: M31::from(1),
+            fp: M31::from(0),
+        };
+        let instruction = Instruction::AssertEqFpFp {
+            src0_off: M31::from(1),
+            src1_off: M31::from(2),
+        };
+        let result = assert_eq_fp_fp(&mut memory, state, &instruction);
+        assert!(result.is_err());
+        assert_eq!(state.pc, M31::from(2));
+    }
+
+    #[test]
+    fn test_assert_eq_fp_imm() {
+        let mut memory = Memory::from_iter([0, 1, 2].map(Into::into));
+        let state = State {
+            pc: M31::from(1),
+            fp: M31::from(0),
+        };
+        let instruction = Instruction::AssertEqFpImm {
+            src_off: M31::from(1),
+            imm: M31::from(1),
+        };
+        let result = assert_eq_fp_imm(&mut memory, state, &instruction);
+        assert!(result.is_ok());
+        assert_eq!(state.pc, M31::from(2));
+
+        let mut memory = Memory::from_iter([0, 1, 3].map(Into::into));
+        let state = State {
+            pc: M31::from(1),
+            fp: M31::from(0),
+        };
+        let instruction = Instruction::AssertEqFpImm {
+            src_off: M31::from(1),
+            imm: M31::from(2),
+        };
+        let result = assert_eq_fp_imm(&mut memory, state, &instruction);
+        assert!(result.is_err());
+    }
+}

--- a/crates/runner/src/vm/instructions/mod.rs
+++ b/crates/runner/src/vm/instructions/mod.rs
@@ -16,6 +16,7 @@
 //! - `StoreAddFpFp { src0_off: M31, src1_off: M31, dst_off: M31 }` - 4 M31 total
 //! - `Ret {}` - 1 M31 total (just the opcode)
 
+use assert::{assert_eq_fp_fp, assert_eq_fp_imm};
 use cairo_m_common::instruction::*;
 use cairo_m_common::{Instruction, State};
 use stwo_prover::core::fields::m31::M31;
@@ -27,6 +28,7 @@ use crate::vm::instructions::print::*;
 use crate::vm::instructions::store::*;
 use crate::vm::{Memory, MemoryError};
 
+pub mod assert;
 pub mod call;
 pub mod jnz;
 pub mod jump;
@@ -192,6 +194,8 @@ pub fn opcode_to_instruction_fn(op: M31) -> Result<InstructionFn, InstructionErr
         STORE_TO_DOUBLE_DEREF_FP_FP => store_to_double_deref_fp_fp,
         PRINT_M31 => print_m31,
         PRINT_U32 => print_u32,
+        ASSERT_EQ_FP_FP => assert_eq_fp_fp,
+        ASSERT_EQ_FP_IMM => assert_eq_fp_imm,
         _ => return Err(InstructionError::InvalidOpcode(op)),
     };
     Ok(f)


### PR DESCRIPTION
- Add AssertionFailed error variant for assertion instructions
- Implement AssertEqFpFp for comparing two FP-relative values
- Implement AssertEqFpImm for comparing FP-relative value with immediate
- Add comprehensive tests for assertion instructions
- Register new opcodes 49 and 50 for assert instructions

Closes CORE-1147