### PR TITLE
fix(parser): remove misleading TODO comment about pointer types deprecation

### DIFF
--- a/crates/compiler/parser/tests/parser/types.rs
+++ b/crates/compiler/parser/tests/parser/types.rs
@@ -23,8 +23,6 @@ fn custom_type() {
 // Pointer Types
 // ===================
 
-// TODO: deprecated, remove.
-
 #[test]
 fn pointer_type() {
     assert_parses_ok!(&with_param("felt*"));


### PR DESCRIPTION
Remove incorrect `// TODO: deprecated, remove.` comment from pointer type tests.

Git history shows the TODO was added mistakenly in commit 372e69d during array syntax implementation. Pointer types are still actively used (e.g., SHA-256 example uses `u32*` parameters) and fully supported throughout the compiler pipeline.
