### PR TITLE
feat: add array repetition syntax [value; count]

### DIFF
--- a/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@arrays_in_cairo_m___array_repetition_syntax.snap
+++ b/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@arrays_in_cairo_m___array_repetition_syntax.snap
@@ -1,0 +1,40 @@
+---
+source: crates/compiler/codegen/tests/mdtest_snapshots.rs
+description: "Codegen snapshot for mdtest: Arrays in Cairo-M - Array Repetition Syntax"
+input_file: mdtest/01-basics/05-arrays.md
+---
+Source:
+fn test_main() -> u32 {
+    let (arr1, arr2) = repeat_array_u32_one();
+    return arr1[1] + arr2[2];
+}
+
+fn repeat_array_u32_one() -> ([u32;3], [u32; 4]) {
+    return ([0u32; 3], [1u32; 4]);
+}
+============================================================
+Generated CASM:
+test_main:
+test_main:
+test_main_0:
+   0: 10 10 9 _            // call repeat_array_u32_one
+   1: 8 8 2 2              // [fp + 2] = [[fp + 8] + 2] (load array element)
+   2: 8 8 3 3              // [fp + 3] = [[fp + 8] + 3] (load array element slot 1)
+   3: 8 9 4 4              // [fp + 4] = [[fp + 9] + 4] (load array element)
+   4: 8 9 5 5              // [fp + 5] = [[fp + 9] + 5] (load array element slot 1)
+   5: 15 2 4 6             // u32([fp + 6], [fp + 7]) = u32([fp + 2], [fp + 3]) U32Add u32([fp + 4], [fp + 5])
+   6: 4 6 0 2147483643     // Return value 0 slot 0: [fp -4] = [fp + 6] + 0
+   7: 4 7 0 2147483644     // Return value 0 slot 1: [fp -3] = [fp + 7] + 0
+   8: 11 _ _ _             // return
+repeat_array_u32_one:
+repeat_array_u32_one:
+repeat_array_u32_one_0:
+   9: 43 2 0 _             // [fp + 0] = fp + 2
+  10: 23 1 0 8             // [fp + 8], [fp + 9] = u32(1)
+  11: 23 1 0 10            // [fp + 10], [fp + 11] = u32(1)
+  12: 23 1 0 12            // [fp + 12], [fp + 13] = u32(1)
+  13: 23 1 0 14            // [fp + 14], [fp + 15] = u32(1)
+  14: 43 8 1 _             // [fp + 1] = fp + 8
+  15: 4 0 0 2147483643     // Return value 0: [fp -4] = [fp + 0] + 0
+  16: 4 1 0 2147483644     // Return value 1: [fp -3] = [fp + 1] + 0
+  17: 11 _ _ _             // return

--- a/crates/compiler/formatter/src/rules/expressions.rs
+++ b/crates/compiler/formatter/src/rules/expressions.rs
@@ -90,6 +90,13 @@ impl Format for Expression {
                     Doc::text("]"),
                 ])
             }
