### PR TITLE
bench: add lto and codegen-units settings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,11 @@
 # lld must be installed! Run: `brew install lld`
-[target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/opt/lld/bin/ld64.lld"]
+[target.'cfg(target_os = "macos")']
+rustflags = [
+  "-C",
+  "target-cpu=native",
+  "-C",
+  "link-arg=-fuse-ld=/opt/homebrew/opt/lld/bin/ld64.lld",
+]
+
+[target.'cfg(not(target_os = "macos"))']
+rustflags = ["-C", "target-cpu=native"]

--- a/.github/workflows/benchmark-prover.yml
+++ b/.github/workflows/benchmark-prover.yml
@@ -42,12 +42,12 @@ jobs:
       - name: Run prover speed benchmarks
         run: |
           cd crates/prover
-          cargo bench --bench prover_speed_benchmark -- --output-format bencher | tee speed_output.txt
+          cargo bench --bench prover_speed_benchmark --profile release-lto -- --output-format bencher | tee speed_output.txt
 
       - name: Run prover memory benchmarks
         run: |
           cd crates/prover
-          cargo bench --bench prover_memory_benchmark -- --nocapture > mem_output.json
+          cargo bench --bench prover_memory_benchmark --profile release-lto -- --nocapture > mem_output.json
 
       - name: Store prover speed benchmark result (main branch)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run benchmarks
         run: |
           cd crates/runner
-          cargo bench --bench vm_benchmark -- --output-format bencher | tee output.txt
+          cargo bench --bench vm_benchmark --profile release-lto -- --output-format bencher | tee output.txt
 
       - name: Store benchmark result (main branch)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,8 @@ stwo-constraint-framework = { path = "external/stwo/crates/constraint_framework"
 # TODO: Remove this patch once https://github.com/HorizenLabs/poseidon2/pull/XXX is merged
 [patch."https://github.com/HorizenLabs/poseidon2.git"]
 zkhash = { git = "https://github.com/AntoineFONDEUR/poseidon2.git", branch = "poseidon2-M31" }
+
+[profile.release-lto]
+inherits = "release"
+codegen-units = 1
+lto = true


### PR DESCRIPTION
Build optimization: Enable LTO and single codegen unit.
Added a new release profile release-lto with LTO enabled and single codegen unit for maximum performance. Updated prover and runner benchmarks in CI to use this optimized profile for more accurate performance measurements.

See
* https://doc.rust-lang.org/rustc/codegen-options/index.html#lto
* https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units

<img width="1005" height="260" alt="Capture d’écran 2025-09-11 à 16 07 47" src="https://github.com/user-attachments/assets/3b17d510-ca85-4f2f-9206-d2a490723b9a" />

