### PR TITLE
fix: double deref memory accesses & add sha test

### DIFF
--- a/crates/common/src/instruction.rs
+++ b/crates/common/src/instruction.rs
@@ -378,13 +378,17 @@ instructions! {
         base_off: (OperandType::Memory(DataType::Felt)),
         imm: (OperandType::Immediate),
         dst_off: (OperandType::Memory(DataType::Felt)),
-    };
+    }, implicit_operands: [
+        (OperandType::Memory(DataType::Felt)),
+    ];
     // [fp + dst_off] = [[fp + base_off] + [fp + offset_off]]
     StoreDoubleDerefFpFp = 42 {
         base_off: (OperandType::Memory(DataType::Felt)),
         offset_off: (OperandType::Memory(DataType::Felt)),
         dst_off: (OperandType::Memory(DataType::Felt)),
-    };
+    }, implicit_operands: [
+        (OperandType::Memory(DataType::Felt)),
+    ];
     // [fp + dst_off] = imm
     StoreImm = 9 {
         imm: (OperandType::Immediate),
@@ -559,13 +563,17 @@ instructions! {
         src_off: (OperandType::Memory(DataType::Felt)),
         imm: (OperandType::Immediate),
         base_off: (OperandType::Memory(DataType::Felt)),
-    };
+    }, implicit_operands: [
+        (OperandType::Memory(DataType::Felt)),
+    ];
     // [[fp + base_off] + [fp + offset_off]] = [fp + src_off]
     StoreToDoubleDerefFpFp = 45 {
         src_off: (OperandType::Memory(DataType::Felt)),
         base_off: (OperandType::Memory(DataType::Felt)),
         offset_off: (OperandType::Memory(DataType::Felt)),
-    };
+    }, implicit_operands: [
+        (OperandType::Memory(DataType::Felt)),
+    ];
 
     // Print operations for debugging
     PrintM31 = 46 { offset: (OperandType::Memory(DataType::Felt)) };

--- a/examples/sha256-cairo-m/Cargo.lock
+++ b/examples/sha256-cairo-m/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
  "smallvec",
  "sonic-rs 0.3.17",
  "stwo-prover",
+ "thiserror 2.0.16",
 ]
 
 [[package]]


### PR DESCRIPTION
SHA256 team had issues running the prover's adapter on the sha256.cm program.
This PR fixes the bug found in the adapter and adds the SHA256 test to the prover crate.
For `DoubleDerefs` the fix was to do add `implicit_operands`:

```
StoreToDoubleDerefFpImm = 44 {
        src_off: (OperandType::Memory(DataType::Felt)),
        imm: (OperandType::Immediate),
        base_off: (OperandType::Memory(DataType::Felt)),
    }, implicit_operands: [
        (OperandType::Memory(DataType::Felt)),
    ];
```