+            Self::ArrayRepeat { element, count } => Doc::concat(vec![
+                Doc::text("["),
+                element.value().format(ctx),
+                Doc::text("; "),
+                Doc::text(count.value().to_string()),
+                Doc::text("]"),
+            ]),
             Self::Cast { expr, target_type } => Doc::concat(vec![
                 expr.value().format(ctx),
                 Doc::text(" as "),

--- a/crates/compiler/mir/tests/snapshots/mdtest_mir_snapshots@arrays_in_cairo_m___array_repetition_syntax.snap
+++ b/crates/compiler/mir/tests/snapshots/mdtest_mir_snapshots@arrays_in_cairo_m___array_repetition_syntax.snap
@@ -1,0 +1,42 @@
+---
+source: crates/compiler/mir/tests/mdtest_snapshots.rs
+description: "MIR snapshot for mdtest: Arrays in Cairo-M - Array Repetition Syntax"
+input_file: mdtest/01-basics/05-arrays.md
+---
+Source:
+fn test_main() -> u32 {
+    let (arr1, arr2) = repeat_array_u32_one();
+    return arr1[1] + arr2[2];
+}
+
+fn repeat_array_u32_one() -> ([u32;3], [u32; 4]) {
+    return ([0u32; 3], [1u32; 4]);
+}
+============================================================
+Generated MIR:
+module {
+  // Function 0
+  fn test_main {
+    entry: 0
+
+    0:
+      %0, %1 = call 1()
+      %5 = arrayindex %0, 1
+      %6 = arrayindex %1, 2
+      %7 = %5 U32Add %6
+      return %7
+
+  }
+
+  // Function 1
+  fn repeat_array_u32_one {
+    entry: 0
+
+    0:
+      %0 = makefixedarray [0, 0, 0]
+      %1 = makefixedarray [1, 1, 1, 1]
+      return (%0, %1)
+
+  }
+
+}

--- a/crates/compiler/parser/tests/parser/statements.rs
+++ b/crates/compiler/parser/tests/parser/statements.rs
@@ -49,6 +49,17 @@ fn array_creation_parameterized() {
 }
 
 #[test]
+fn test_array_repeat_syntax() {
+    assert_parses_parameterized! {
+        ok: [
+            in_function("let arr = [1; 3];"),
+            in_function("let arr: [felt; 3] = [1; 3];"),
+            in_function("let arr: [u32; 4] = [1u32; 4];"),
+       ]
+    }
+}
+
+#[test]
 fn assignment_statements_parameterized() {
     assert_parses_parameterized! {
         ok: [

--- a/crates/compiler/parser/tests/snapshots/parameterized__statements::test_array_repeat_syntax_ok.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__statements::test_array_repeat_syntax_ok.snap
@@ -1,0 +1,207 @@
+---
+source: crates/compiler/parser/tests/common.rs
+expression: snapshot
+---
+--- Input 1 ---
+fn test() { let arr = [1; 3]; }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Let {
+                            pattern: Identifier(
+                                Spanned(
+                                    "arr",
+                                    16..19,
+                                ),
+                            ),
+                            statement_type: None,
+                            value: Spanned(
+                                ArrayRepeat {
+                                    element: Spanned(
+                                        Literal(
+                                            1,
+                                            None,
+                                        ),
+                                        23..24,
+                                    ),
+                                    count: Spanned(
+                                        3,
+                                        26..27,
+                                    ),
+                                },
+                                22..28,
+                            ),
+                        },
+                        12..29,
+                    ),
+                ],
+            },
+            0..31,
+        ),
+    ),
+]
+============================================================
+
+--- Input 2 ---
+fn test() { let arr: [felt; 3] = [1; 3]; }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Let {
+                            pattern: Identifier(
+                                Spanned(
+                                    "arr",
+                                    16..19,
+                                ),
+                            ),
+                            statement_type: Some(
+                                Spanned(
+                                    FixedArray {
+                                        element_type: Spanned(
+                                            Named(
+                                                Spanned(
+                                                    Felt,
+                                                    22..26,
+                                                ),
+                                            ),
+                                            22..26,
+                                        ),
+                                        size: Spanned(
+                                            3,
+                                            28..29,
+                                        ),
+                                    },
+                                    21..30,
+                                ),
+                            ),
+                            value: Spanned(
+                                ArrayRepeat {
+                                    element: Spanned(
+                                        Literal(
+                                            1,
+                                            None,
+                                        ),
+                                        34..35,
+                                    ),
+                                    count: Spanned(
+                                        3,
+                                        37..38,
+                                    ),
+                                },
+                                33..39,
+                            ),
+                        },
+                        12..40,
+                    ),
+                ],
+            },
+            0..42,
+        ),
+    ),
+]
+============================================================
+
+--- Input 3 ---
+fn test() { let arr: [u32; 4] = [1u32; 4]; }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Let {
+                            pattern: Identifier(
+                                Spanned(
+                                    "arr",
+                                    16..19,
+                                ),
+                            ),
+                            statement_type: Some(
+                                Spanned(
+                                    FixedArray {
+                                        element_type: Spanned(
+                                            Named(
+                                                Spanned(
+                                                    U32,
+                                                    22..25,
+                                                ),
+                                            ),
+                                            22..25,
+                                        ),
+                                        size: Spanned(
+                                            4,
+                                            27..28,
+                                        ),
+                                    },
+                                    21..29,
+                                ),
+                            ),
+                            value: Spanned(
+                                ArrayRepeat {
+                                    element: Spanned(
+                                        Literal(
+                                            1,
+                                            Some(
+                                                "u32",
+                                            ),
+                                        ),
+                                        33..37,
+                                    ),
+                                    count: Spanned(
+                                        4,
+                                        39..40,
+                                    ),
+                                },
+                                32..41,
+                            ),
+                        },
+                        12..42,
+                    ),
+                ],
+            },
+            0..44,
+        ),
+    ),
+]

