### PR TITLE
fix(semantic): prevent self-referential let bindings crash

### DIFF
--- a/crates/compiler/semantic/src/type_resolution.rs
+++ b/crates/compiler/semantic/src/type_resolution.rs
@@ -467,8 +467,12 @@ pub fn expression_semantic_type<'db>(
             TypeId::new(db, TypeData::Error)
         }
         Expression::Identifier(name) => {
-            if let Some((def_idx, _)) =
-                semantic_index.resolve_name_to_definition(name.value(), expr_info.scope_id)
+            if let Some((def_idx, _)) = semantic_index
+                .resolve_name_to_definition_skip_let_initializer(
+                    name.value(),
+                    expr_info.scope_id,
+                    expr_info.ast_span,
+                )
             {
                 let def_id = DefinitionId::new(db, file, def_idx);
                 definition_semantic_type(db, crate_id, def_id)

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__statements::let_local_statements::test_let_statements.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__statements::let_local_statements::test_let_statements.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/compiler/semantic/tests/common/mod.rs
+assertion_line: 423
 expression: snapshot
 ---
 --- Input 1 (ERROR) ---
@@ -11,4 +12,17 @@ fn test() { let x = undefined_var; return; }
  1 │ fn test() { let x = undefined_var; return; }
    │                     ──────┬──────  
    │                           ╰──────── Undeclared variable 'undefined_var'
+───╯
+
+============================================================
+
+--- Input 2 (ERROR) ---
+fn test() { let x = x + 1; return; }
+--- Diagnostics ---
+[1001] Error: Undeclared variable 'x'
+   ╭─[ semantic_tests::statements::let_local_statements::test_let_statements:1:21 ]
+   │
+ 1 │ fn test() { let x = x + 1; return; }
+   │                     ┬  
+   │                     ╰── Undeclared variable 'x'
 ───╯

--- a/crates/compiler/semantic/tests/statements/let_local_statements.rs
+++ b/crates/compiler/semantic/tests/statements/let_local_statements.rs
@@ -17,6 +17,8 @@ fn test_let_statements() {
         ],
         err: [
             in_function("let x = undefined_var;"),
+            // Self-referential assignment when variable is not defined
+            in_function("let x = x + 1;"),
         ]
     }
 }


### PR DESCRIPTION
## Summary
- Fixes crash in semantic analysis when a variable is used in its own initializer expression (e.g., `let x = x + 1;`)
- Adds new resolution methods that skip let bindings when the identifier usage is within the binding's own initializer
- Properly reports undeclared variable error for self-referential assignments

## Changes
- Added `resolve_name_to_definition_skip_let_initializer` and `resolve_name_with_imports_skip_let_initializer` methods to SemanticIndex
- Updated type resolution and scope validation to use the new skip-aware methods
- Added test case to verify the fix handles self-referential let bindings correctly

## Test plan
- [x] Added semantic test for self-referential let binding (`let x = x + 1;`)
- [x] Verified existing tests pass
- [x] Snapshot tests updated and reviewed

Close https://linear.app/kkrt-labs/issue/CORE-989/crash-semantic-analysis-bug-using-variable-declared-in-same-stmt

🤖 Generated with [Claude Code](https://claude.ai/code)