### PR TITLE
feat(compiler): heap allocation and pointers with `new`

### DIFF
--- a/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@pointers_and_heap_allocation__new____allocate_felt_and_read_back.snap
+++ b/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@pointers_and_heap_allocation__new____allocate_felt_and_read_back.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/compiler/codegen/tests/mdtest_snapshots.rs
+assertion_line: 60
 description: "Codegen snapshot for mdtest: Pointers and Heap Allocation (new) - Allocate felt and read back"
 input_file: mdtest/03-types/03-pointers-and-heap.md
 ---
@@ -42,3 +43,6 @@ alloc_felt_0:
   22: 8 0 2 7              // [fp + 7] = [[fp + 0] + 2] (load slot 0)
   23: 0 6 7 2147483644     // [fp + -3] = [fp + 6] op [fp + 7]
   24: 11 _ _ _             // return
+---- data (base 25) ----
+; blob 0 (1 words)
+  25: 0 0 0 0

--- a/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@pointers_and_heap_allocation__new____allocate_felt_and_read_back.snap
+++ b/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@pointers_and_heap_allocation__new____allocate_felt_and_read_back.snap
@@ -1,0 +1,44 @@
+---
+source: crates/compiler/codegen/tests/mdtest_snapshots.rs
+description: "Codegen snapshot for mdtest: Pointers and Heap Allocation (new) - Allocate felt and read back"
+input_file: mdtest/03-types/03-pointers-and-heap.md
+---
+Source:
+fn alloc_felt() -> felt {
+    let p: felt* = new felt[3];
+    // Initialize via pointer indexing
+    p[0] = 7;
+    p[1] = 8;
+    p[2] = 9;
+    return p[0] + p[1] + p[2];
+}
+============================================================
+Generated CASM:
+alloc_felt:
+alloc_felt:
+alloc_felt_0:
+   0: 9 25 9 _             // [fp + 9] = <HEAP_CURSOR>
+   1: 8 9 0 10             // [fp + 10] = [[fp + 9] + 0] (load heap cursor)
+   2: 9 3 11 _             // [fp + 11] = 3 (cells)
+   3: 0 10 11 12           // [fp + 12] = [fp + 10] + [fp + 11] (cur+size)
+   4: 4 12 2147483646 12   // [fp + 12] = [fp + 12] + (-1) (-1 as M31 -> 2147483646 (=-1 mod M31))
+   5: 9 268435455 13 _     // [fp + 13] = MAX_ADDRESS (268435455)
+   6: 1 13 12 14           // [fp + 14] = [fp + 13] - [fp + 12] (base)
+   7: 0 10 11 15           // [fp + 15] = [fp + 10] + [fp + 11] (advance cursor)
+   8: 44 9 0 15            // [[fp + 9] + 0] = [fp + 15] (store heap cursor)
+   9: 4 14 0 0             // [fp + 0] = [fp + 14] (heap ptr)
+  10: 8 0 0 1              // [fp + 1] = [[fp + 0] + 0] (load slot 0)
+  11: 9 7 16 _             // [fp + 16] = 7
+  12: 44 0 0 16            // [[fp + 0] + 0] = [fp + 16]
+  13: 8 0 1 2              // [fp + 2] = [[fp + 0] + 1] (load slot 0)
+  14: 9 8 17 _             // [fp + 17] = 8
+  15: 44 0 1 17            // [[fp + 0] + 1] = [fp + 17]
+  16: 8 0 2 3              // [fp + 3] = [[fp + 0] + 2] (load slot 0)
+  17: 9 9 18 _             // [fp + 18] = 9
+  18: 44 0 2 18            // [[fp + 0] + 2] = [fp + 18]
+  19: 8 0 0 4              // [fp + 4] = [[fp + 0] + 0] (load slot 0)
+  20: 8 0 1 5              // [fp + 5] = [[fp + 0] + 1] (load slot 0)
+  21: 0 4 5 6              // [fp + 6] = [fp + 4] op [fp + 5]
+  22: 8 0 2 7              // [fp + 7] = [[fp + 0] + 2] (load slot 0)
+  23: 0 6 7 2147483644     // [fp + -3] = [fp + 6] op [fp + 7]
+  24: 11 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@pointers_and_heap_allocation__new____allocate_struct_pointer_and_access_fields.snap
+++ b/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@pointers_and_heap_allocation__new____allocate_struct_pointer_and_access_fields.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/compiler/codegen/tests/mdtest_snapshots.rs
+assertion_line: 60
 description: "Codegen snapshot for mdtest: Pointers and Heap Allocation (new) - Allocate struct pointer and access fields"
 input_file: mdtest/03-types/03-pointers-and-heap.md
 ---
@@ -54,3 +55,6 @@ alloc_struct_0:
   31: 8 1 3 15             // [fp + 15] = [[fp + 1] + 3] (load slot 0)
   32: 0 12 15 2147483644   // [fp + -3] = [fp + 12] op [fp + 15]
   33: 11 _ _ _             // return
+---- data (base 34) ----
+; blob 0 (1 words)
+  34: 0 0 0 0

--- a/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@pointers_and_heap_allocation__new____allocate_struct_pointer_and_access_fields.snap
+++ b/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@pointers_and_heap_allocation__new____allocate_struct_pointer_and_access_fields.snap
@@ -1,0 +1,56 @@
+---
+source: crates/compiler/codegen/tests/mdtest_snapshots.rs
+description: "Codegen snapshot for mdtest: Pointers and Heap Allocation (new) - Allocate struct pointer and access fields"
+input_file: mdtest/03-types/03-pointers-and-heap.md
+---
+Source:
+struct Point { x: felt, y: felt }
+
+fn alloc_struct() -> felt {
+    let ps: Point* = new Point[2];
+    // Write fields via pointer indexing then field
+    (ps[0]).x = 3;
+    (ps[0]).y = 4;
+    (ps[1]).x = 5;
+    (ps[1]).y = 6;
+    return ps[0].x + ps[1].y;
+}
+============================================================
+Generated CASM:
+alloc_struct:
+alloc_struct:
+alloc_struct_0:
+   0: 9 4 0 _              // [fp + 0] = 4
+   1: 9 34 17 _            // [fp + 17] = <HEAP_CURSOR>
+   2: 8 17 0 18            // [fp + 18] = [[fp + 17] + 0] (load heap cursor)
+   3: 0 18 0 19            // [fp + 19] = [fp + 18] + [fp + 0] (cur+size)
+   4: 4 19 2147483646 19   // [fp + 19] = [fp + 19] + (-1) (-1 as M31 -> 2147483646 (=-1 mod M31))
+   5: 9 268435455 20 _     // [fp + 20] = MAX_ADDRESS (268435455)
+   6: 1 20 19 21           // [fp + 21] = [fp + 20] - [fp + 19] (base)
+   7: 0 18 0 22            // [fp + 22] = [fp + 18] + [fp + 0] (advance cursor)
+   8: 44 17 0 22           // [[fp + 17] + 0] = [fp + 22] (store heap cursor)
+   9: 4 21 0 1             // [fp + 1] = [fp + 21] (heap ptr)
+  10: 8 1 0 2              // [fp + 2] = [[fp + 1] + 0] (load slot 0)
+  11: 8 1 1 3              // [fp + 3] = [[fp + 1] + 1] (load slot 1)
+  12: 9 3 23 _             // [fp + 23] = 3
+  13: 44 1 0 23            // [[fp + 1] + 0] = [fp + 23]
+  14: 8 1 0 4              // [fp + 4] = [[fp + 1] + 0] (load slot 0)
+  15: 8 1 1 5              // [fp + 5] = [[fp + 1] + 1] (load slot 1)
+  16: 9 4 24 _             // [fp + 24] = 4
+  17: 44 1 1 24            // [[fp + 1] + 1] = [fp + 24]
+  18: 8 1 2 6              // [fp + 6] = [[fp + 1] + 2] (load slot 0)
+  19: 8 1 3 7              // [fp + 7] = [[fp + 1] + 3] (load slot 1)
+  20: 9 5 25 _             // [fp + 25] = 5
+  21: 44 1 2 25            // [[fp + 1] + 2] = [fp + 25]
+  22: 8 1 2 8              // [fp + 8] = [[fp + 1] + 2] (load slot 0)
+  23: 8 1 3 9              // [fp + 9] = [[fp + 1] + 3] (load slot 1)
+  24: 9 6 26 _             // [fp + 26] = 6
+  25: 44 1 3 26            // [[fp + 1] + 3] = [fp + 26]
+  26: 8 1 0 10             // [fp + 10] = [[fp + 1] + 0] (load slot 0)
+  27: 8 1 1 11             // [fp + 11] = [[fp + 1] + 1] (load slot 1)
+  28: 8 1 0 12             // [fp + 12] = [[fp + 1] + 0] (load slot 0)
+  29: 8 1 2 13             // [fp + 13] = [[fp + 1] + 2] (load slot 0)
+  30: 8 1 3 14             // [fp + 14] = [[fp + 1] + 3] (load slot 1)
+  31: 8 1 3 15             // [fp + 15] = [[fp + 1] + 3] (load slot 0)
+  32: 0 12 15 2147483644   // [fp + -3] = [fp + 12] op [fp + 15]
+  33: 11 _ _ _             // return

