### PR TITLE
Fix formatter for c-style for loops

### DIFF
--- a/crates/compiler/formatter/src/rules/statements.rs
+++ b/crates/compiler/formatter/src/rules/statements.rs
@@ -124,7 +124,7 @@ impl Format for Statement {
             } => {
                 let mut parts = vec![Doc::text("for"), Doc::text(" "), Doc::text("(")];
 
-                // Format init without semicolon (we'll add it manually)
+                // Format init (already includes semicolon for let statements)
                 let init_formatted = init.value().format(ctx);
                 parts.push(init_formatted);
                 parts.push(Doc::text(" "));
@@ -133,9 +133,17 @@ impl Format for Statement {
                 parts.push(Doc::text(";"));
                 parts.push(Doc::text(" "));
 
-                // Format step - if it's an expression statement, don't include the semicolon
+                // Format step - need to format without semicolon since this is inside for loop parentheses
                 match step.value() {
                     Self::Expression(expr) => parts.push(expr.value().format(ctx)),
+                    Self::Assignment { lhs, rhs } => {
+                        // Format assignment without semicolon for for-loop context
+                        parts.push(Doc::concat(vec![
+                            lhs.value().format(ctx),
+                            Doc::text(" = "),
+                            rhs.value().format(ctx),
+                        ]));
+                    }
                     _ => parts.push(step.value().format(ctx)),
                 }
 

--- a/crates/compiler/formatter/tests/formatter_tests.rs
+++ b/crates/compiler/formatter/tests/formatter_tests.rs
@@ -81,3 +81,36 @@ fn maj(x: u32, y: u32, z: u32) -> u32 {
 "#;
     assert_eq!(format_code(input), expected);
 }
+
+#[test]
+fn test_for_loop_formatting_with_parentheses() {
+    let input = r#"fn test() -> () {
+    for (let i = 0u32; i < 10; i = i + 1) {
+        do_stuff();
+    }
+}"#;
+    let expected = r#"fn test() -> () {
+    for (let i = 0u32; i < 10; i = i + 1) {
+        do_stuff();
+    }
+}
+"#;
+    assert_eq!(format_code(input), expected);
+}
+
+#[test]  
+fn test_for_loop_formatting_ensures_parentheses() {
+    // Test that formatter always includes parentheses around for loop expressions
+    let input = r#"fn test() -> () {
+    for (let i=0u32;i<10;i=i+1) {
+        do_stuff();
+    }
+}"#;
+    let expected = r#"fn test() -> () {
+    for (let i = 0u32; i < 10; i = i + 1) {
+        do_stuff();
+    }
+}
+"#;
+    assert_eq!(format_code(input), expected);
+}


### PR DESCRIPTION
Fix formatter to correctly handle semicolons and spacing within C-style `for` loop expressions.

Previously, the formatter would either miss a semicolon after the `init` part (for `let` statements) or incorrectly add a trailing semicolon to the `step` part (for assignment statements), resulting in malformed `for` loop syntax. This change ensures proper semicolon placement and spacing for all components within the `for` loop's parentheses.

---
Linear Issue: [CORE-1167](https://linear.app/kkrt-labs/issue/CORE-1167/fix-formatter-with-for-loops)

<a href="https://cursor.com/background-agent?bcId=bc-c0b85bf8-6bc5-4f36-8256-94e755945729">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0b85bf8-6bc5-4f36-8256-94e755945729">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

