### PR TITLE
fix(compiler): add semantic validation for const variable element assignments

### DIFF
--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__statements::assignments::test_const_assignment.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__statements::assignments::test_const_assignment.snap
@@ -149,3 +149,20 @@ struct Point { x: u32, y: u32 } const TP: (Point, u32) = (Point { x: 1u32, y: 2u
    │                                                                                                             │    
    │                                                                                                             ╰──── cannot assign to field of const variable `TP`
 ───╯
+
+============================================================
+
+--- Input 11 (ERROR) ---
+const ARR: [u32; 3] = [1u32, 2u32, 3u32];
+// --- main.cm ---
+use constants::ARR; fn test() { ARR[0] = 9u32; return; }
+--- Diagnostics ---
+[2014] Error: cannot assign to element of const variable `ARR`
+   ╭─[ main.cm:1:33 ]
+   │
+ 1 │ const ARR: [u32; 3] = [1u32, 2u32, 3u32];
+   │       ─┬─                       ──┬──  
+   │        ╰─────────────────────────────── const variable defined here
+   │                                   │    
+   │                                   ╰──── cannot assign to element of const variable `ARR`
+───╯

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__statements::assignments::test_const_assignment.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__statements::assignments::test_const_assignment.snap
@@ -29,3 +29,123 @@ fn test() { const x = 42; x = 100; return; }
    │                                           ──┬──  
    │                                             ╰──── Array element at index 2 has type `felt`, but expected `u32` to match first element
 ───╯
+
+============================================================
+
+--- Input 3 (ERROR) ---
+const POW2: [u32; 5] = [1u32, 2, 4, 8, 16]; fn test() { POW2[0] = 10u32; return; }
+--- Diagnostics ---
+[2014] Error: cannot assign to element of const variable `POW2`
+   ╭─[ semantic_tests::statements::assignments::test_const_assignment:1:57 ]
+   │
+ 1 │ const POW2: [u32; 5] = [1u32, 2, 4, 8, 16]; fn test() { POW2[0] = 10u32; return; }
+   │       ──┬─                                              ───┬──  
+   │         ╰─────────────────────────────────────────────────────── const variable defined here
+   │                                                            │    
+   │                                                            ╰──── cannot assign to element of const variable `POW2`
+───╯
+
+============================================================
+
+--- Input 4 (ERROR) ---
+struct Point { x: felt, y: felt } const P: Point = Point { x: 1, y: 2 }; fn test() { P.x = 3; return; }
+--- Diagnostics ---
+[2014] Error: cannot assign to field of const variable `P`
+   ╭─[ semantic_tests::statements::assignments::test_const_assignment:1:86 ]
+   │
+ 1 │ struct Point { x: felt, y: felt } const P: Point = Point { x: 1, y: 2 }; fn test() { P.x = 3; return; }
+   │                                         ┬                                            ─┬─  
+   │                                         ╰───────────────────────────────────────────────── const variable defined here
+   │                                                                                       │   
+   │                                                                                       ╰─── cannot assign to field of const variable `P`
+───╯
+
+============================================================
+
+--- Input 5 (ERROR) ---
+const T = (1u32, 2u32); fn test() { T.0 = 3u32; return; }
+--- Diagnostics ---
+[2014] Error: cannot assign to element of const variable `T`
+   ╭─[ semantic_tests::statements::assignments::test_const_assignment:1:37 ]
+   │
+ 1 │ const T = (1u32, 2u32); fn test() { T.0 = 3u32; return; }
+   │       ┬                             ─┬─  
+   │       ╰────────────────────────────────── const variable defined here
+   │                                      │   
+   │                                      ╰─── cannot assign to element of const variable `T`
+───╯
+
+============================================================
+
+--- Input 6 (ERROR) ---
+struct Point { x: u32, y: u32 } const ARR: [Point; 2] = [Point { x: 1u32, y: 2u32 }, Point { x: 3u32, y: 4u32 }]; fn test() { ARR[0].x = 7u32; return; }
+--- Diagnostics ---
+[2014] Error: cannot assign to field of const variable `ARR`
+   ╭─[ semantic_tests::statements::assignments::test_const_assignment:1:127 ]
+   │
+ 1 │ struct Point { x: u32, y: u32 } const ARR: [Point; 2] = [Point { x: 1u32, y: 2u32 }, Point { x: 3u32, y: 4u32 }]; fn test() { ARR[0].x = 7u32; return; }
+   │                                       ─┬─                                                                                     ────┬───  
+   │                                        ╰──────────────────────────────────────────────────────────────────────────────────────────────── const variable defined here
+   │                                                                                                                                   │     
+   │                                                                                                                                   ╰───── cannot assign to field of const variable `ARR`
+───╯
+
+============================================================
+
+--- Input 7 (ERROR) ---
+const POW2A: [u32; 2] = [1u32, 2u32]; fn test() { (POW2A)[1] = 1u32; return; }
+--- Diagnostics ---
+[2014] Error: cannot assign to element of const variable `POW2A`
+   ╭─[ semantic_tests::statements::assignments::test_const_assignment:1:51 ]
+   │
+ 1 │ const POW2A: [u32; 2] = [1u32, 2u32]; fn test() { (POW2A)[1] = 1u32; return; }
+   │       ──┬──                                       ────┬────  
+   │         ╰──────────────────────────────────────────────────── const variable defined here
+   │                                                       │      
+   │                                                       ╰────── cannot assign to element of const variable `POW2A`
+───╯
+
+============================================================
+
+--- Input 8 (ERROR) ---
+const TA: ([u32; 3], u32) = ([1u32, 2u32, 3u32], 0u32); fn test() { TA.0[1] = 5u32; return; }
+--- Diagnostics ---
+[2014] Error: cannot assign to element of const variable `TA`
+   ╭─[ semantic_tests::statements::assignments::test_const_assignment:1:69 ]
+   │
+ 1 │ const TA: ([u32; 3], u32) = ([1u32, 2u32, 3u32], 0u32); fn test() { TA.0[1] = 5u32; return; }
+   │       ─┬                                                            ───┬──  
+   │        ╰──────────────────────────────────────────────────────────────────── const variable defined here
+   │                                                                        │    
+   │                                                                        ╰──── cannot assign to element of const variable `TA`
+───╯
+
+============================================================
+
+--- Input 9 (ERROR) ---
+struct Point { x: felt, y: felt } const P2: Point = Point { x: 1, y: 2 }; fn test() { (P2).x = 2; return; }
+--- Diagnostics ---
+[2014] Error: cannot assign to field of const variable `P2`
+   ╭─[ semantic_tests::statements::assignments::test_const_assignment:1:87 ]
+   │
+ 1 │ struct Point { x: felt, y: felt } const P2: Point = Point { x: 1, y: 2 }; fn test() { (P2).x = 2; return; }
+   │                                         ─┬                                            ───┬──  
+   │                                          ╰──────────────────────────────────────────────────── const variable defined here
+   │                                                                                          │    
+   │                                                                                          ╰──── cannot assign to field of const variable `P2`
+───╯
+
+============================================================
+
+--- Input 10 (ERROR) ---
+struct Point { x: u32, y: u32 } const TP: (Point, u32) = (Point { x: 1u32, y: 2u32 }, 5u32); fn test() { TP.0.x = 2u32; return; }
+--- Diagnostics ---
+[2014] Error: cannot assign to field of const variable `TP`
+   ╭─[ semantic_tests::statements::assignments::test_const_assignment:1:106 ]
+   │
+ 1 │ struct Point { x: u32, y: u32 } const TP: (Point, u32) = (Point { x: 1u32, y: 2u32 }, 5u32); fn test() { TP.0.x = 2u32; return; }
+   │                                       ─┬                                                                 ───┬──  
+   │                                        ╰───────────────────────────────────────────────────────────────────────── const variable defined here
+   │                                                                                                             │    
+   │                                                                                                             ╰──── cannot assign to field of const variable `TP`
+───╯

--- a/crates/compiler/semantic/tests/statements/assignments.rs
+++ b/crates/compiler/semantic/tests/statements/assignments.rs
@@ -102,6 +102,25 @@ fn test_const_assignment() {
                 "struct Point {{ x: u32, y: u32 }} const TP: (Point, u32) = (Point {{ x: 1u32, y: 2u32 }}, 5u32); {}",
                 in_function("TP.0.x = 2u32;")
             ),
+
+            // Cross-module const: import and mutate should be rejected
+            // constants.cm defines a const array; main imports and tries to assign
+            crate::multi_file(
+                "main.cm",
+                &[
+                    (
+                        "constants.cm",
+                        "const ARR: [u32; 3] = [1u32, 2u32, 3u32];",
+                    ),
+                    (
+                        "main.cm",
+                        &format!(
+                            "use constants::ARR; {}",
+                            in_function("ARR[0] = 9u32;")
+                        ),
+                    ),
+                ],
+            ),
         ]
     }
 }