--- a/crates/compiler/semantic/src/type_resolution_tests.rs
+++ b/crates/compiler/semantic/src/type_resolution_tests.rs
@@ -226,6 +226,7 @@ fn test_expression_type_coverage() {
             Expression::StructLiteral { .. } => "StructLiteral",
             Expression::Tuple(_) => "Tuple",
             Expression::ArrayLiteral(_) => "ArrayLiteral",
+            Expression::ArrayRepeat { .. } => "ArrayRepeat",
             Expression::TupleIndex { .. } => "TupleIndex",
             Expression::Cast { .. } => "Cast",
         };

--- a/crates/compiler/semantic/tests/arrays/array_literals.rs
+++ b/crates/compiler/semantic/tests/arrays/array_literals.rs
@@ -26,6 +26,11 @@ fn test_array_literal_type_inference() {
             // Arrays with trailing comma
             in_function("let arr = [1, 2, 3,];"),
 
+            // Array repetition
+            in_function("let arr = [1; 10];"),
+            in_function("let arr: [felt; 3] = [1; 3];"),
+            in_function("let arr: [u32; 4] = [1u32; 4];"),
+
             ],
         err: [
                 // Mixed types in array literal
@@ -52,6 +57,10 @@ fn test_array_literal_type_inference() {
                 // Nested arrays (not supported yet)
             in_function("let arr = [[1, 2], [3, 4]];"),
             in_function("let arr: [[felt; 2]; 2] = [[1, 2], [3, 4]];"),
+
+                // Array repetition with type mismatch
+                in_function("let arr: [felt; 4] = [1u32; 4];"),
+                in_function("let arr: [u32; 5] = [1u32; 4];"),
         ]
     }
 }

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__arrays::array_literals::test_array_literal_type_inference.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__arrays::array_literals::test_array_literal_type_inference.snap
@@ -182,3 +182,36 @@ fn test() { let arr: [[felt; 2]; 2] = [[1, 2], [3, 4]]; return; }
    │                                       ────────┬───────  
    │                                               ╰───────── Nested arrays are not supported yet
 ───╯
+
+============================================================
+
+--- Input 14 (ERROR) ---
+fn test() { let arr: [felt; 4] = [1u32; 4]; return; }
+--- Diagnostics ---
+[2001] Error: Type mismatch for let statement `arr`. Expected `[felt; 4]`, found `[u32; 4]`
+   ╭─[ semantic_tests::arrays::array_literals::test_array_literal_type_inference:1:34 ]
+   │
+ 1 │ fn test() { let arr: [felt; 4] = [1u32; 4]; return; }
+   │                                  ────┬────  
+   │                                      ╰────── Type mismatch for let statement `arr`. Expected `[felt; 4]`, found `[u32; 4]`
+───╯
+[2001] Error: Array element has type `u32`, but expected `felt`
+   ╭─[ semantic_tests::arrays::array_literals::test_array_literal_type_inference:1:35 ]
+   │
+ 1 │ fn test() { let arr: [felt; 4] = [1u32; 4]; return; }
+   │                                   ──┬─  
+   │                                     ╰─── Array element has type `u32`, but expected `felt`
+───╯
+
+============================================================
+
+--- Input 15 (ERROR) ---
+fn test() { let arr: [u32; 5] = [1u32; 4]; return; }
+--- Diagnostics ---
+[2001] Error: Type mismatch for let statement `arr`. Expected `[u32; 5]`, found `[u32; 4]`
+   ╭─[ semantic_tests::arrays::array_literals::test_array_literal_type_inference:1:33 ]
+   │
+ 1 │ fn test() { let arr: [u32; 5] = [1u32; 4]; return; }
+   │                                 ────┬────  
+   │                                     ╰────── Type mismatch for let statement `arr`. Expected `[u32; 5]`, found `[u32; 4]`
+───╯

--- a/examples/sha256-cairo-m/Cargo.lock
+++ b/examples/sha256-cairo-m/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
  "smallvec",
  "sonic-rs 0.3.17",
  "stwo-prover",
+ "thiserror 2.0.16",
 ]
 
 [[package]]

