### PR TITLE
Add Clone trait to Proof and related structs

### DIFF
--- a/crates/prover/src/components/mod.rs
+++ b/crates/prover/src/components/mod.rs
@@ -25,7 +25,7 @@ use crate::preprocessed::range_check::{range_check_16, range_check_20, range_che
 use crate::public_data::PublicData;
 use crate::relations;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Claim {
     pub opcodes: opcodes::Claim,
     pub memory: memory::Claim,
@@ -62,7 +62,7 @@ pub struct InteractionClaimData {
     pub bitwise: bitwise::InteractionClaimData,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InteractionClaim {
     pub opcodes: opcodes::InteractionClaim,
     pub memory: memory::InteractionClaim,

--- a/crates/prover/src/components/opcodes/mod.rs
+++ b/crates/prover/src/components/opcodes/mod.rs
@@ -16,7 +16,7 @@ macro_rules! define_opcodes {
             $(pub $opcode: $opcode::InteractionClaimData,)*
         }
 
-        #[derive(Serialize, Deserialize, Debug)]
+        #[derive(Serialize, Deserialize, Clone, Debug)]
         pub struct InteractionClaim {
             $(pub $opcode: $opcode::InteractionClaim,)*
         }

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -58,7 +58,7 @@ use crate::public_data::PublicData;
 ///
 /// ## Type Parameters
 /// * `H` - The Merkle hasher used for tree commitments (typically Blake2s)
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Proof<H: MerkleHasher> {
     /// Claim about the execution trace (log sizes for each component)
     pub claim: Claim,


### PR DESCRIPTION
## Summary
• Add Clone derive to Proof<H> struct to enable proof cloning
• Add Clone derive to Claim and InteractionClaim structs in components
• Add Clone derive to InteractionClaim in opcodes macro

## Test plan
- [x] Verify compilation passes
- [x] Ensure no breaking changes to existing API
- [x] Confirm Clone implementation works correctly for all affected structs

🤖 Generated with [Claude Code](https://claude.ai/code)

Note: Copy was not as straightforward as down the line we face some reference types.

Resolves: #344 