--- a/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@pointers_and_heap_allocation__new____allocate_u32_with_dynamic_size.snap
+++ b/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@pointers_and_heap_allocation__new____allocate_u32_with_dynamic_size.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/compiler/codegen/tests/mdtest_snapshots.rs
+assertion_line: 60
 description: "Codegen snapshot for mdtest: Pointers and Heap Allocation (new) - Allocate u32 with dynamic size"
 input_file: mdtest/03-types/03-pointers-and-heap.md
 ---
@@ -35,3 +36,6 @@ alloc_u32_0:
   17: 4 4 0 2147483643     // Return value 0 slot 0: [fp -4] = [fp + 4] + 0
   18: 4 5 0 2147483644     // Return value 0 slot 1: [fp -3] = [fp + 5] + 0
   19: 11 _ _ _             // return
+---- data (base 20) ----
+; blob 0 (1 words)
+  20: 0 0 0 0

--- a/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@pointers_and_heap_allocation__new____allocate_u32_with_dynamic_size.snap
+++ b/crates/compiler/codegen/tests/snapshots/mdtest_codegen_snapshots@pointers_and_heap_allocation__new____allocate_u32_with_dynamic_size.snap
@@ -1,0 +1,37 @@
+---
+source: crates/compiler/codegen/tests/mdtest_snapshots.rs
+description: "Codegen snapshot for mdtest: Pointers and Heap Allocation (new) - Allocate u32 with dynamic size"
+input_file: mdtest/03-types/03-pointers-and-heap.md
+---
+Source:
+fn alloc_u32() -> u32 {
+    let p: u32* = new u32[3];
+    // Single element write/read
+    p[0] = 42u32;
+    return p[0];
+}
+============================================================
+Generated CASM:
+alloc_u32:
+alloc_u32:
+alloc_u32_0:
+   0: 9 6 0 _              // [fp + 0] = 6
+   1: 9 20 6 _             // [fp + 6] = <HEAP_CURSOR>
+   2: 8 6 0 7              // [fp + 7] = [[fp + 6] + 0] (load heap cursor)
+   3: 0 7 0 8              // [fp + 8] = [fp + 7] + [fp + 0] (cur+size)
+   4: 4 8 2147483646 8     // [fp + 8] = [fp + 8] + (-1) (-1 as M31 -> 2147483646 (=-1 mod M31))
+   5: 9 268435455 9 _      // [fp + 9] = MAX_ADDRESS (268435455)
+   6: 1 9 8 10             // [fp + 10] = [fp + 9] - [fp + 8] (base)
+   7: 0 7 0 11             // [fp + 11] = [fp + 7] + [fp + 0] (advance cursor)
+   8: 44 6 0 11            // [[fp + 6] + 0] = [fp + 11] (store heap cursor)
+   9: 4 10 0 1             // [fp + 1] = [fp + 10] (heap ptr)
+  10: 8 1 0 2              // [fp + 2] = [[fp + 1] + 0] (load slot 0)
+  11: 8 1 1 3              // [fp + 3] = [[fp + 1] + 1] (load slot 1)
+  12: 23 42 0 12           // [fp + 12], [fp + 13] = u32(42)
+  13: 44 1 0 12            // [[fp + 1] + 0] = [fp + 12] (u32 slot 0)
+  14: 44 1 1 13            // [[fp + 1] + 1] = [fp + 13] (u32 slot 1)
+  15: 8 1 0 4              // [fp + 4] = [[fp + 1] + 0] (load slot 0)
+  16: 8 1 1 5              // [fp + 5] = [[fp + 1] + 1] (load slot 1)
+  17: 4 4 0 2147483643     // Return value 0 slot 0: [fp -4] = [fp + 4] + 0
+  18: 4 5 0 2147483644     // Return value 0 slot 1: [fp -3] = [fp + 5] + 0
+  19: 11 _ _ _             // return

--- a/crates/compiler/formatter/src/rules/expressions.rs
+++ b/crates/compiler/formatter/src/rules/expressions.rs
@@ -102,6 +102,13 @@ impl Format for Expression {
                 Doc::text(" as "),
                 target_type.value().format(ctx),
             ]),
+            Self::New { elem_type, count } => Doc::concat(vec![
+                Doc::text("new "),
+                elem_type.value().format(ctx),
+                Doc::text("["),
+                count.value().format(ctx),
+                Doc::text("]"),
+            ]),
             Self::Parenthesized(inner) => parens(inner.value().format(ctx)),
         }
     }