--- a/crates/compiler/semantic/tests/statements/assignments.rs
+++ b/crates/compiler/semantic/tests/statements/assignments.rs
@@ -63,6 +63,45 @@ fn test_const_assignment() {
             r#"
             const POW2: [u32; 3] = [1, 2, 4felt];
             "#,
+            format!(
+                "const POW2: [u32; 5] = [1u32, 2, 4, 8, 16]; {}",
+                in_function("POW2[0] = 10u32;")
+            ),
+            // Field assignment on const struct
+            format!(
+                "struct Point {{ x: felt, y: felt }} const P: Point = Point {{ x: 1, y: 2 }}; {}",
+                in_function("P.x = 3;")
+            ),
+            // Tuple element assignment on const tuple
+            format!(
+                "const T = (1u32, 2u32); {}",
+                in_function("T.0 = 3u32;")
+            ),
+            // Nested: array of structs, assign field of element
+            format!(
+                "struct Point {{ x: u32, y: u32 }} const ARR: [Point; 2] = [Point {{ x: 1u32, y: 2u32 }}, Point {{ x: 3u32, y: 4u32 }}]; {}",
+                in_function("ARR[0].x = 7u32;")
+            ),
+            // Parenthesized const root
+            format!(
+                "const POW2A: [u32; 2] = [1u32, 2u32]; {}",
+                in_function("(POW2A)[1] = 1u32;")
+            ),
+            // Tuple containing array: assign into array element through tuple index
+            format!(
+                "const TA: ([u32; 3], u32) = ([1u32, 2u32, 3u32], 0u32); {}",
+                in_function("TA.0[1] = 5u32;")
+            ),
+            // Parenthesized const struct root
+            format!(
+                "struct Point {{ x: felt, y: felt }} const P2: Point = Point {{ x: 1, y: 2 }}; {}",
+                in_function("(P2).x = 2;")
+            ),
+            // Tuple of struct: assign field via tuple index
+            format!(
+                "struct Point {{ x: u32, y: u32 }} const TP: (Point, u32) = (Point {{ x: 1u32, y: 2u32 }}, 5u32); {}",
+                in_function("TP.0.x = 2u32;")
+            ),
         ]
     }
 }


