### PR TITLE
feat(semantic): forbid const arrays escaping by pointer (calls, aggregates, returns)

### DIFF
--- a/crates/compiler/diagnostics/src/diagnostics.rs
+++ b/crates/compiler/diagnostics/src/diagnostics.rs
@@ -120,6 +120,8 @@ pub enum DiagnosticCode {
     AssignmentToConst,
     IndexOutOfBounds,
     TypeInferenceError,
+    /// Passing or embedding a const array by pointer (disallowed); user must copy first
+    ConstArrayByPointer,
     // TODO: Add more type-related diagnostic codes:
     // - InvalidTypeAnnotation
     // - TypeArgumentMismatch
@@ -184,6 +186,7 @@ impl From<DiagnosticCode> for u32 {
             DiagnosticCode::AssignmentToConst => 2014,
             DiagnosticCode::IndexOutOfBounds => 2015,
             DiagnosticCode::TypeInferenceError => 2016,
+            DiagnosticCode::ConstArrayByPointer => 2017,
             DiagnosticCode::InternalError => 9001,
         }
     }

--- a/crates/compiler/semantic/tests/arrays/const_arrays.rs
+++ b/crates/compiler/semantic/tests/arrays/const_arrays.rs
@@ -1,0 +1,57 @@
+//! Tests for semantic validation of const arrays escaping by pointer
+use crate::assert_semantic_parameterized;
+
+#[test]
+fn test_const_arrays_cant_be_written_to() {
+    assert_semantic_parameterized! {
+        ok: [
+            r#"
+            const ARR: [u32; 2] = [1u32, 2u32];
+            fn main() { let _x = ARR[0]; return;}
+            "#,
+        ],
+        err: [
+            r#"
+            const ARR: [u32; 2] = [1u32, 2u32];
+            fn main() { ARR[0] = 3u32; return; }
+            "#,
+        ]
+    }
+}
+
+#[test]
+fn test_const_arrays_blocked_in_calls_and_aggregates() {
+    assert_semantic_parameterized! {
+        ok: [
+            r#"
+            const ARR: [u32; 2] = [1u32, 2u32];
+            fn id(a: u32) -> u32 { return a; }
+            fn main() { let _x = ARR[0]; return; }
+            "#,
+        ],
+        err: [
+            // Passing const array to function parameter
+            r#"
+            const ARR: [u32; 2] = [1u32, 2u32];
+            fn f(a: [u32; 2]) { let _ = a[0]; return; }
+            fn main() { f(ARR); return; }
+            "#,
+            // Embedding const array in struct field of array type
+            r#"
+            struct S { a: [u32; 2] }
+            const ARR: [u32; 2] = [1u32, 2u32];
+            fn main() { let _s = S { a: ARR }; return; }
+            "#,
+            // Returning const array in function with array return type
+            r#"
+            const ARR: [u32; 2] = [1u32, 2u32];
+            fn give() -> [u32; 2] { return ARR; }
+            "#,
+            // Tuple embedding
+            r#"
+            const ARR: [u32; 2] = [1u32, 2u32];
+            fn main() { let _t = (ARR, 1u32); return; }
+            "#,
+        ]
+    }
+}

--- a/crates/compiler/semantic/tests/arrays/mod.rs
+++ b/crates/compiler/semantic/tests/arrays/mod.rs
@@ -1,3 +1,5 @@
 pub mod array_indexing;
 pub mod array_literals;
 pub mod array_types;