--- a/crates/compiler/mir/src/lowering/expr.rs
+++ b/crates/compiler/mir/src/lowering/expr.rs
@@ -79,6 +79,54 @@ impl<'a, 'db> LowerExpr<'a> for MirBuilder<'a, 'db> {
         match &expr_info.ast_node {
             Expression::Literal(n, _) => Ok(LoweredExpr::new(Value::integer(*n as u32))),
             Expression::BooleanLiteral(b) => Ok(LoweredExpr::new(Value::boolean(*b))),
+            Expression::New { elem_type, count } => {
+                // Compute cells = count * elem_slots, where elem_slots depends on T
+                let sem_elem_type = cairo_m_compiler_semantic::type_resolution::resolve_ast_type(
+                    self.ctx.db,
+                    self.ctx.crate_id,
+                    self.ctx.file,
+                    elem_type.clone(),
+                    expr_info.scope_id,
+                );
+                let elem_mir_ty = MirType::from_semantic_type(self.ctx.db, sem_elem_type);
+                let elem_slots = crate::DataLayout::value_size_of(&elem_mir_ty);
+
+                // Lower count expression to a value
+                let count_val = self.lower_expression(count)?;
+
+                // If element occupies more than one slot, multiply
+                let cells_val = if elem_slots == 1 {
+                    count_val
+                } else {
+                    // Build literal for elem_slots
+                    let lit = crate::Value::integer(elem_slots as u32);
+                    // Determine typed binary op based on left type
+                    let left_expr_id = self.expr_id(count.span())?;
+                    let left_type = expression_semantic_type(
+                        self.ctx.db,
+                        self.ctx.crate_id,
+                        self.ctx.file,
+                        left_expr_id,
+                        None,
+                    );
+                    let left_type_data = left_type.data(self.ctx.db);
+                    let typed_op = crate::BinaryOp::from_parser(BinaryOp::Mul, &left_type_data)?;
+                    let dest_tmp = self.state.mir_function.new_typed_value_id(MirType::Felt);
+                    self.instr()
+                        .binary_op_to(typed_op, dest_tmp, count_val.into_value(), lit);
+                    LoweredExpr::new(Value::operand(dest_tmp))
+                };
+
+                // Destination pointer value with element type information
+                let dest = self
+                    .state
+                    .mir_function
+                    .new_typed_value_id(MirType::pointer(elem_mir_ty));
+                // Emit heap allocation instruction
+                self.instr()
+                    .add_instruction(Instruction::heap_alloc_cells(dest, cells_val.into_value()));
+                Ok(LoweredExpr::new(Value::operand(dest)))
+            }
             Expression::Identifier(name) => self.lower_identifier(name, current_scope_id),
             Expression::UnaryOp { op, expr } => self.lower_unary_op(*op, expr, expr_id),
             Expression::BinaryOp { op, left, right } => {
@@ -554,10 +602,28 @@ impl<'a, 'db> MirBuilder<'a, 'db> {
         // Get the MIR type of the array
         let array_mir_type = self.expr_mir_type(array.span())?;
 
-        // Get element type
+        // Get element type. Prefer MIR information (FixedArray or Pointer),
+        // otherwise fall back to semantic pointer element type.
         let element_mir_type = match &array_mir_type {
             MirType::FixedArray { element_type, .. } => (**element_type).clone(),
-            _ => return Err("IndexAccess on non-array type".to_string()),
+            MirType::Pointer { element } => (**element).clone(),
+            _ => {
+                // Fallback to semantic type: support pointers (T*)
+                let array_expr_id = self.expr_id(array.span())?;
+                let sem_ty = expression_semantic_type(
+                    self.ctx.db,
+                    self.ctx.crate_id,
+                    self.ctx.file,
+                    array_expr_id,
+                    None,
+                );
+                match sem_ty.data(self.ctx.db) {
+                    cairo_m_compiler_semantic::types::TypeData::Pointer { element_type } => {
+                        MirType::from_semantic_type(self.ctx.db, element_type)
+                    }
+                    _ => return Err("IndexAccess on non-array type".to_string()),
+                }
+            }
         };
 
         // Lower index expression and reuse it for both load and potential store

--- a/crates/compiler/mir/src/mir_types.rs
+++ b/crates/compiler/mir/src/mir_types.rs
@@ -213,6 +213,10 @@ impl MirType {
 
                 Self::struct_type(struct_name, fields)
             }
+            TypeData::Pointer { element_type } => {
+                let element_mir_type = Self::from_semantic_type(db, element_type);
+                Self::pointer(element_mir_type)
+            }
             TypeData::FixedArray { element_type, size } => {
                 let element_mir_type = Self::from_semantic_type(db, element_type);
                 Self::FixedArray {

--- a/crates/compiler/mir/src/passes/constant_propagation.rs
+++ b/crates/compiler/mir/src/passes/constant_propagation.rs
@@ -148,6 +148,7 @@ impl ConstantPropagation {
             | K::InsertField { .. }
             | K::InsertTuple { .. }
             | K::MakeFixedArray { .. }
+            | K::HeapAllocCells { .. }
             | K::Cast { .. }
             | K::Call { .. }
             | K::Debug { .. }
@@ -267,6 +268,9 @@ impl ConstantPropagation {
                         for e in elements {
                             replace_value(e, state, &mut modified);
                         }
+                    }
+                    InstructionKind::HeapAllocCells { cells, .. } => {
+                        replace_value(cells, state, &mut modified);
                     }
                     InstructionKind::AssertEq { left, right } => {
                         replace_value(left, state, &mut modified);

--- a/crates/compiler/mir/src/passes/local_cse.rs
+++ b/crates/compiler/mir/src/passes/local_cse.rs
@@ -168,6 +168,7 @@ impl PureExpressionKey {
             | InstructionKind::Store { .. }
             | InstructionKind::Phi { .. }
             | InstructionKind::Nop
+            | InstructionKind::HeapAllocCells { .. }
             | InstructionKind::AssertEq { .. } => None,
 
             // Aggregate modification operations - skip for conservatism

--- a/crates/compiler/mir/src/passes/sroa.rs
+++ b/crates/compiler/mir/src/passes/sroa.rs
@@ -712,6 +712,11 @@ impl ScalarReplacementOfAggregates {
                     callback(*id);
                 }
             }
+            InstructionKind::HeapAllocCells { cells, .. } => {
+                if let Value::Operand(id) = cells {
+                    callback(*id);
+                }
+            }
         }
     }
 

--- a/crates/compiler/mir/tests/snapshots/mdtest_mir_snapshots@pointers_and_heap_allocation__new____allocate_felt_and_read_back.snap
+++ b/crates/compiler/mir/tests/snapshots/mdtest_mir_snapshots@pointers_and_heap_allocation__new____allocate_felt_and_read_back.snap
@@ -1,0 +1,40 @@
+---
+source: crates/compiler/mir/tests/mdtest_snapshots.rs
+assertion_line: 52
+description: "MIR snapshot for mdtest: Pointers and Heap Allocation (new) - Allocate felt and read back"
+input_file: mdtest/03-types/03-pointers-and-heap.md
+---
+Source:
+fn alloc_felt() -> felt {
+    let p: felt* = new felt[3];
+    // Initialize via pointer indexing
+    p[0] = 7;
+    p[1] = 8;
+    p[2] = 9;
+    return p[0] + p[1] + p[2];
+}
+============================================================
+Generated MIR:
+module {
+  // Function 0
+  fn alloc_felt {
+    entry: 0
+
+    0:
+      %0 = heapalloccells 3
+      %1 = load %0[0]
+      store 7 -> %0[0]
+      %2 = load %0[1]
+      store 8 -> %0[1]
+      %3 = load %0[2]
+      store 9 -> %0[2]
+      %4 = load %0[0]
+      %5 = load %0[1]
+      %6 = %4 + %5
+      %7 = load %0[2]
+      %8 = %6 + %7
+      return %8
+
+  }
+
+}

--- a/crates/compiler/mir/tests/snapshots/mdtest_mir_snapshots@pointers_and_heap_allocation__new____allocate_struct_pointer_and_access_fields.snap
+++ b/crates/compiler/mir/tests/snapshots/mdtest_mir_snapshots@pointers_and_heap_allocation__new____allocate_struct_pointer_and_access_fields.snap
@@ -1,0 +1,46 @@
+---
+source: crates/compiler/mir/tests/mdtest_snapshots.rs
+assertion_line: 52
+description: "MIR snapshot for mdtest: Pointers and Heap Allocation (new) - Allocate struct pointer and access fields"
+input_file: mdtest/03-types/03-pointers-and-heap.md
+---
+Source:
+struct Point { x: felt, y: felt }
+
+fn alloc_struct() -> felt {
+    let ps: Point* = new Point[2];
+    // Write fields via pointer indexing then field
+    (ps[0]).x = 3;
+    (ps[0]).y = 4;
+    (ps[1]).x = 5;
+    (ps[1]).y = 6;
+    return ps[0].x + ps[1].y;
+}
+============================================================
+Generated MIR:
+module {
+  // Function 0
+  fn alloc_struct {
+    entry: 0
+
+    0:
+      %0 = 2 * 2
+      %1 = heapalloccells %0
+      %2 = load %1[0]
+      store 3 -> %1[0].x
+      %3 = load %1[0]
+      store 4 -> %1[0].y
+      %4 = load %1[1]
+      store 5 -> %1[1].x
+      %5 = load %1[1]
+      store 6 -> %1[1].y
+      %6 = load %1[0]
+      %7 = load %1[0].x
+      %8 = load %1[1]
+      %9 = load %1[1].y
+      %10 = %7 + %9
+      return %10
+
+  }
+
+}

--- a/crates/compiler/mir/tests/snapshots/mdtest_mir_snapshots@pointers_and_heap_allocation__new____allocate_u32_with_dynamic_size.snap
+++ b/crates/compiler/mir/tests/snapshots/mdtest_mir_snapshots@pointers_and_heap_allocation__new____allocate_u32_with_dynamic_size.snap
@@ -1,0 +1,31 @@
+---
+source: crates/compiler/mir/tests/mdtest_snapshots.rs
+assertion_line: 52
+description: "MIR snapshot for mdtest: Pointers and Heap Allocation (new) - Allocate u32 with dynamic size"
+input_file: mdtest/03-types/03-pointers-and-heap.md
+---
+Source:
+fn alloc_u32() -> u32 {
+    let p: u32* = new u32[3];
+    // Single element write/read
+    p[0] = 42u32;
+    return p[0];
+}
+============================================================
+Generated MIR:
+module {
+  // Function 0
+  fn alloc_u32 {
+    entry: 0
+
+    0:
+      %0 = 3 * 2
+      %1 = heapalloccells %0
+      %2 = load %1[0]
+      store 42 -> %1[0]
+      %3 = load %1[0]
+      return %3
+
+  }
+
+}

--- a/crates/compiler/parser/src/lexer.rs
+++ b/crates/compiler/parser/src/lexer.rs
@@ -179,6 +179,8 @@ pub enum TokenType<'a> {
     If,
     #[token("let")]
     Let,
+    #[token("new")]
+    New,
     #[token("return")]
     Return,
     #[token("struct")]
@@ -284,6 +286,7 @@ impl<'a> fmt::Display for TokenType<'a> {
             TokenType::Function => write!(f, "fn"),
             TokenType::If => write!(f, "if"),
             TokenType::Let => write!(f, "let"),
+            TokenType::New => write!(f, "new"),
             TokenType::Return => write!(f, "return"),
             TokenType::Struct => write!(f, "struct"),
             TokenType::True => write!(f, "true"),

--- a/crates/compiler/parser/tests/parser/expressions.rs
+++ b/crates/compiler/parser/tests/parser/expressions.rs
@@ -310,3 +310,24 @@ fn complex_expression_precedence() {
         "result = a.field[0].method(b + c * d, e && f || g).value;"
     ));
 }
+
+// ===================
+// Heap Allocation (new T[n])
+// ===================
+
+#[test]
+fn heap_allocation_new_parameterized() {
+    assert_parses_parameterized! {
+        ok: [
+            in_function("let p = new felt[10];"),
+            in_function("let q = new u32[n];"),
+            // With struct type name in scope
+            r#"struct Point { x: felt, y: felt }
+               fn test() { let r = new Point[2]; }"#,
+        ],
+        err: [
+            in_function("let p = new [10];"),
+            in_function("let p = new felt;"),
+        ]
+    }
+}

--- a/crates/compiler/parser/tests/snapshots/diagnostics__file__mod::parser::integration::test_cases_files__tuple_destructuring.cm.snap
+++ b/crates/compiler/parser/tests/snapshots/diagnostics__file__mod::parser::integration::test_cases_files__tuple_destructuring.cm.snap
@@ -44,10 +44,10 @@ fn test_with_type_annotation() {
 }
 
 --- Diagnostics ---
-[02] Error: found 'fn' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, identifier, '[', '(', or '}'
+[02] Error: found 'fn' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, 'new', identifier, '[', '(', or '}'
     ╭─[ tests/test_cases/tuple_destructuring.cm:11:5 ]
     │
  11 │     fn get_pair() -> (felt, felt) {
     │     ─┬  
-    │      ╰── found 'fn' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, identifier, '[', '(', or '}'
+    │      ╰── found 'fn' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, 'new', identifier, '[', '(', or '}'
 ────╯

--- a/crates/compiler/parser/tests/snapshots/parameterized__expressions::binary_operations_parameterized_err.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__expressions::binary_operations_parameterized_err.snap
@@ -5,12 +5,12 @@ expression: snapshot
 --- Input 1 (ERROR) ---
 fn test() { a +; }
 --- Diagnostics ---
-[02] Error: found ';' expected '!', '-', something else, identifier, '[', or '('
+[02] Error: found ';' expected '!', '-', something else, 'new', identifier, '[', or '('
    ╭─[ test.cairo:1:16 ]
    │
  1 │ fn test() { a +; }
    │                ┬  
-   │                ╰── found ';' expected '!', '-', something else, identifier, '[', or '('
+   │                ╰── found ';' expected '!', '-', something else, 'new', identifier, '[', or '('
 ───╯
 
 ============================================================
@@ -18,12 +18,12 @@ fn test() { a +; }
 --- Input 2 (ERROR) ---
 fn test() { + b; }
 --- Diagnostics ---
-[02] Error: found '+' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, identifier, '[', '(', or '}'
+[02] Error: found '+' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, 'new', identifier, '[', '(', or '}'
    ╭─[ test.cairo:1:13 ]
    │
  1 │ fn test() { + b; }
    │             ┬  
-   │             ╰── found '+' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, identifier, '[', '(', or '}'
+   │             ╰── found '+' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, 'new', identifier, '[', '(', or '}'
 ───╯
 
 ============================================================
@@ -31,12 +31,12 @@ fn test() { + b; }
 --- Input 3 (ERROR) ---
 fn test() { a ==; }
 --- Diagnostics ---
-[02] Error: found ';' expected '!', '-', something else, identifier, '[', or '('
+[02] Error: found ';' expected '!', '-', something else, 'new', identifier, '[', or '('
    ╭─[ test.cairo:1:17 ]
    │
  1 │ fn test() { a ==; }
    │                 ┬  
-   │                 ╰── found ';' expected '!', '-', something else, identifier, '[', or '('
+   │                 ╰── found ';' expected '!', '-', something else, 'new', identifier, '[', or '('
 ───╯
 
 ============================================================
@@ -44,12 +44,12 @@ fn test() { a ==; }
 --- Input 4 (ERROR) ---
 fn test() { && b; }
 --- Diagnostics ---
-[02] Error: found '&&' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, identifier, '[', '(', or '}'
+[02] Error: found '&&' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, 'new', identifier, '[', '(', or '}'
    ╭─[ test.cairo:1:13 ]
    │
  1 │ fn test() { && b; }
    │             ─┬  
-   │              ╰── found '&&' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, identifier, '[', '(', or '}'
+   │              ╰── found '&&' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, 'new', identifier, '[', '(', or '}'
 ───╯
 
 ============================================================
@@ -57,12 +57,12 @@ fn test() { && b; }
 --- Input 5 (ERROR) ---
 fn test() { a << b; }
 --- Diagnostics ---
-[02] Error: found '<' expected '!', '-', something else, identifier, '[', or '('
+[02] Error: found '<' expected '!', '-', something else, 'new', identifier, '[', or '('
    ╭─[ test.cairo:1:16 ]
    │
  1 │ fn test() { a << b; }
    │                ┬  
-   │                ╰── found '<' expected '!', '-', something else, identifier, '[', or '('
+   │                ╰── found '<' expected '!', '-', something else, 'new', identifier, '[', or '('
 ───╯
 
 ============================================================
@@ -70,12 +70,12 @@ fn test() { a << b; }
 --- Input 6 (ERROR) ---
 fn test() { a >> b; }
 --- Diagnostics ---
-[02] Error: found '>' expected '!', '-', something else, identifier, '[', or '('
+[02] Error: found '>' expected '!', '-', something else, 'new', identifier, '[', or '('
    ╭─[ test.cairo:1:16 ]
    │
  1 │ fn test() { a >> b; }
    │                ┬  
-   │                ╰── found '>' expected '!', '-', something else, identifier, '[', or '('
+   │                ╰── found '>' expected '!', '-', something else, 'new', identifier, '[', or '('
 ───╯
 
 ============================================================
@@ -83,10 +83,10 @@ fn test() { a >> b; }
 --- Input 7 (ERROR) ---
 fn test() { a ** b; }
 --- Diagnostics ---
-[02] Error: found '*' expected '!', '-', something else, identifier, '[', or '('
+[02] Error: found '*' expected '!', '-', something else, 'new', identifier, '[', or '('
    ╭─[ test.cairo:1:16 ]
    │
  1 │ fn test() { a ** b; }
    │                ┬  
-   │                ╰── found '*' expected '!', '-', something else, identifier, '[', or '('
+   │                ╰── found '*' expected '!', '-', something else, 'new', identifier, '[', or '('
 ───╯

--- a/crates/compiler/parser/tests/snapshots/parameterized__expressions::cast_expressions_parameterized_err.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__expressions::cast_expressions_parameterized_err.snap
@@ -18,12 +18,12 @@ fn test() { x as; }
 --- Input 2 (ERROR) ---
 fn test() { as felt; }
 --- Diagnostics ---
-[02] Error: found 'as' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, identifier, '[', '(', or '}'
+[02] Error: found 'as' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, 'new', identifier, '[', '(', or '}'
    ╭─[ test.cairo:1:13 ]
    │
  1 │ fn test() { as felt; }
    │             ─┬  
-   │              ╰── found 'as' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, identifier, '[', '(', or '}'
+   │              ╰── found 'as' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, 'new', identifier, '[', '(', or '}'
 ───╯
 
 ============================================================

--- a/crates/compiler/parser/tests/snapshots/parameterized__expressions::heap_allocation_new_parameterized_err.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__expressions::heap_allocation_new_parameterized_err.snap
@@ -5,12 +5,12 @@ expression: snapshot
 --- Input 1 (ERROR) ---
 fn test() { let p = new [10]; }
 --- Diagnostics ---
-[02] Error: found '[' expected identifier
+[02] Error: found '[' expected identifier, or '('
    ╭─[ test.cairo:1:25 ]
    │
  1 │ fn test() { let p = new [10]; }
    │                         ┬  
-   │                         ╰── found '[' expected identifier
+   │                         ╰── found '[' expected identifier, or '('
 ───╯
 
 ============================================================
@@ -18,10 +18,10 @@ fn test() { let p = new [10]; }
 --- Input 2 (ERROR) ---
 fn test() { let p = new felt; }
 --- Diagnostics ---
-[02] Error: found ';' expected '['
+[02] Error: found ';' expected '*', or '['
    ╭─[ test.cairo:1:29 ]
    │
  1 │ fn test() { let p = new felt; }
    │                             ┬  
-   │                             ╰── found ';' expected '['
+   │                             ╰── found ';' expected '*', or '['
 ───╯

--- a/crates/compiler/parser/tests/snapshots/parameterized__expressions::heap_allocation_new_parameterized_err.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__expressions::heap_allocation_new_parameterized_err.snap
@@ -1,0 +1,27 @@
+---
+source: crates/compiler/parser/tests/common.rs
+expression: snapshot
+---
+--- Input 1 (ERROR) ---
+fn test() { let p = new [10]; }
+--- Diagnostics ---
+[02] Error: found '[' expected identifier
+   ╭─[ test.cairo:1:25 ]
+   │
+ 1 │ fn test() { let p = new [10]; }
+   │                         ┬  
+   │                         ╰── found '[' expected identifier
+───╯
+
+============================================================
+
+--- Input 2 (ERROR) ---
+fn test() { let p = new felt; }
+--- Diagnostics ---
+[02] Error: found ';' expected '['
+   ╭─[ test.cairo:1:29 ]
+   │
+ 1 │ fn test() { let p = new felt; }
+   │                             ┬  
+   │                             ╰── found ';' expected '['
+───╯

--- a/crates/compiler/parser/tests/snapshots/parameterized__expressions::heap_allocation_new_parameterized_ok.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__expressions::heap_allocation_new_parameterized_ok.snap
@@ -1,0 +1,230 @@
+---
+source: crates/compiler/parser/tests/common.rs
+expression: snapshot
+---
+--- Input 1 ---
+fn test() { let p = new felt[10]; }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Let {
+                            pattern: Identifier(
+                                Spanned(
+                                    "p",
+                                    16..17,
+                                ),
+                            ),
+                            statement_type: None,
+                            value: Spanned(
+                                New {
+                                    elem_type: Spanned(
+                                        Named(
+                                            Spanned(
+                                                Felt,
+                                                24..28,
+                                            ),
+                                        ),
+                                        24..28,
+                                    ),
+                                    count: Spanned(
+                                        Literal(
+                                            10,
+                                            None,
+                                        ),
+                                        29..31,
+                                    ),
+                                },
+                                20..32,
+                            ),
+                        },
+                        12..33,
+                    ),
+                ],
+            },
+            0..35,
+        ),
+    ),
+]
+============================================================
+
+--- Input 2 ---
+fn test() { let q = new u32[n]; }
+--- AST ---
+[
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    3..7,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Let {
+                            pattern: Identifier(
+                                Spanned(
+                                    "q",
+                                    16..17,
+                                ),
+                            ),
+                            statement_type: None,
+                            value: Spanned(
+                                New {
+                                    elem_type: Spanned(
+                                        Named(
+                                            Spanned(
+                                                U32,
+                                                24..27,
+                                            ),
+                                        ),
+                                        24..27,
+                                    ),
+                                    count: Spanned(
+                                        Identifier(
+                                            Spanned(
+                                                "n",
+                                                28..29,
+                                            ),
+                                        ),
+                                        28..29,
+                                    ),
+                                },
+                                20..30,
+                            ),
+                        },
+                        12..31,
+                    ),
+                ],
+            },
+            0..33,
+        ),
+    ),
+]
+============================================================
+
+--- Input 3 ---
+struct Point { x: felt, y: felt }
+               fn test() { let r = new Point[2]; }
+--- AST ---
+[
+    Struct(
+        Spanned(
+            StructDef {
+                name: Spanned(
+                    "Point",
+                    7..12,
+                ),
+                fields: [
+                    (
+                        Spanned(
+                            "x",
+                            15..16,
+                        ),
+                        Spanned(
+                            Named(
+                                Spanned(
+                                    Felt,
+                                    18..22,
+                                ),
+                            ),
+                            18..22,
+                        ),
+                    ),
+                    (
+                        Spanned(
+                            "y",
+                            24..25,
+                        ),
+                        Spanned(
+                            Named(
+                                Spanned(
+                                    Felt,
+                                    27..31,
+                                ),
+                            ),
+                            27..31,
+                        ),
+                    ),
+                ],
+            },
+            0..33,
+        ),
+    ),
+    Function(
+        Spanned(
+            FunctionDef {
+                name: Spanned(
+                    "test",
+                    52..56,
+                ),
+                params: [],
+                return_type: Spanned(
+                    Tuple(
+                        [],
+                    ),
+                    0..0,
+                ),
+                body: [
+                    Spanned(
+                        Let {
+                            pattern: Identifier(
+                                Spanned(
+                                    "r",
+                                    65..66,
+                                ),
+                            ),
+                            statement_type: None,
+                            value: Spanned(
+                                New {
+                                    elem_type: Spanned(
+                                        Named(
+                                            Spanned(
+                                                Custom(
+                                                    "Point",
+                                                ),
+                                                73..78,
+                                            ),
+                                        ),
+                                        73..78,
+                                    ),
+                                    count: Spanned(
+                                        Literal(
+                                            2,
+                                            None,
+                                        ),
+                                        79..80,
+                                    ),
+                                },
+                                69..81,
+                            ),
+                        },
+                        61..82,
+                    ),
+                ],
+            },
+            49..84,
+        ),
+    ),
+]