### PR DESCRIPTION
## Summary

- Implement comprehensive const assignment validation to prevent mutations to const variables and their nested elements
- Add recursive checking through member accesses, index accesses, and tuple indices to trace back to const root variables
- Provide clear error diagnostics with related spans showing where const variables are defined

## Changes

This PR adds semantic validation in the type validator to detect and reject assignments to const variables and their nested elements:

- **Array element assignments**: `POW2[0] = 10` is now properly rejected
- **Struct field assignments**: `const_struct.field = value` is rejected
- **Tuple element assignments**: `const_tuple.0 = value` is rejected  
- **Nested combinations**: Complex expressions like `const_array[0].field` or `const_tuple.0[1]` are properly traced back to their const root

The implementation uses a recursive helper function `lvalue_resolves_to_const` that traverses through the LHS expression tree to determine if it ultimately references a const variable, handling parenthesized expressions and all forms of member/index access.

## Test Plan

- [x] Added comprehensive test cases covering all const assignment scenarios
- [x] All existing tests pass
- [x] Snapshot tests updated with expected error messages
- [x] Verified error messages include helpful related spans pointing to const definitions

Close https://linear.app/kkrt-labs/issue/CORE-1214/const-array-semantic-rejection-not-working

🤖 Generated with [Claude Code](https://claude.ai/code)