### PR TITLE
feat(runner): add LowerThan, AssertEqFpFp and AssertEqFpImm instructions

### DIFF
--- a/crates/common/src/instruction.rs
+++ b/crates/common/src/instruction.rs
@@ -16,6 +16,8 @@ pub enum InstructionError {
     InvalidOpcode(M31),
     #[error("Size mismatch for instruction: expected {expected}, found {found}")]
     SizeMismatch { expected: usize, found: usize },
+    #[error("Assertion failed: {0} != {1}")]
+    AssertionFailed(M31, M31),
 }
 
 pub const INSTRUCTION_MAX_SIZE: usize = 5;
@@ -301,7 +303,10 @@ define_instruction!(
 
     // Print operations for debugging
     PrintM31 = 46, 1, fields: [offset], size: 2, operands: [Felt];                      // print [fp + offset] as M31
-    PrintU32 = 47, 2, fields: [offset], size: 2, operands: [U32]                        // print u32([fp + offset], [fp + offset + 1])
+    PrintU32 = 47, 2, fields: [offset], size: 2, operands: [U32];                        // print u32([fp + offset], [fp + offset + 1])
+
+    AssertEqFpFp = 49, 2, fields: [src0_off, src1_off], size: 3, operands: [Felt, Felt]; // assert [fp + src0_off] == [fp + src1_off]
+    AssertEqFpImm = 50, 1, fields: [src_off, imm], size: 3, operands: [Felt] // assert [fp + src_off] == imm
 );
 
 impl From<Instruction> for SmallVec<[M31; INSTRUCTION_MAX_SIZE]> {

--- a/crates/common/src/instruction.rs
+++ b/crates/common/src/instruction.rs
@@ -305,6 +305,7 @@ define_instruction!(
     PrintM31 = 46, 1, fields: [offset], size: 2, operands: [Felt];                      // print [fp + offset] as M31
     PrintU32 = 47, 2, fields: [offset], size: 2, operands: [U32];                        // print u32([fp + offset], [fp + offset + 1])
 
+    StoreLowerThanFpImm = 48, 2, fields: [src_off, imm, dst_off], size: 4, operands: [Felt, Felt]; // [fp + dst_off] = [fp + src_off] < imm
     AssertEqFpFp = 49, 2, fields: [src0_off, src1_off], size: 3, operands: [Felt, Felt]; // assert [fp + src0_off] == [fp + src1_off]
     AssertEqFpImm = 50, 1, fields: [src_off, imm], size: 3, operands: [Felt] // assert [fp + src_off] == imm
 );

--- a/crates/common/src/instruction.rs
+++ b/crates/common/src/instruction.rs
@@ -238,6 +238,13 @@ define_instruction!(
     StoreMulFpImm = 6, 2, fields: [src_off, imm, dst_off], size: 4, operands: [Felt, Felt];                // [fp + dst_off] = [fp + src_off] * imm
     StoreDivFpImm = 7, 2, fields: [src_off, imm, dst_off], size: 4, operands: [Felt, Felt];                // [fp + dst_off] = [fp + src_off] / imm
 
+    // Comparison operations
+    StoreLowerThanFpImm = 48, 2, fields: [src_off, imm, dst_off], size: 4, operands: [Felt, Felt]; // [fp + dst_off] = [fp + src_off] < imm
+
+    // Assertions
+    AssertEqFpFp = 49, 2, fields: [src0_off, src1_off], size: 3, operands: [Felt, Felt]; // assert [fp + src0_off] == [fp + src1_off]
+    AssertEqFpImm = 50, 1, fields: [src_off, imm], size: 3, operands: [Felt]; // assert [fp + src_off] == imm
+
     // Memory operations
     StoreDoubleDerefFp = 8, 3, fields: [base_off, imm, dst_off], size: 4, operands: [Felt, Felt, Felt]; // [fp + dst_off] = [[fp + base_off] + imm]
     StoreDoubleDerefFpFp = 42, 3, fields: [base_off, offset_off, dst_off], size: 4, operands: [Felt, Felt, Felt]; // [fp + dst_off] = [[fp + base_off] + [fp + offset_off]]
@@ -303,11 +310,7 @@ define_instruction!(
 
     // Print operations for debugging
     PrintM31 = 46, 1, fields: [offset], size: 2, operands: [Felt];                      // print [fp + offset] as M31
-    PrintU32 = 47, 2, fields: [offset], size: 2, operands: [U32];                        // print u32([fp + offset], [fp + offset + 1])
-
-    StoreLowerThanFpImm = 48, 2, fields: [src_off, imm, dst_off], size: 4, operands: [Felt, Felt]; // [fp + dst_off] = [fp + src_off] < imm
-    AssertEqFpFp = 49, 2, fields: [src0_off, src1_off], size: 3, operands: [Felt, Felt]; // assert [fp + src0_off] == [fp + src1_off]
-    AssertEqFpImm = 50, 1, fields: [src_off, imm], size: 3, operands: [Felt] // assert [fp + src_off] == imm
+    PrintU32 = 47, 2, fields: [offset], size: 2, operands: [U32]                        // print u32([fp + offset], [fp + offset + 1])
 );
 
 impl From<Instruction> for SmallVec<[M31; INSTRUCTION_MAX_SIZE]> {

--- a/crates/common/tests/instruction_tests.rs
+++ b/crates/common/tests/instruction_tests.rs
@@ -883,6 +883,22 @@ fn test_try_from_smallvec() {
             },
             "PrintU32 instruction",
         ),
+        (
+            smallvec![M31::from(49), M31::from(1), M31::from(2)],
+            Instruction::AssertEqFpFp {
+                src0_off: M31::from(1),
+                src1_off: M31::from(2),
+            },
+            "AssertEqFpFp instruction",
+        ),
+        (
+            smallvec![M31::from(50), M31::from(1), M31::from(2)],
+            Instruction::AssertEqFpImm {
+                src_off: M31::from(1),
+                imm: M31::from(2),
+            },
+            "AssertEqFpImm instruction",
+        ),
     ];
 
     assert_eq!(test_cases.len(), MAX_OPCODE as usize + 1);
@@ -1123,6 +1139,14 @@ fn test_roundtrip_all_instructions() {
             imm_hi: M31::from(0x1234),
             imm_lo: M31::from(0x5678),
             dst_off: M31::from(23),
+        },
+        Instruction::AssertEqFpFp {
+            src0_off: M31::from(27),
+            src1_off: M31::from(28),
+        },
+        Instruction::AssertEqFpImm {
+            src_off: M31::from(29),
+            imm: M31::from(30),
         },
     ];
 

