### PR TITLE
Add link to design doc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # Welcome to Cairo M
 
-Cairo M is a brand new Cpu AIR leveraging M31 as its native prime field,
-unleashing the Maximum power of Starkware's S-TWO to enable Mobile proving.
-
-Cairo Max looks like Cairo Zero, just tastes better.
+Cairo M is a new Cpu AIR leveraging M31 as its native prime field, with a focus
+on modularity, built on Starkware's S-TWO to enable Mobile proving.
 
 ## Overview
 
 Cairo M is designed to provide efficient computation on consumer hardware,
-especially mobile phone. It includes several components that work together to
+especially mobile phones. It includes several components that work together to
 compile, run, and prove Cairo programs.
 
 The main design choices are
@@ -20,6 +18,9 @@ The main design choices are
 - variable-size instruction encoding (x86 style)
 - support of native types (felt, u32, etc.) thanks to an heavy use of Stwo's
   component system
+
+For a more detailed overview, you can read the
+[design document](./docs/design.pdf).
 
 ## Crates
 

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -14,7 +14,6 @@ words:
   - binop
   - branchcmp
   - bswap
-  - Fontaine
   - bytemuck
   - CAIR
   - cairols
@@ -60,6 +59,7 @@ words:
   - fips
   - foldl
   - foldr
+  - Fontaine
   - framealloc
   - funcs
   - getelementptr
@@ -177,8 +177,8 @@ words:
   - texmfcache
   - texmfvar
   - texttt
-  - Titelman
   - thiserror
+  - Titelman
   - tlsv
   - toplevel
   - topo


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a design document link to the README and makes small wording/grammar improvements.
> 
> - **Documentation**:
>   - **README** (`README.md`):
>     - Add link to the detailed design document (`docs/design.pdf`).
>     - Refine introductory wording (emphasis on modularity) and fix minor grammar/pluralization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c4822e836d3cf01f82730d2dbe1f896ad04e241. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->