### PR TITLE
Add support for optional parentheses in while statements

### DIFF
--- a/crates/compiler/formatter/tests/formatter_tests.rs
+++ b/crates/compiler/formatter/tests/formatter_tests.rs
@@ -51,6 +51,18 @@ fn test_idempotence() {
 }
 
 #[test]
+fn test_format_while_statement_with_parens() {
+    let input = r#"fn test(){while(i!=n){i=i+1;}}"#;
+    assert_snapshot!(format_code(input));
+}
+
+#[test]
+fn test_format_while_statement_without_parens() {
+    let input = r#"fn test(){while i!=n{i=i+1;}}"#;
+    assert_snapshot!(format_code(input));
+}
+
+#[test]
 fn test_should_not_format_unparsable_code() {
     let input = r#"fn test(x:felt)->felt{let z; let y=x+1;return y;}"#;
     let formatted = format_code(input);

--- a/crates/compiler/formatter/tests/snapshots/formatter_tests__format_while_statement_with_parens.snap
+++ b/crates/compiler/formatter/tests/snapshots/formatter_tests__format_while_statement_with_parens.snap
@@ -1,0 +1,9 @@
+---
+source: crates/compiler/formatter/tests/formatter_tests.rs
+expression: format_code(input)
+---
+fn test() -> () {
+    while i != n {
+        i = i + 1;
+    }
+}

--- a/crates/compiler/formatter/tests/snapshots/formatter_tests__format_while_statement_without_parens.snap
+++ b/crates/compiler/formatter/tests/snapshots/formatter_tests__format_while_statement_without_parens.snap
@@ -1,0 +1,9 @@
+---
+source: crates/compiler/formatter/tests/formatter_tests.rs
+expression: format_code(input)
+---
+fn test() -> () {
+    while i != n {
+        i = i + 1;
+    }
+}

--- a/crates/compiler/parser/src/parser.rs
+++ b/crates/compiler/parser/src/parser.rs
@@ -1094,12 +1094,15 @@ where
             })
             .map_with(|stmt, extra| Spanned::new(stmt, extra.span()));
 
-        // While statement: while (condition) { ... }
+        // While statement: supports both `while (cond) { ... }` and `while cond { ... }`
+        let while_condition = choice((
+            expr.clone()
+                .delimited_by(just(TokenType::LParen), just(TokenType::RParen)), // condition in parens
+            expr.clone(), // bare condition
+        ));
+
         let while_stmt = just(TokenType::While)
-            .ignore_then(
-                expr.clone()
-                    .delimited_by(just(TokenType::LParen), just(TokenType::RParen)), // condition in parens
-            )
+            .ignore_then(while_condition)
             .then(statement.clone()) // body
             .map(|(condition, body)| Statement::While {
                 condition,

--- a/crates/compiler/parser/tests/parser/statements.rs
+++ b/crates/compiler/parser/tests/parser/statements.rs
@@ -115,7 +115,9 @@ fn loop_statements_parameterized() {
             in_function("loop { break; }"),
             in_function("loop { continue; }"),
             in_function("while (x != 10) { x = x + 1; }"),
+            in_function("while x != 10 { x = x + 1; }"), // Test without parentheses
             in_function("while (true) { if done { break; } }"),
+            in_function("while true { if done { break; } }"), // Test without parentheses
             in_function("for (let i = 0; i < 10; i = i + 1) { let x = i; }"),
             in_function("for (let item = 0; item < items_len; item = item + 1) { if skip { continue; } process(item); }"),
             in_function("while (outer) { for (let inner = 0; inner < items_len; inner = inner + 1) { if found { break; } } }"),

--- a/crates/compiler/parser/tests/snapshots/parameterized__statements::loop_statements_parameterized_ok.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__statements::loop_statements_parameterized_ok.snap
@@ -244,6 +244,103 @@ fn test() { while (x != 10) { x = x + 1; } }
 ============================================================
 
 --- Input 5 ---
+fn test() { while x != 10 { x = x + 1; } }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        While {
+                            condition: Spanned(
+                                BinaryOp {
+                                    op: Neq,
+                                    left: Spanned(
+                                        Identifier(
+                                            Spanned(
+                                                "x",
+                                                18..19,
+                                            ),
+                                        ),
+                                        18..19,
+                                    ),
+                                    right: Spanned(
+                                        Literal(
+                                            10,
+                                            None,
+                                        ),
+                                        23..25,
+                                    ),
+                                },
+                                18..25,
+                            ),
+                            body: Spanned(
+                                Block(
+                                    [
+                                        Spanned(
+                                            Assignment {
+                                                lhs: Spanned(
+                                                    Identifier(
+                                                        Spanned(
+                                                            "x",
+                                                            28..29,
+                                                        ),
+                                                    ),
+                                                    28..29,
+                                                ),
+                                                rhs: Spanned(
+                                                    BinaryOp {
+                                                        op: Add,
+                                                        left: Spanned(
+                                                            Identifier(
+                                                                Spanned(
+                                                                    "x",
+                                                                    32..33,
+                                                                ),
+                                                            ),
+                                                            32..33,
+                                                        ),
+                                                        right: Spanned(
+                                                            Literal(
+                                                                1,
+                                                                None,
+                                                            ),
+                                                            36..37,
+                                                        ),
+                                                    },
+                                                    32..37,
+                                                ),
+                                            },
+                                            28..38,
+                                        ),
+                                    ],
+                                ),
+                                26..40,
+                            ),
+                        },
+                        12..40,
+                    ),
+                ],
+            },
+            0..42,
+        ),
+    ),
+]
+============================================================
+
+--- Input 6 ---
 fn test() { while (true) { if done { break; } } }
 --- AST ---
 [
@@ -314,7 +411,78 @@ fn test() { while (true) { if done { break; } } }
 ]
 ============================================================
 