--- a/crates/common/tests/instruction_tests.rs
+++ b/crates/common/tests/instruction_tests.rs
@@ -884,6 +884,15 @@ fn test_try_from_smallvec() {
             "PrintU32 instruction",
         ),
         (
+            smallvec![M31::from(48), M31::from(1), M31::from(2), M31::from(3)],
+            Instruction::StoreLowerThanFpImm {
+                src_off: M31::from(1),
+                imm: M31::from(2),
+                dst_off: M31::from(3),
+            },
+            "StoreLowerThanFpImm instruction",
+        ),
+        (
             smallvec![M31::from(49), M31::from(1), M31::from(2)],
             Instruction::AssertEqFpFp {
                 src0_off: M31::from(1),
@@ -1139,6 +1148,11 @@ fn test_roundtrip_all_instructions() {
             imm_hi: M31::from(0x1234),
             imm_lo: M31::from(0x5678),
             dst_off: M31::from(23),
+        },
+        Instruction::StoreLowerThanFpImm {
+            src_off: M31::from(24),
+            imm: M31::from(25),
+            dst_off: M31::from(26),
         },
         Instruction::AssertEqFpFp {
             src0_off: M31::from(27),

--- a/crates/runner/src/vm/instructions/assert.rs
+++ b/crates/runner/src/vm/instructions/assert.rs
@@ -56,8 +56,7 @@ mod assert_tests {
             src0_off: M31::from(1),
             src1_off: M31::from(2),
         };
-        let result = assert_eq_fp_fp(&mut memory, state, &instruction);
-        assert!(result.is_ok());
+        let state = assert_eq_fp_fp(&mut memory, state, &instruction).unwrap();
         assert_eq!(state.pc, M31::from(2));
 
         let mut memory = Memory::from_iter([0, 1, 2].map(Into::into));
@@ -69,9 +68,14 @@ mod assert_tests {
             src0_off: M31::from(1),
             src1_off: M31::from(2),
         };
-        let result = assert_eq_fp_fp(&mut memory, state, &instruction);
-        assert!(result.is_err());
-        assert_eq!(state.pc, M31::from(2));
+        let state = assert_eq_fp_fp(&mut memory, state, &instruction).unwrap_err();
+        match state {
+            InstructionExecutionError::Instruction(InstructionError::AssertionFailed(a, b)) => {
+                assert_eq!(a, M31::from(1));
+                assert_eq!(b, M31::from(2));
+            }
+            _ => panic!("Expected AssertionFailed error, got: {:?}", state),
+        }
     }
 
     #[test]
@@ -85,8 +89,7 @@ mod assert_tests {
             src_off: M31::from(1),
             imm: M31::from(1),
         };
-        let result = assert_eq_fp_imm(&mut memory, state, &instruction);
-        assert!(result.is_ok());
+        let state = assert_eq_fp_imm(&mut memory, state, &instruction).unwrap();
         assert_eq!(state.pc, M31::from(2));
 
         let mut memory = Memory::from_iter([0, 1, 3].map(Into::into));
@@ -98,7 +101,13 @@ mod assert_tests {
             src_off: M31::from(1),
             imm: M31::from(2),
         };
-        let result = assert_eq_fp_imm(&mut memory, state, &instruction);
-        assert!(result.is_err());
+        let state = assert_eq_fp_imm(&mut memory, state, &instruction).unwrap_err();
+        match state {
+            InstructionExecutionError::Instruction(InstructionError::AssertionFailed(a, b)) => {
+                assert_eq!(a, M31::from(1));
+                assert_eq!(b, M31::from(2));
+            }
+            _ => panic!("Expected AssertionFailed error, got: {:?}", state),
+        }
     }
 }