--- a/examples/sha256-cairo-m/src/sha256.cm
+++ b/examples/sha256-cairo-m/src/sha256.cm
@@ -59,7 +59,7 @@ fn maj(x: u32, y: u32, z: u32) -> u32 {
 /// Updates the hash state H in-place.
 fn process_chunk(chunk: [u32; 16], H: [u32; 8]) {
     // Message schedule array
-    let W: [u32; 64] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // Copy chunk into first 16 words of message schedule
+    let W: [u32; 64] = [0u32; 64];
     for (let t: felt = 0; t != 16; t = t + 1) {
         W[t] = chunk[t];
     } // Extend the message schedule
@@ -100,11 +100,11 @@ fn process_chunk(chunk: [u32; 16], H: [u32; 8]) {
 }
 
 /// Computes SHA-256 hash of a pre-padded message.
-/// 
+///
 /// ## Arguments
 /// * `padded_message` - A buffer of 32 u32 words (128 bytes)
 /// * `num_chunks` - The number of 16-word (64-byte) chunks to process
-/// 
+///
 /// ## Returns
 /// The SHA-256 hash as an array of 8 u32 words
 fn sha256_hash(padded_message: [u32; 32], num_chunks: felt) -> [u32; 8] {
@@ -118,9 +118,9 @@ fn sha256_hash(padded_message: [u32; 32], num_chunks: felt) -> [u32; 8] {
         528734635,
         1541459225
     ];
-    
+
     for (let chunk_index: felt = 0; chunk_index != num_chunks; chunk_index = chunk_index + 1) {
-        let current_chunk: [u32; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let current_chunk: [u32; 16] = [0u32; 16];
         for (let i: felt = 0; i != 16; i = i + 1) {
             current_chunk[i] = padded_message[chunk_index * 16 + i];
         }

--- a/mdtest/01-basics/05-arrays.md
+++ b/mdtest/01-basics/05-arrays.md
@@ -19,6 +19,26 @@ fn create_array_u32() -> u32 {
 }
 ```
 
+## Array Repetition Syntax
+
+You can create a fixed-size array by repeating a single element using the
+`[elem; N]` syntax (similar to Rust):
+
+```cairo-m
+fn test_main() -> u32 {
+    let (arr1, arr2) = repeat_array_u32_one();
+    return arr1[1] + arr2[2];
+}
+
+fn repeat_array_u32_one() -> ([u32;3], [u32; 4]) {
+    return ([0u32; 3], [1u32; 4]);
+}
+```
+
+Note: when the repeated element is zero, the compiler avoids writing each
+element explicitly as the stack is zero-initialized; it only reserves the space
+and stores the pointer.
+
 ## Array Element Assignment
 
 ```cairo-m


### PR DESCRIPTION
## Summary

This PR implements array repetition syntax for Cairo-M, allowing developers to create arrays with repeated values using the concise `[value; count]` syntax. This feature matches Rust's array initialization syntax and significantly improves code readability when working with arrays that need to be initialized with the same value.

**Key Changes:**
- ✨ Added new array repetition syntax `[value; count]` to the language
- 🔧 Extended parser to recognize and parse the new syntax  
- ✅ Added comprehensive semantic validation for type checking and count validation
- 🚀 Implemented MIR lowering that expands repetitions into repeated elements
- 📝 Added documentation and test cases demonstrating the new feature

## Examples

```cairo
// Initialize array with zeros
let x: [u32; 4] = [0; 4];  // Creates [0, 0, 0, 0]

// Initialize with any value
let y = [42; 3];            // Creates [42, 42, 42]

// Works with any type
let flags: [bool; 5] = [true; 5];  // Creates [true, true, true, true, true]
```

## Implementation Details

The implementation follows the compiler's multi-phase architecture:

1. **Parser**: Extended the array literal parser to handle semicolon-separated repetition syntax
2. **Semantic Analysis**: Added validation to ensure:
   - Repetition count is a literal integer
   - Value type matches the array element type
   - Count matches array size (when type is explicit)
3. **MIR Generation**: Transforms repetition syntax into expanded array with repeated elements
4. **Code Generation**: Generates efficient CASM code for repeated values

## Testing

Added comprehensive test coverage across all compiler phases:
- Parser snapshot tests for AST structure
- Semantic validation tests for type checking
- MIR snapshot tests for lowering verification
- Codegen snapshot tests for assembly output
- Integration test in `mdtest/01-basics/05-arrays.md`

## Future Optimizations

As noted in the Linear issue, future optimizations could include:
- Skip memory writes when initializing with zero values
- Use efficient memory fill operations for non-zero repeated values

Close CORE-1176