+
+pub mod const_arrays;

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__arrays::const_arrays::test_const_arrays_blocked_in_calls_and_aggregates.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__arrays::const_arrays::test_const_arrays_blocked_in_calls_and_aggregates.snap
@@ -1,0 +1,80 @@
+---
+source: crates/compiler/semantic/tests/common/mod.rs
+expression: snapshot
+---
+--- Input 1 (ERROR) ---
+
+            const ARR: [u32; 2] = [1u32, 2u32];
+            fn f(a: [u32; 2]) { let _ = a[0]; return; }
+            fn main() { f(ARR); return; }
+            
+--- Diagnostics ---
+[2017] Error: cannot pass const array `ARR` by pointer; make a writable copy first
+   ╭─[ semantic_tests::arrays::const_arrays::test_const_arrays_blocked_in_calls_and_aggregates:4:27 ]
+   │
+ 2 │             const ARR: [u32; 2] = [1u32, 2u32];
+   │                   ─┬─  
+   │                    ╰─── const defined here
+   │ 
+ 4 │             fn main() { f(ARR); return; }
+   │                           ─┬─  
+   │                            ╰─── cannot pass const array `ARR` by pointer; make a writable copy first
+───╯
+
+============================================================
+
+--- Input 2 (ERROR) ---
+
+            struct S { a: [u32; 2] }
+            const ARR: [u32; 2] = [1u32, 2u32];
+            fn main() { let _s = S { a: ARR }; return; }
+            
+--- Diagnostics ---
+[2017] Error: cannot embed const array `ARR` in struct field `a`; make a writable copy first
+   ╭─[ semantic_tests::arrays::const_arrays::test_const_arrays_blocked_in_calls_and_aggregates:4:41 ]
+   │
+ 3 │             const ARR: [u32; 2] = [1u32, 2u32];
+   │                   ─┬─  
+   │                    ╰─── const defined here
+ 4 │             fn main() { let _s = S { a: ARR }; return; }
+   │                                         ─┬─  
+   │                                          ╰─── cannot embed const array `ARR` in struct field `a`; make a writable copy first
+───╯
+
+============================================================
+
+--- Input 3 (ERROR) ---
+
+            const ARR: [u32; 2] = [1u32, 2u32];
+            fn give() -> [u32; 2] { return ARR; }
+            
+--- Diagnostics ---
+[2017] Error: cannot return const array `ARR` by pointer; make a writable copy first
+   ╭─[ semantic_tests::arrays::const_arrays::test_const_arrays_blocked_in_calls_and_aggregates:3:44 ]
+   │
+ 2 │             const ARR: [u32; 2] = [1u32, 2u32];
+   │                   ─┬─  
+   │                    ╰─── const defined here
+ 3 │             fn give() -> [u32; 2] { return ARR; }
+   │                                            ─┬─  
+   │                                             ╰─── cannot return const array `ARR` by pointer; make a writable copy first
+───╯
+
+============================================================
+
+--- Input 4 (ERROR) ---
+
+            const ARR: [u32; 2] = [1u32, 2u32];
+            fn main() { let _t = (ARR, 1u32); return; }
+            
+--- Diagnostics ---
+[2017] Error: cannot embed const array `ARR` in tuple; make a writable copy first
+   ╭─[ semantic_tests::arrays::const_arrays::test_const_arrays_blocked_in_calls_and_aggregates:3:35 ]
+   │
+ 2 │             const ARR: [u32; 2] = [1u32, 2u32];
+   │                   ─┬─  
+   │                    ╰─── const defined here
+ 3 │             fn main() { let _t = (ARR, 1u32); return; }
+   │                                   ─┬─  
+   │                                    ╰─── cannot embed const array `ARR` in tuple; make a writable copy first
+───╯

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__arrays::const_arrays::test_const_arrays_cant_be_written_to.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__arrays::const_arrays::test_const_arrays_cant_be_written_to.snap
@@ -1,0 +1,20 @@
+---
+source: crates/compiler/semantic/tests/common/mod.rs
+expression: snapshot
+---
+--- Input 1 (ERROR) ---
+
+            const ARR: [u32; 2] = [1u32, 2u32];
+            fn main() { ARR[0] = 3u32; return; }
+            
+--- Diagnostics ---
+[2014] Error: cannot assign to element of const variable `ARR`
+   ╭─[ semantic_tests::arrays::const_arrays::test_const_arrays_cant_be_written_to:3:25 ]
+   │
+ 2 │             const ARR: [u32; 2] = [1u32, 2u32];
+   │                   ─┬─  
+   │                    ╰─── const variable defined here
+ 3 │             fn main() { ARR[0] = 3u32; return; }
+   │                         ──┬──  
+   │                           ╰──── cannot assign to element of const variable `ARR`
+───╯


### PR DESCRIPTION
This PR adds semantic validation to prevent const arrays from escaping by pointer. It surfaces clear diagnostics early and avoids accidental mutation of read‑only const arrays via aliasing.

Summary
- Rejects passing const arrays to function parameters of type `[T; N]`.
- Rejects embedding const arrays into aggregates (struct fields and tuple elements) of type `[T; N]`.
- Rejects returning const arrays where the function return type is `[T; N]`.
- Adds a dedicated diagnostic code and thorough tests with snapshots.

Diagnostics
- Add `ConstArrayByPointer` (2017) to error when a const array is passed/embedded/returned by pointer.
  - File: `crates/compiler/diagnostics/src/diagnostics.rs`

Semantic checks (TypeValidator)
- Helper: detect when an expression resolves to a const array identifier (local or imported).
  - `expr_resolves_to_const_array(...)`
  - File: `crates/compiler/semantic/src/validation/type_validator.rs`

- Function calls: disallow passing const arrays to array parameters.
  - `check_function_call_types(...)` adds an error when `param_type` is `FixedArray` and arg resolves to a const array.
  - File: `crates/compiler/semantic/src/validation/type_validator.rs`

- Struct literals: disallow embedding const arrays in fields with array type.
  - `check_struct_literal_types(...)` adds an error for array field types whose value resolves to a const array.
  - File: `crates/compiler/semantic/src/validation/type_validator.rs`

- Tuple literals: disallow embedding const arrays in tuple elements.
  - `check_expression_types(...)` match arm for `Expression::Tuple` adds an error if any element resolves to a const array.
  - File: `crates/compiler/semantic/src/validation/type_validator.rs`

- Returns: disallow returning const arrays for functions with array return type.
  - `check_return_types(...)` adds an error when expected return type is `FixedArray` and the return expression resolves to a const array.
  - File: `crates/compiler/semantic/src/validation/type_validator.rs`

Tests
- New tests to validate behavior and diagnostics:
  - `crates/compiler/semantic/tests/arrays/const_arrays.rs`
    - `test_const_arrays_cant_be_written_to` (safety baseline)
    - `test_const_arrays_blocked_in_calls_and_aggregates` (calls, struct, tuple, return)
  - Snapshots:
    - `crates/compiler/semantic/tests/common/snapshots/parameterized__arrays::const_arrays::test_const_arrays_cant_be_written_to.snap`
    - `crates/compiler/semantic/tests/common/snapshots/parameterized__arrays::const_arrays::test_const_arrays_blocked_in_calls_and_aggregates.snap`

Rationale
- Arrays are passed by pointer; const arrays live in read‑only memory. Allowing these pointers to escape enables mutations through aliases. Enforcing this rule at the semantic layer gives users clear, actionable errors and prevents subtle bugs.

Follow‑ups (optional)
- Provide a standard `array_copy([T; N]) -> [T; N]` helper/builtin and reference it in diagnostics to guide remediation.
- If desired later: relax rule for functions proven read‑only on the parameter via simple analysis.