---- Input 6 ---
+--- Input 7 ---
+fn test() { while true { if done { break; } } }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        While {
+                            condition: Spanned(
+                                BooleanLiteral(
+                                    true,
+                                ),
+                                18..22,
+                            ),
+                            body: Spanned(
+                                Block(
+                                    [
+                                        Spanned(
+                                            If {
+                                                condition: Spanned(
+                                                    Identifier(
+                                                        Spanned(
+                                                            "done",
+                                                            28..32,
+                                                        ),
+                                                    ),
+                                                    28..32,
+                                                ),
+                                                then_block: Spanned(
+                                                    Block(
+                                                        [
+                                                            Spanned(
+                                                                Break,
+                                                                35..41,
+                                                            ),
+                                                        ],
+                                                    ),
+                                                    33..43,
+                                                ),
+                                                else_block: None,
+                                            },
+                                            25..43,
+                                        ),
+                                    ],
+                                ),
+                                23..45,
+                            ),
+                        },
+                        12..45,
+                    ),
+                ],
+            },
+            0..47,
+        ),
+    ),
+]
+============================================================
+
+--- Input 8 ---
 fn test() { for (let i = 0; i < 10; i = i + 1) { let x = i; } }
 --- AST ---
 [
@@ -451,7 +619,7 @@ fn test() { for (let i = 0; i < 10; i = i + 1) { let x = i; } }
 ]
 ============================================================
 
---- Input 7 ---
+--- Input 9 ---
 fn test() { for (let item = 0; item < items_len; item = item + 1) { if skip { continue; } process(item); } }
 --- AST ---
 [
@@ -625,7 +793,7 @@ fn test() { for (let item = 0; item < items_len; item = item + 1) { if skip { co
 ]
 ============================================================
 
---- Input 8 ---
+--- Input 10 ---
 fn test() { while (outer) { for (let inner = 0; inner < items_len; inner = inner + 1) { if found { break; } } } }
 --- AST ---
 [
@@ -790,7 +958,7 @@ fn test() { while (outer) { for (let inner = 0; inner < items_len; inner = inner
 ]
 ============================================================
 
---- Input 9 ---
+--- Input 11 ---
 fn test() { if condition { loop { work(); if done { break; } } } }
 --- AST ---
 [
@@ -897,7 +1065,7 @@ fn test() { if condition { loop { work(); if done { break; } } } }
 ]
 ============================================================
 
---- Input 10 ---
+--- Input 12 ---
 fn test() { break; }
 --- AST ---
 [
@@ -928,7 +1096,7 @@ fn test() { break; }
 ]
 ============================================================
 
---- Input 11 ---
+--- Input 13 ---
 fn test() { continue; }
 --- AST ---
 [


### PR DESCRIPTION
Make `while` loop conditions optionally parenthesized to align with `if` statements and resolve formatter's invalid output.

The previous parser required parentheses for `while` conditions, but the formatter would remove them, resulting in invalid code (`while condition`). This PR updates the parser to accept both parenthesized and non-parenthesized `while` conditions, making the formatter's consistent output (`while condition`) valid. This aligns `while` statement parsing with `if` statements, which already support both forms.

---
Linear Issue: [CORE-1146](https://linear.app/kkrt-labs/issue/CORE-1146/unwanted-removal-of-parenthesis)

<a href="https://cursor.com/background-agent?bcId=bc-6b504c58-cbd7-4322-9cb0-1e8e996640ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6b504c58-cbd7-4322-9cb0-1e8e996640ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

