### PR TITLE
feat(vm): change memory from vec to hashmap

### DIFF
--- a/crates/runner/src/vm/mod.rs
+++ b/crates/runner/src/vm/mod.rs
@@ -186,7 +186,7 @@ impl VM {
             self.segments.push(Segment {
                 initial_memory: std::mem::replace(
                     &mut self.initial_memory,
-                    self.memory.data.clone(),
+                    self.memory.linear_snapshot(self.program_length.0),
                 ),
                 memory_trace: std::mem::take(&mut self.memory.trace),
                 trace: std::mem::take(&mut self.trace),
@@ -239,7 +239,7 @@ impl VM {
 
         self.memory
             .insert_entrypoint_call(&self.final_pc, &self.state.fp)?;
-        self.initial_memory = self.memory.data.clone();
+        self.initial_memory = self.memory.linear_snapshot(self.program_length.0);
 
         loop {
             match self.execute(options.max_steps) {


### PR DESCRIPTION
This PR changes the VM memory from a 'Vec<QM31>` to a `HashMap<u32, QM31>`, allowing to grow memory from both sides without bloating RAM.

This should fix #305 and help us implement dynamic memory in Cairo-M later on.

Fib 100'000 only performs ~25% worse