--- a/crates/runner/src/vm/instructions/assert.rs
+++ b/crates/runner/src/vm/instructions/assert.rs
@@ -1,0 +1,104 @@
+// Assert instructions for the Cairo M VM.
+
+use cairo_m_common::{Instruction, InstructionError, State};
+
+use super::InstructionExecutionError;
+use crate::extract_as;
+use crate::memory::Memory;
+use crate::vm::state::VmState;
+
+pub fn assert_eq_fp_fp(
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    let (src0_off, src1_off) = extract_as!(instruction, AssertEqFpFp, (src0_off, src1_off));
+    let value0 = memory.get_data(state.fp + src0_off)?;
+    let value1 = memory.get_data(state.fp + src1_off)?;
+    if value0 != value1 {
+        return Err(InstructionExecutionError::Instruction(
+            InstructionError::AssertionFailed(value0, value1),
+        ));
+    }
+    Ok(state.advance_by(instruction.size_in_qm31s()))
+}
+
+pub fn assert_eq_fp_imm(
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    let (src_off, imm) = extract_as!(instruction, AssertEqFpImm, (src_off, imm));
+    let value = memory.get_data(state.fp + src_off)?;
+    if value != imm {
+        return Err(InstructionExecutionError::Instruction(
+            InstructionError::AssertionFailed(value, imm),
+        ));
+    }
+    Ok(state.advance_by(instruction.size_in_qm31s()))
+}
+
+#[cfg(test)]
+mod assert_tests {
+    use super::*;
+    use crate::memory::Memory;
+    use cairo_m_common::State;
+    use stwo_prover::core::fields::m31::M31;
+
+    #[test]
+    fn test_assert_eq_fp_fp() {
+        let mut memory = Memory::from_iter([0, 1, 1].map(Into::into));
+        let state = State {
+            pc: M31::from(1),
+            fp: M31::from(0),
+        };
+        let instruction = Instruction::AssertEqFpFp {
+            src0_off: M31::from(1),
+            src1_off: M31::from(2),
+        };
+        let result = assert_eq_fp_fp(&mut memory, state, &instruction);
+        assert!(result.is_ok());
+        assert_eq!(state.pc, M31::from(2));
+
+        let mut memory = Memory::from_iter([0, 1, 2].map(Into::into));
+        let state = State {
+            pc: M31::from(1),
+            fp: M31::from(0),
+        };
+        let instruction = Instruction::AssertEqFpFp {
+            src0_off: M31::from(1),
+            src1_off: M31::from(2),
+        };
+        let result = assert_eq_fp_fp(&mut memory, state, &instruction);
+        assert!(result.is_err());
+        assert_eq!(state.pc, M31::from(2));
+    }
+
+    #[test]
+    fn test_assert_eq_fp_imm() {
+        let mut memory = Memory::from_iter([0, 1, 2].map(Into::into));
+        let state = State {
+            pc: M31::from(1),
+            fp: M31::from(0),
+        };
+        let instruction = Instruction::AssertEqFpImm {
+            src_off: M31::from(1),
+            imm: M31::from(1),
+        };
+        let result = assert_eq_fp_imm(&mut memory, state, &instruction);
+        assert!(result.is_ok());
+        assert_eq!(state.pc, M31::from(2));
+
+        let mut memory = Memory::from_iter([0, 1, 3].map(Into::into));
+        let state = State {
+            pc: M31::from(1),
+            fp: M31::from(0),
+        };
+        let instruction = Instruction::AssertEqFpImm {
+            src_off: M31::from(1),
+            imm: M31::from(2),
+        };
+        let result = assert_eq_fp_imm(&mut memory, state, &instruction);
+        assert!(result.is_err());
+    }
+}

