### PR TITLE
fix(cargo-cairo-m): replace template placeholders with valid one

### DIFF
--- a/crates/cargo-cairo-m/src/main.rs
+++ b/crates/cargo-cairo-m/src/main.rs
@@ -93,7 +93,7 @@ fn write_cairom_toml(project_path: &Path, name: &str) -> Result<()> {
 
 fn write_cargo_toml(project_path: &Path, name: &str) -> Result<()> {
     let template = include_str!("../templates/Cargo.toml");
-    let content = template.replace("{{name}}", name);
+    let content = template.replace("cairo-m-template", name);
     fs::write(project_path.join("Cargo.toml"), content).context("Failed to write Cargo.toml")?;
     Ok(())
 }

--- a/crates/cargo-cairo-m/templates/Cargo.toml
+++ b/crates/cargo-cairo-m/templates/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "{{name}}"
+name = "cairo-m-template"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
Close CORE-1187

Replace {{name}} with cairo-m-template in Cargo.toml template to avoid cargo compilation errors when parsing template files