--- a/crates/compiler/parser/tests/snapshots/parameterized__expressions::struct_literal_parameterized_err.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__expressions::struct_literal_parameterized_err.snap
@@ -18,10 +18,10 @@ fn test() { Point { x: 1, y: 2, z }; }
 --- Input 2 (ERROR) ---
 fn test() { Rectangle { top_left: Point { x: 0, y: 0 }, width: }; }
 --- Diagnostics ---
-[02] Error: found '}' expected '!', '-', something else, identifier, '[', or '('
+[02] Error: found '}' expected '!', '-', something else, 'new', identifier, '[', or '('
    ╭─[ test.cairo:1:64 ]
    │
  1 │ fn test() { Rectangle { top_left: Point { x: 0, y: 0 }, width: }; }
    │                                                                ┬  
-   │                                                                ╰── found '}' expected '!', '-', something else, identifier, '[', or '('
+   │                                                                ╰── found '}' expected '!', '-', something else, 'new', identifier, '[', or '('
 ───╯

--- a/crates/compiler/parser/tests/snapshots/parameterized__expressions::tuple_parameterized_err.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__expressions::tuple_parameterized_err.snap
@@ -5,10 +5,10 @@ expression: snapshot
 --- Input 1 (ERROR) ---
 fn test() { (single_element, }
 --- Diagnostics ---
-[02] Error: found '}' expected '!', '-', something else, identifier, '[', '(', or ')'
+[02] Error: found '}' expected '!', '-', something else, 'new', identifier, '[', '(', or ')'
    ╭─[ test.cairo:1:30 ]
    │
  1 │ fn test() { (single_element, }
    │                              ┬  
-   │                              ╰── found '}' expected '!', '-', something else, identifier, '[', '(', or ')'
+   │                              ╰── found '}' expected '!', '-', something else, 'new', identifier, '[', '(', or ')'
 ───╯

--- a/crates/compiler/parser/tests/snapshots/parameterized__statements::assignment_statements_parameterized_err.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__statements::assignment_statements_parameterized_err.snap
@@ -5,10 +5,10 @@ expression: snapshot
 --- Input 1 (ERROR) ---
 fn test() { = 5; }
 --- Diagnostics ---
-[02] Error: found '=' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, identifier, '[', '(', or '}'
+[02] Error: found '=' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, 'new', identifier, '[', '(', or '}'
    ╭─[ test.cairo:1:13 ]
    │
  1 │ fn test() { = 5; }
    │             ┬  
-   │             ╰── found '=' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, identifier, '[', '(', or '}'
+   │             ╰── found '=' expected '{', 'if', 'loop', 'while', 'for', 'break', 'continue', 'let', 'const', 'return', '!', '-', something else, 'new', identifier, '[', '(', or '}'
 ───╯

--- a/crates/compiler/parser/tests/snapshots/parameterized__statements::if_statements_parameterized_err.snap
+++ b/crates/compiler/parser/tests/snapshots/parameterized__statements::if_statements_parameterized_err.snap
@@ -5,10 +5,10 @@ expression: snapshot
 --- Input 1 (ERROR) ---
 fn test() { if { x = 1; } }
 --- Diagnostics ---
-[02] Error: found '{' expected '(', '!', '-', something else, identifier, or '['
+[02] Error: found '{' expected '(', '!', '-', something else, 'new', identifier, or '['
    ╭─[ test.cairo:1:16 ]
    │
  1 │ fn test() { if { x = 1; } }
    │                ┬  
-   │                ╰── found '{' expected '(', '!', '-', something else, identifier, or '['
+   │                ╰── found '{' expected '(', '!', '-', something else, 'new', identifier, or '['
 ───╯

--- a/crates/compiler/semantic/src/semantic_index.rs
+++ b/crates/compiler/semantic/src/semantic_index.rs
@@ -63,6 +63,7 @@ use crate::definition::{DefinitionKind, ParameterDefRef, UseDefRef};
 use crate::place::{FileScopeId, Scope};
 use crate::semantic_errors::{SemanticSyntaxChecker, SemanticSyntaxContext};
 use crate::visitor::{walk_type_expr, Visitor};
+// TypeUsage is defined in this module; refer to it directly
 use crate::{module_semantic_index, Crate, Definition, File, SemanticDb};
 
 // Define DefinitionIndex as an index type for definitions within a single file.
@@ -1319,6 +1320,12 @@ impl<'db, 'sink> SemanticIndexBuilder<'db, 'sink> {
                 } else {
                     self.visit_expr_with_origin(element, elem_origin);
                 }
+            }
+            Expression::New { elem_type, count } => {
+                // Leverage existing TypeExpr visitor to record type usages (and nested types)
+                self.visit_type_expr(elem_type);
+                // Visit count expression normally
+                self.visit_expr(count);
             }
             Expression::Cast {
                 expr,

--- a/crates/compiler/semantic/src/type_resolution_tests.rs
+++ b/crates/compiler/semantic/src/type_resolution_tests.rs
@@ -229,6 +229,7 @@ fn test_expression_type_coverage() {
             Expression::ArrayRepeat { .. } => "ArrayRepeat",
             Expression::TupleIndex { .. } => "TupleIndex",
             Expression::Cast { .. } => "Cast",
+            Expression::New { .. } => "New",
         };
         expression_types_found.insert(variant_name);
 

--- a/crates/compiler/semantic/src/types.rs
+++ b/crates/compiler/semantic/src/types.rs
@@ -45,6 +45,9 @@ impl<'db> TypeId<'db> {
                     format!("({})", formatted_types.join(", "))
                 }
             }
+            TypeData::Pointer { element_type } => {
+                format!("{}*", Self::format_type(db, element_type))
+            }
             TypeData::FixedArray { element_type, size } => {
                 format!("[{}; {}]", Self::format_type(db, element_type), size)
             }
@@ -80,6 +83,9 @@ pub enum TypeData<'db> {
 
     /// A tuple type containing an ordered list of component types
     Tuple(Vec<TypeId<'db>>),
+
+    /// A typed pointer to an element type
+    Pointer { element_type: TypeId<'db> },
 
     /// A fixed-size array type with element type and size
     FixedArray {
@@ -196,6 +202,9 @@ impl<'db> TypeData<'db> {
                 } else {
                     format!("({})", type_names.join(", "))
                 }
+            }
+            TypeData::Pointer { element_type } => {
+                format!("{}*", element_type.data(db).display_name(db))
             }
             TypeData::FixedArray { element_type, size } => {
                 format!("[{}; {}]", element_type.data(db).display_name(db), size)

--- a/crates/compiler/semantic/src/validation/type_validator.rs
+++ b/crates/compiler/semantic/src/validation/type_validator.rs
@@ -285,17 +285,17 @@ impl TypeValidator {
                 // Element type must resolve; diagnostics for undeclared will be produced elsewhere
                 let _ = resolve_ast_type(db, crate_id, file, elem_type.clone(), expr_info.scope_id);
 
-                // Count must be numeric (felt or u32)
+                // Count must be a felt
                 if let Some(count_id) = index.expression_id_by_span(count.span()) {
                     let count_ty = expression_semantic_type(db, crate_id, file, count_id, None);
                     match count_ty.data(db) {
-                        TypeData::Felt | TypeData::U32 | TypeData::Error | TypeData::Unknown => {}
+                        TypeData::Felt | TypeData::Error | TypeData::Unknown => {}
                         other => {
                             sink.push(
                                 Diagnostic::error(
                                     DiagnosticCode::TypeMismatch,
                                     format!(
-                                        "count must be numeric (felt or u32), found `{}`",
+                                        "count for `new` must be felt, found `{}`",
                                         other.display_name(db)
                                     ),
                                 )

--- a/crates/compiler/semantic/src/validation/type_validator.rs
+++ b/crates/compiler/semantic/src/validation/type_validator.rs
@@ -281,6 +281,30 @@ impl TypeValidator {
         sink: &dyn DiagnosticSink,
     ) {
         match &expr_info.ast_node {
+            Expression::New { elem_type, count } => {
+                // Element type must resolve; diagnostics for undeclared will be produced elsewhere
+                let _ = resolve_ast_type(db, crate_id, file, elem_type.clone(), expr_info.scope_id);
+
+                // Count must be numeric (felt or u32)
+                if let Some(count_id) = index.expression_id_by_span(count.span()) {
+                    let count_ty = expression_semantic_type(db, crate_id, file, count_id, None);
+                    match count_ty.data(db) {
+                        TypeData::Felt | TypeData::U32 | TypeData::Error | TypeData::Unknown => {}
+                        other => {
+                            sink.push(
+                                Diagnostic::error(
+                                    DiagnosticCode::TypeMismatch,
+                                    format!(
+                                        "count must be numeric (felt or u32), found `{}`",
+                                        other.display_name(db)
+                                    ),
+                                )
+                                .with_location(file.file_path(db).to_string(), count.span()),
+                            );
+                        }
+                    }
+                }
+            }
             Expression::UnaryOp { expr, op } => {
                 self.check_unary_op_types(db, crate_id, file, index, expr, op, sink);
             }
@@ -777,6 +801,25 @@ impl TypeValidator {
                     }
                 }
                 // TODO: Add bounds checking for compile-time constant expressions
+            }
+            TypeData::Pointer { .. } => {
+                // Allow pointer indexing; require felt index (consistent with arrays)
+                let Some(index_id) = index.expression_id_by_span(index_expr.span()) else {
+                    return;
+                };
+                let index_type_id = expression_semantic_type(db, crate_id, file, index_id, None);
+                if !matches!(index_type_id.data(db), TypeData::Felt) {
+                    sink.push(
+                        Diagnostic::error(
+                            DiagnosticCode::InvalidIndexType,
+                            format!(
+                                "Array index must be of type felt, found `{}`",
+                                index_type_id.data(db).display_name(db)
+                            ),
+                        )
+                        .with_location(file.file_path(db).to_string(), index_expr.span()),
+                    );
+                }
             }
             TypeData::Tuple(_) => {
                 sink.push(

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::new_expr::test_new_expression_semantics.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::new_expr::test_new_expression_semantics.snap
@@ -1,0 +1,42 @@
+---
+source: crates/compiler/semantic/tests/common/mod.rs
+assertion_line: 423
+expression: snapshot
+---
+--- Input 1 (ERROR) ---
+fn test() { let p = new Unknown[3]; return; }
+--- Diagnostics ---
+[1009] Error: Cannot find type 'Unknown' in this scope
+   ╭─[ semantic_tests::expressions::new_expr::test_new_expression_semantics:1:25 ]
+   │
+ 1 │ fn test() { let p = new Unknown[3]; return; }
+   │                         ───┬───  
+   │                            ╰───── Cannot find type 'Unknown' in this scope
+───╯
+
+============================================================
+
+--- Input 2 (ERROR) ---
+fn test() { let p = new felt[true]; return; }
+--- Diagnostics ---
+[2001] Error: heap count must be numeric (felt or u32), found `bool`
+   ╭─[ semantic_tests::expressions::new_expr::test_new_expression_semantics:1:30 ]
+   │
+ 1 │ fn test() { let p = new felt[true]; return; }
+   │                              ──┬─  
+   │                                ╰─── heap count must be numeric (felt or u32), found `bool`
+───╯
+
+============================================================
+
+--- Input 3 (ERROR) ---
+fn test() { let p = new u32[Point { x: 1, y: 2 }]; return; }
+--- Diagnostics ---
+[1009] Error: Cannot find type 'Point' in this scope
+   ╭─[ semantic_tests::expressions::new_expr::test_new_expression_semantics:1:29 ]
+   │
+ 1 │ fn test() { let p = new u32[Point { x: 1, y: 2 }]; return; }
+   │                             ──┬──  
+   │                               ╰──── Cannot find type 'Point' in this scope
+───╯
+

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::pointer_expr::test_new_expression_semantics.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::pointer_expr::test_new_expression_semantics.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/compiler/semantic/tests/common/mod.rs
+assertion_line: 423
 expression: snapshot
 ---
 --- Input 1 (ERROR) ---
@@ -18,12 +19,12 @@ fn test() { let p = new Unknown[3]; return; }
 --- Input 2 (ERROR) ---
 fn test() { let p = new felt[true]; return; }
 --- Diagnostics ---
-[2001] Error: count must be numeric (felt or u32), found `bool`
+[2001] Error: count for `new` must be felt, found `bool`
    ╭─[ semantic_tests::expressions::pointer_expr::test_new_expression_semantics:1:30 ]
    │
  1 │ fn test() { let p = new felt[true]; return; }
    │                              ──┬─  
-   │                                ╰─── count must be numeric (felt or u32), found `bool`
+   │                                ╰─── count for `new` must be felt, found `bool`
 ───╯
 
 ============================================================
@@ -37,4 +38,17 @@ fn test() { let p = new u32[Point { x: 1, y: 2 }]; return; }
  1 │ fn test() { let p = new u32[Point { x: 1, y: 2 }]; return; }
    │                             ──┬──  
    │                               ╰──── Cannot find type 'Point' in this scope
+───╯
+
+============================================================
+
+--- Input 4 (ERROR) ---
+fn test() { let p = new felt[1u32]; return; }
+--- Diagnostics ---
+[2001] Error: count for `new` must be felt, found `u32`
+   ╭─[ semantic_tests::expressions::pointer_expr::test_new_expression_semantics:1:30 ]
+   │
+ 1 │ fn test() { let p = new felt[1u32]; return; }
+   │                              ──┬─  
+   │                                ╰─── count for `new` must be felt, found `u32`
 ───╯

--- a/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::pointer_expr::test_new_expression_semantics.snap
+++ b/crates/compiler/semantic/tests/common/snapshots/parameterized__expressions::pointer_expr::test_new_expression_semantics.snap
@@ -1,0 +1,40 @@
+---
+source: crates/compiler/semantic/tests/common/mod.rs
+expression: snapshot
+---
+--- Input 1 (ERROR) ---
+fn test() { let p = new Unknown[3]; return; }
+--- Diagnostics ---
+[1009] Error: Cannot find type 'Unknown' in this scope
+   ╭─[ semantic_tests::expressions::pointer_expr::test_new_expression_semantics:1:25 ]
+   │
+ 1 │ fn test() { let p = new Unknown[3]; return; }
+   │                         ───┬───  
+   │                            ╰───── Cannot find type 'Unknown' in this scope
+───╯
+
+============================================================
+
+--- Input 2 (ERROR) ---
+fn test() { let p = new felt[true]; return; }
+--- Diagnostics ---
+[2001] Error: count must be numeric (felt or u32), found `bool`
+   ╭─[ semantic_tests::expressions::pointer_expr::test_new_expression_semantics:1:30 ]
+   │
+ 1 │ fn test() { let p = new felt[true]; return; }
+   │                              ──┬─  
+   │                                ╰─── count must be numeric (felt or u32), found `bool`
+───╯
+
+============================================================
+
+--- Input 3 (ERROR) ---
+fn test() { let p = new u32[Point { x: 1, y: 2 }]; return; }
+--- Diagnostics ---
+[1009] Error: Cannot find type 'Point' in this scope
+   ╭─[ semantic_tests::expressions::pointer_expr::test_new_expression_semantics:1:29 ]
+   │
+ 1 │ fn test() { let p = new u32[Point { x: 1, y: 2 }]; return; }
+   │                             ──┬──  
+   │                               ╰──── Cannot find type 'Point' in this scope
+───╯

--- a/crates/compiler/semantic/tests/expressions/mod.rs
+++ b/crates/compiler/semantic/tests/expressions/mod.rs
@@ -5,6 +5,7 @@
 pub mod type_errors;
 
 pub mod binary_expressions;
+pub mod pointer_expr;
 pub mod tuple_index;
 pub mod unary_expressions;
 

--- a/crates/compiler/semantic/tests/expressions/pointer_expr.rs
+++ b/crates/compiler/semantic/tests/expressions/pointer_expr.rs
@@ -1,0 +1,44 @@
+use crate::{assert_semantic_parameterized, in_function};
+
+#[test]
+fn test_new_expression_semantics() {
+    assert_semantic_parameterized! {
+        ok: [
+            // Basic allocations
+            in_function("let p: felt* = new felt[10];"),
+            in_function("let n = 3; let q: u32* = new u32[n];"),
+
+            // Struct allocations
+            r#"
+                struct Point { x: felt, y: felt }
+                fn test() { let r: Point* = new Point[2]; return; }
+            "#,
+
+            // Zero-sized allocation is allowed
+            in_function("let p: felt* = new felt[0];"),
+
+            // Indexing pointers
+            in_function("let p: felt* = new felt[10]; let a = p[0];"),
+            in_function("let p: felt* = new felt[10]; p[0] = 1;"),
+
+            // With structs
+            r#"
+                struct Point { x: felt, y: felt }
+                fn test() { let p: Point* = new Point[2]; let a = p[0].x; return; }
+            "#,
+
+            // With tuples
+            r#"
+                fn test() { let p: (felt, felt)* = new (felt, felt)[2]; let a = p[0].0; return; }
+            "#,
+        ],
+        err: [
+            // Invalid element type (undeclared)
+            in_function("let p = new Unknown[3];"),
+
+            // Invalid count type
+            in_function("let p = new felt[true];"),
+            in_function("let p = new u32[Point { x: 1, y: 2 }];"),
+        ]
+    }
+}

--- a/crates/compiler/semantic/tests/expressions/pointer_expr.rs
+++ b/crates/compiler/semantic/tests/expressions/pointer_expr.rs
@@ -39,6 +39,9 @@ fn test_new_expression_semantics() {
             // Invalid count type
             in_function("let p = new felt[true];"),
             in_function("let p = new u32[Point { x: 1, y: 2 }];"),
+
+            // Invalid type for count (non felt)
+            in_function("let p = new felt[1u32];"),
         ]
     }
 }

--- a/crates/compiler/semantic/tests/types/mod.rs
+++ b/crates/compiler/semantic/tests/types/mod.rs
@@ -12,6 +12,7 @@
 //! - **Function Signatures**: Tests for `function_semantic_signature` resolution
 //! - **Struct Types**: Tests for `struct_semantic_data` and field resolution
 //! - **Type Compatibility**: Tests for type compatibility and conversion rules
+//! - **Pointer Types**: Tests for pointer types and dereferencing
 
 mod definition_type_tests;
 mod expression_type_tests;
@@ -19,6 +20,7 @@ mod fixed_array_tests;
 mod function_signature_tests;
 mod literal_range_validation_tests;
 mod literal_type_inference_tests;
+mod pointer_type_tests;
 mod query_integration_tests;
 mod recursive_and_error_types_tests;
 mod return_type_inference;

--- a/crates/compiler/semantic/tests/types/pointer_type_tests.rs
+++ b/crates/compiler/semantic/tests/types/pointer_type_tests.rs
@@ -1,0 +1,110 @@
+//! Tests for pointer types and heap allocation `new` expression
+
+use super::*;
+use crate::{crate_from_program, get_main_semantic_index};
+use cairo_m_compiler_semantic::semantic_index::DefinitionId;
+
+#[test]
+fn resolve_pointer_types() {
+    let db = test_db();
+    let code = r#"
+        struct Point { x: felt, y: felt }
+        fn f(p: felt*, q: u32*, r: Point*) { }
+    "#;
+    let crate_id = crate_from_program(&db, code);
+    let file = *crate_id.modules(&db).values().next().unwrap();
+    let index = get_main_semantic_index(&db, crate_id);
+
+    // Find function definition and check param types
+    for (def_idx, def) in index.all_definitions() {
+        if def.name == "f" {
+            let def_id = DefinitionId::new(&db, file, def_idx);
+            if let Some(sig) =
+                cairo_m_compiler_semantic::type_resolution::function_semantic_signature(
+                    &db, crate_id, def_id,
+                )
+                .as_ref()
+            {
+                let params = sig.params(&db);
+                assert_eq!(params.len(), 3);
+                match params[0].1.data(&db) {
+                    TypeData::Pointer { .. } => {}
+                    other => panic!("expected pointer, got {other:?}"),
+                }
+                match params[1].1.data(&db) {
+                    TypeData::Pointer { .. } => {}
+                    other => panic!("expected pointer, got {other:?}"),
+                }
+                match params[2].1.data(&db) {
+                    TypeData::Pointer { .. } => {}
+                    other => panic!("expected pointer, got {other:?}"),
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn new_expression_and_index_typing() {
+    let db = test_db();
+    let program = r#"
+        struct Point { x: felt, y: felt }
+        fn test(n: felt, i: felt) {
+            let pf: felt* = new felt[10];
+            let uf: u32* = new u32[n];
+            let ps: Point* = new Point[2];
+
+            let a = pf[0];        // felt
+            let b = uf[i];        // u32
+            let c = ps[1].x;      // felt
+        }
+    "#;
+    let crate_id = crate_from_program(&db, program);
+    let file = *crate_id.modules(&db).values().next().unwrap();
+    let index = get_main_semantic_index(&db, crate_id);
+
+    // Find function scope
+    let root_scope = index.root_scope().unwrap();
+    let func_scope = index
+        .child_scopes(root_scope)
+        .find(|s| {
+            index.scope(*s).unwrap().kind == cairo_m_compiler_semantic::place::ScopeKind::Function
+        })
+        .unwrap();
+
+    // pf/uf/ps should be pointer types
+    for name in ["pf", "uf", "ps"] {
+        let def_idx = index
+            .latest_definition_index_by_name(func_scope, name)
+            .unwrap();
+        let def_id = DefinitionId::new(&db, file, def_idx);
+        let ty = cairo_m_compiler_semantic::type_resolution::definition_semantic_type(
+            &db, crate_id, def_id,
+        );
+        assert!(
+            matches!(ty.data(&db), TypeData::Pointer { .. }),
+            "{} should be pointer type",
+            name
+        );
+    }
+
+    // b (let b = uf[i]) must be u32
+    let b_def_idx = index
+        .latest_definition_index_by_name(func_scope, "b")
+        .unwrap();
+    let b_def_id = DefinitionId::new(&db, file, b_def_idx);
+    let b_ty = cairo_m_compiler_semantic::type_resolution::definition_semantic_type(
+        &db, crate_id, b_def_id,
+    );
+    assert!(matches!(b_ty.data(&db), TypeData::U32));
+
+    // c (let c = ps[1].x) must be felt
+    let c_def_idx = index
+        .latest_definition_index_by_name(func_scope, "c")
+        .unwrap();
+    let c_def_id = DefinitionId::new(&db, file, c_def_idx);
+    let c_ty = cairo_m_compiler_semantic::type_resolution::definition_semantic_type(
+        &db, crate_id, c_def_id,
+    );
+    assert!(matches!(c_ty.data(&db), TypeData::Felt));
+}

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -53,6 +53,7 @@ words:
   - funcs
   - getelementptr
   - horizen
+  - heapalloccells
   - ilog
   - imma
   - immediates

--- a/docs/heap-pointer-plan.md
+++ b/docs/heap-pointer-plan.md
@@ -1,0 +1,156 @@
+# Heap Allocation and Typed Pointers Plan
+
+This document outlines the minimal, end-to-end changes to support heap
+allocation via a `new` expression and typed pointers that flow from the frontend
+to the runner.
+
+## Big Picture
+
+- Add `new T[n]` expression that returns a `T*`.
+- Done: Added `TokenType::New` and `Expression::New { elem_type, count }`;
+  lowered through all phases.
+- Introduce typed pointers in semantic types; represent pointers in MIR as
+  `Pointer<T>` (single-slot, typed).
+- Done: Implemented `TypeData::Pointer{element_type}` in semantic; mapped to
+  `MirType::Pointer { element }`.
+- Lower `new T[n]` to a MIR `HeapAllocCells` with
+  `cells = n * size_in_slots(T)`.
+- Done: Implemented in MIR lowering (`expr.rs`) using
+  `DataLayout::value_size_of`.
+- Allow `ptr[i]` reads/writes via explicit `Load`/`Store` on `Place`s in MIR;
+  codegen scales by element size.
+- Done: MIR lowering emits `Load`/`Store` for pointer interactions with proper
+  element types.
+
+## Parser
+
+- Files:
+  - `crates/compiler/parser/src/lexer.rs`
+  - `crates/compiler/parser/src/parser.rs`
+- Changes:
+  - Keyword: Add token `TokenType::New` (+ `Display`) so the lexer recognizes
+    `new`.
+    - Status: Implemented in `lexer.rs`.
+  - AST: Add
+    `Expression::New { elem_type: Spanned<TypeExpr>, count: Spanned<Expression> }`.
+    - Status: Implemented in `parser.rs`.
+  - Grammar: In the expression parser `Primary` tier, parse
+    `new TypeExpr "[" Expr "]"` into `Expression::New { ... }`.
+    - Status: Implemented in `parser.rs` (uses simplified named type as
+      planned).
+  - Notes: Pointer types already parse via
+    `TypeExpr::Pointer(Box<Spanned<TypeExpr>>)`; no changes required here. To
+    keep things simple and break cycles, `new` may use a simplified type parser
+    (named types) initially; semantic resolution will still enforce struct
+    names, etc.
+    - Status: As planned; full `TypeExpr` support for `new` can be added later.
+
+## Semantic
+
+- Files:
+  - `crates/compiler/semantic/src/types.rs`
+  - `crates/compiler/semantic/src/type_resolution.rs`
+  - `crates/compiler/semantic/src/validation/*` (optional adjustments)
+- Changes:
+  - Types: add typed pointers
+    - Add `TypeData::Pointer { element_type: TypeId<'db> }`.
+    - Update `TypeId::format_type` / `TypeData::display_name` to render `T*`.
+    - Status: Implemented in `types.rs` (formatting and display included).
+  - Type resolution
+    - In `resolve_ast_type`: map `AstTypeExpr::Pointer(inner)` to
+      `TypeData::Pointer` instead of `Error`.
+    - In `expression_semantic_type`:
+      - Add case for `Expression::New`: resolve `elem_type`; return
+        `TypeData::Pointer { element_type: ... }`.
+      - Extend IndexAccess to accept pointers: if the container type is
+        `Pointer { element_type }`, the resulting type is `element_type`.
+    - Status: Implemented in `type_resolution.rs` (pointer type, `new`, and
+      pointer indexing supported).
+  - Type compatibility
+    - Extend `are_types_compatible` to consider `Pointer(A)` compatible with
+      `Pointer(B)` iff `A` compatible with `B`.
+    - Status: Implemented in `type_resolution.rs`.
+  - Validation
+    - No special validation required beyond existing rules; optional restriction
+      to disallow `new` in const contexts can be added later.
+    - Status: Added `new`-specific count type check; element type is visited via
+      `visit_type_expr`, so undeclared types are caught by existing scope
+      validator.
+
+## MIR
+
+- Files:
+  - `crates/compiler/mir/src/mir_types.rs`
+  - `crates/compiler/mir/src/lowering/expr.rs`
+  - `crates/compiler/mir/src/lowering/stmt.rs`
+  - (Instruction already exists) `crates/compiler/mir/src/instruction.rs`
+- Changes:
+  - Pointer mapping
+    - In `MirType::from_semantic_type`, map `TypeData::Pointer { .. }` to
+      `MirType::Pointer { element }` (single-slot, typed).
+    - Status: Implemented in `mir_types.rs`.
+  - Lowering: `new`
+    - Handle `Expression::New { elem_type, count }`:
+      - Convert element type to MIR type and compute
+        `elem_slots = DataLayout::value_size_of(elem_ty)`.
+      - Lower `count` to a `Value`. If `elem_slots > 1`, emit a `* elem_slots`
+        multiply to get `cells`.
+      - Emit `Instruction::heap_alloc_cells(dest, cells)` where `dest: felt` is
+        the pointer.
+    - Status: Implemented in `lowering/expr.rs`.
+  - Lowering: pointer indexing
+    - Reads: For `ptr[i]`, build a `Place` with index projection and emit
+      `Load(dest, place, elem_ty)`.
+    - Writes: For `ptr[i] = v`, reuse the same `Place` extended as needed
+      (fields/tuples) and emit `Store(place, v, elem_ty)`. Do not rebind the
+      pointer variable.
+    - Status: Implemented in `lowering/expr.rs` (reads) and `lowering/stmt.rs`
+      (writes); uses `Place` projections.
+
+## Codegen
+
+- Files: No changes required.
+  - `crates/compiler/codegen/src/generator.rs` already lowers `HeapAllocCells`
+    using a bump allocator over a global `HEAP_CURSOR` and supports
+    pointer-based `ArrayIndex`/`ArrayInsert` with element-size scaling.
+  - Status: Match arms updated for exhaustiveness; `HeapAllocCells` lowering is
+    handled at the block level.
+
+## Runner
+
+- Files: No changes required.
+  - `crates/runner/src/memory/mod.rs` implements split locals/heap and
+    high-address mapping; it aligns with the bump allocation semantics used by
+    codegen.
+  - Status: Verified; no changes needed.
+
+## Edge Cases and Simplifications
+
+- `new T[n]` supported for `felt`, `u32`, and structs composed of these.
+  - Status: Implemented and covered by tests.
+- Pointer arithmetic is out-of-scope; only `ptr[i]` loads/stores are supported.
+  - Status: Intentionally unsupported.
+- Nested arrays remain unsupported.
+  - Status: Intentionally unsupported.
+- Pointers are single-slot values in MIR (`Pointer<T>`), preserving element type
+  for layout.
+- Status: Implemented.
+
+## Minimal Test Plan
+
+- Parser
+  - `let p: felt* = new felt[10];`
+  - `let q: u32* = new u32[n];`
+  - `let r: Point* = new Point[3];`
+  - Status: Implemented in parser tests; all pass.
+- Semantic
+  - `new T[n]` has type `T*`.
+  - `p[i]` has type `felt`; `q[i]` has type `u32`; `r[i].x` has the type of
+    `Point.x`.
+  - Status: Covered by white‑box tests and parameterized snapshot tests; all
+    pass.
+- MIR/Codegen snapshots
+  - `new u32[n]` emits `HeapAllocCells` with `cells = 2*n`.
+  - `p[i]` load emits `Load` in MIR and double-deref with scaled index in CASM.
+  - `p[i] = v` emits `Store` in MIR and correct slot writes in CASM.
+  - Status: MIR and codegen snapshots added for pointer cases.

--- a/mdtest/03-types/03-pointers-and-heap.md
+++ b/mdtest/03-types/03-pointers-and-heap.md
@@ -1,0 +1,73 @@
+# Pointers and Heap Allocation (new)
+
+This page demonstrates the `new` keyword for heap allocation and pointer-based
+indexing semantics.
+
+## Allocate felt and read back
+
+```cairo-m
+fn alloc_felt() -> felt {
+    let p: felt* = new felt[3];
+    // Initialize via pointer indexing
+    p[0] = 7;
+    p[1] = 8;
+    p[2] = 9;
+    return p[0] + p[1] + p[2];
+}
+```
+
+```rust
+fn alloc_felt() -> i32 {
+    let mut p: Vec<i32> = Vec::with_capacity(3);
+    p.push(7);
+    p.push(8);
+    p.push(9);
+    return p[0] + p[1] + p[2];
+}
+```
+
+## Allocate u32 with dynamic size
+
+```cairo-m
+fn alloc_u32() -> u32 {
+    let p: u32* = new u32[3];
+    // Single element write/read
+    p[0] = 42u32;
+    return p[0];
+}
+```
+
+```rust
+fn alloc_u32() -> i32 {
+    let mut p: Vec<i32> = Vec::with_capacity(3);
+    p.push(42);
+    return p[0];
+}
+```
+
+## Allocate struct pointer and access fields
+
+```cairo-m
+struct Point { x: felt, y: felt }
+
+fn alloc_struct() -> felt {
+    let ps: Point* = new Point[2];
+    // Write fields via pointer indexing then field
+    (ps[0]).x = 3;
+    (ps[0]).y = 4;
+    (ps[1]).x = 5;
+    (ps[1]).y = 6;
+    return ps[0].x + ps[1].y;
+}
+```
+
+```rust
+struct Point { x: i32, y: i32 }
+
+fn alloc_struct() -> i32 {
+    let mut ps: Vec<Point> = Vec::with_capacity(2);
+    ps.push(Point { x: 3, y: 4 });
+    ps.push(Point { x: 5, y: 6 });
+    return ps[0].x + ps[1].y;
+}
+```


### PR DESCRIPTION
- Parser: add `new` token and `Expression::New { elem_type, count }`.
- Semantic: introduce typed pointers; resolve `new`; pointer-aware index access; compatibility and validation; tests.
- MIR: add `InstructionKind::HeapAllocCells` constructor; lower `new` to `HeapAllocCells` with `cells = n * size_in_slots(T)`; rework pointer indexing to use `Place` + `Load`/`Store`; preserve element types.
- Passes: mark `HeapAllocCells` as side-effecting for Local CSE; fix ConstantPropagation to rewrite `cells` operand.
- Codegen: lower `HeapAllocCells` via bump allocator over global `HEAP_CURSOR`; implement element-size scaling for pointer `Index` projections; support chained projections (Index/Field/Tuple); handle multi-slot elements (u32).
- Runner: aligns with high-address heap model; no changes required.
- Docs: add `docs/heap-pointer-plan.md`.
- Tests/Snapshots: add mdtest `03-pointers-and-heap.md`; update MIR and codegen snapshots to show `heapalloccells` and `load`/`store` for pointer interactions.