--- a/crates/runner/src/vm/instructions/mod.rs
+++ b/crates/runner/src/vm/instructions/mod.rs
@@ -194,6 +194,7 @@ pub fn opcode_to_instruction_fn(op: M31) -> Result<InstructionFn, InstructionErr
         STORE_TO_DOUBLE_DEREF_FP_FP => store_to_double_deref_fp_fp,
         PRINT_M31 => print_m31,
         PRINT_U32 => print_u32,
+        STORE_LOWER_THAN_FP_IMM => store_lower_than_fp_imm,
         ASSERT_EQ_FP_FP => assert_eq_fp_fp,
         ASSERT_EQ_FP_IMM => assert_eq_fp_imm,
         _ => return Err(InstructionError::InvalidOpcode(op)),

--- a/crates/runner/src/vm/instructions/mod.rs
+++ b/crates/runner/src/vm/instructions/mod.rs
@@ -16,6 +16,7 @@
 //! - `StoreAddFpFp { src0_off: M31, src1_off: M31, dst_off: M31 }` - 4 M31 total
 //! - `Ret {}` - 1 M31 total (just the opcode)
 
+use assert::{assert_eq_fp_fp, assert_eq_fp_imm};
 use cairo_m_common::instruction::*;
 use cairo_m_common::{Instruction, State};
 use stwo_prover::core::fields::m31::M31;
@@ -27,6 +28,7 @@ use crate::vm::instructions::print::*;
 use crate::vm::instructions::store::*;
 use crate::vm::{Memory, MemoryError};
 
+pub mod assert;
 pub mod call;
 pub mod jnz;
 pub mod jump;
@@ -192,6 +194,8 @@ pub fn opcode_to_instruction_fn(op: M31) -> Result<InstructionFn, InstructionErr
         STORE_TO_DOUBLE_DEREF_FP_FP => store_to_double_deref_fp_fp,
         PRINT_M31 => print_m31,
         PRINT_U32 => print_u32,
+        ASSERT_EQ_FP_FP => assert_eq_fp_fp,
+        ASSERT_EQ_FP_IMM => assert_eq_fp_imm,
         _ => return Err(InstructionError::InvalidOpcode(op)),
     };
     Ok(f)

--- a/crates/runner/src/vm/instructions/store.rs
+++ b/crates/runner/src/vm/instructions/store.rs
@@ -173,6 +173,22 @@ impl_store_bin_op_fp_imm!(store_sub_fp_imm, StoreSubFpImm, -);
 impl_store_bin_op_fp_imm!(store_mul_fp_imm, StoreMulFpImm, *);
 impl_store_bin_op_fp_imm!(store_div_fp_imm, StoreDivFpImm, /);
 
+/// Store the result of a less-than comparison as a felt (0 or 1)
+pub fn store_lower_than_fp_imm(
+    memory: &mut Memory,
+    state: State,
+    instruction: &Instruction,
+) -> Result<State, InstructionExecutionError> {
+    let (src_off, imm, dst_off) =
+        extract_as!(instruction, StoreLowerThanFpImm, (src_off, imm, dst_off));
+
+    let src_value = memory.get_data(state.fp + src_off)?;
+    let value = M31::from((src_value < imm) as u32);
+
+    memory.insert(state.fp + dst_off, value.into())?;
+    Ok(state.advance_by(instruction.size_in_qm31s()))
+}
+
 // -------------------------------------------------------------------------------------------------
 // Singular / less-regular STORE instructions (scalar)
 // -------------------------------------------------------------------------------------------------

--- a/crates/runner/src/vm/instructions/store.rs
+++ b/crates/runner/src/vm/instructions/store.rs
@@ -173,6 +173,11 @@ impl_store_bin_op_fp_imm!(store_sub_fp_imm, StoreSubFpImm, -);
 impl_store_bin_op_fp_imm!(store_mul_fp_imm, StoreMulFpImm, *);
 impl_store_bin_op_fp_imm!(store_div_fp_imm, StoreDivFpImm, /);
 
+/// CASM equivalent:
+/// ```casm
+/// [fp + dst_off] = [fp + src_off] < imm
+/// ```
+///
 /// Store the result of a less-than comparison as a felt (0 or 1)
 pub fn store_lower_than_fp_imm(
     memory: &mut Memory,

--- a/crates/runner/src/vm/instructions/store_tests.rs
+++ b/crates/runner/src/vm/instructions/store_tests.rs
@@ -773,6 +773,30 @@ proptest! {
             1,
         ).unwrap();
     }
+
+    #[test]
+    fn test_store_lower_than_fp_imm(src_val: u32, imm_val: u32) {
+        let src = M31::from(src_val);
+        let imm = M31::from(imm_val);
+        let expected_res = if src < imm { M31::from(1) } else { M31::from(0) };
+
+        let mut initial_mem = vec![0; 4];
+        initial_mem[1] = src_val;
+        let mut expected_mem = initial_mem.clone();
+        expected_mem[3] = expected_res.0;
+
+        run_simple_store_test(
+            &initial_mem,
+            Instruction::StoreLowerThanFpImm {
+                src_off: M31(1),
+                imm,
+                dst_off: M31(3),
+            },
+            store_lower_than_fp_imm,
+            &expected_mem,
+            1,
+        ).unwrap();
+    }
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
feat(runner): add AssertEqFpFp and AssertEqFpImm instructions

- Add AssertionFailed error variant for assertion instructions
- Implement AssertEqFpFp for comparing two FP-relative values
- Implement AssertEqFpImm for comparing FP-relative value with immediate
- Add comprehensive tests for assertion instructions
- Register new opcodes 49 and 50 for assert instructions

Closes CORE-1147

feat(runner): add StoreLowerThanFpImm instruction

- Implement StoreLowerThanFpImm for less-than comparisons
- Store result as 0 (false) or 1 (true) in M31 field
- Register opcode 48 for the new instruction
- Add tests for comparison instruction

Closes CORE-1145